### PR TITLE
ci: fix broken Ruby version matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,16 +21,14 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ['3.2', '3.3', '3.4', '4.0']
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
## Summary

The initial CI workflow (added in 1191216) pinned `ruby/setup-ruby` to SHA `55283cc` = **v1.146.0, late 2022**. That release's hardcoded version table tops out at Ruby **3.2.2**, so every single matrix cell — 3.2, 3.3, 3.4, 4.0 — died at the "Set up Ruby" step with:

```
Error: Unknown version 4.0 for ruby on ubuntu-24.04
available versions: ... 3.2.0, 3.2.1, 3.2.2, head, debug
Make sure you use the latest version of the action with
- uses: ruby/setup-ruby@v1
```

First run on main is visible at duncanita/ruby-dag/actions/runs/24137770399 — 4/4 cells failed.

## Fix

Two changes, both on `.github/workflows/ruby.yml`:

1. `ruby/setup-ruby@55283cc…  # v1.146.0` → **`ruby/setup-ruby@v1`**. This is the floating tag [ruby/setup-ruby explicitly recommends](https://github.com/ruby/setup-ruby#versioning) in their own README — it's how the upstream project ships Ruby version support for new releases.
2. Add **`fail-fast: false`** under `strategy:`. With the default, one broken matrix cell cancels the other three, hiding per-version state. The project maintains per-Ruby benchmark baselines (3.2.11, 3.3.11, 3.4.9, 4.0.2) in `benchmarks/` — per-version CI results should be visible independently.

Also drops the stale comment block that pointed at the same fix without applying it.

## Test plan

- [ ] This PR's own CI run green across all 4 Ruby versions (the real test — it runs with the fixed workflow from this branch)
- [ ] `bundle exec rake` local: 355 runs / 8934 assertions / 0 failures, lint clean (unchanged by this PR, workflow-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)