### PR TITLE
refactor: move step attempt handoff into runner

### DIFF
--- a/lib/dag/workflow/parallel/processes.rb
+++ b/lib/dag/workflow/parallel/processes.rb
@@ -168,7 +168,7 @@ module DAG
 
         def decode_payload(task, payload, child_status = nil)
           if payload.empty?
-            now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            now = @clock.monotonic_now
             detail = child_status_detail(task.name, child_status)
             result = Failure.new(error: {
               code: :empty_child_payload,
@@ -180,7 +180,7 @@ module DAG
 
           Marshal.load(payload)
         rescue => e
-          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          now = @clock.monotonic_now
           result = Result.exception_failure(:decode_failed, e,
             message: "failed to decode payload from #{task.name}: #{e.message}",
             strategy: STRATEGY_SYM)
@@ -215,10 +215,10 @@ module DAG
         # Returns the list of pids still alive after the grace period.
         def reap_batch(pids, grace)
           remaining = pids.dup
-          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + grace
+          deadline = @clock.monotonic_now + grace
           until remaining.empty?
             remaining.reject! { |pid| waitpid_nohang(pid) }
-            break if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+            break if @clock.monotonic_now >= deadline
             sleep 0.01
           end
           remaining

--- a/lib/dag/workflow/parallel/sequential.rb
+++ b/lib/dag/workflow/parallel/sequential.rb
@@ -11,8 +11,8 @@ module DAG
       class Sequential < Strategy
         STRATEGY_SYM = :sequential
 
-        def initialize(max_parallelism: 1)
-          super(max_parallelism: 1)
+        def initialize(max_parallelism: 1, clock: Clock.new)
+          super(max_parallelism: 1, clock: clock)
         end
 
         def execute(tasks)

--- a/lib/dag/workflow/parallel/strategy.rb
+++ b/lib/dag/workflow/parallel/strategy.rb
@@ -20,10 +20,11 @@ module DAG
       class Strategy
         attr_reader :max_parallelism
 
-        def initialize(max_parallelism:)
+        def initialize(max_parallelism:, clock: Clock.new)
           raise ArgumentError, "max_parallelism must be >= 1" if max_parallelism < 1
 
           @max_parallelism = max_parallelism
+          @clock = clock
         end
 
         def execute(tasks, &block)
@@ -35,13 +36,9 @@ module DAG
         # The single place that stamps timings, rescues step errors into a
         # Failure, and enforces the executor return contract — so every
         # strategy produces identical trace shape and identical error shape.
-        # Inherited dispatch carries the subclass identity: a `Threads`
-        # instance calling `self.class.run_task(task)` runs the inherited
-        # class method with `self == Threads`, so `STRATEGY_SYM` resolves to
-        # `:threads` without parameter passing.
-        def self.run_task(task)
-          strategy_sym = const_get(:STRATEGY_SYM)
-          started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        def run_task(task)
+          strategy_sym = name
+          started_at = @clock.monotonic_now
           result =
             begin
               raw = task.executor_class.new.call(task.step, task.input)
@@ -61,13 +58,9 @@ module DAG
                 message: "step #{task.name} raised: #{e.message}",
                 strategy: strategy_sym)
             end
-          finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          finished_at = @clock.monotonic_now
           duration_ms = ((finished_at - started_at) * 1000).round(2)
           [task.name, result, started_at, finished_at, duration_ms]
-        end
-
-        def run_task(task)
-          self.class.run_task(task)
         end
       end
     end

--- a/lib/dag/workflow/parallel/threads.rb
+++ b/lib/dag/workflow/parallel/threads.rb
@@ -60,7 +60,7 @@ module DAG
             pushed = true
           ensure
             unless pushed
-              now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              now = @clock.monotonic_now
               failure = Failure.new(error: {
                 code: :worker_died,
                 message: "worker for #{task.name} died without producing a result",

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -50,11 +50,11 @@ module DAG
       def build_strategy(parallel, max_parallelism)
         case parallel
         when false, :sequential
-          Parallel::Sequential.new
+          Parallel::Sequential.new(clock: @clock)
         when true, :threads
-          Parallel::Threads.new(max_parallelism: max_parallelism)
+          Parallel::Threads.new(max_parallelism: max_parallelism, clock: @clock)
         when :processes
-          Parallel::Processes.new(max_parallelism: max_parallelism)
+          Parallel::Processes.new(max_parallelism: max_parallelism, clock: @clock)
         else
           raise ArgumentError, "Unknown parallel mode: #{parallel.inspect}. " \
                                "Use true, false, :sequential, :threads, or :processes."

--- a/spec/parallel_test.rb
+++ b/spec/parallel_test.rb
@@ -462,11 +462,41 @@ class ParallelTest < Minitest::Test
       name: :crash, step: step, input: {},
       executor_class: raising_executor, input_keys: []
     )
-    name, result, _started, _finished, _duration = DAG::Workflow::Parallel::Sequential.run_task(task)
+    strategy = DAG::Workflow::Parallel::Sequential.new
+    name, result, _started, _finished, _duration = strategy.run_task(task)
     assert_equal :crash, name
     assert result.failure?
     assert_equal :step_raised, result.error[:code]
     assert_match(/executor kaboom/, result.error[:message])
+  end
+
+  def test_strategy_run_task_uses_injected_clock_for_trace_timing
+    fake_clock = Class.new do
+      def initialize(times)
+        @times = times.dup
+      end
+
+      def wall_now = Time.utc(2026, 4, 14, 0, 0, 0)
+
+      def monotonic_now
+        @times.shift || @times.last || 0.0
+      end
+    end.new([10.0, 10.25])
+
+    step = DAG::Workflow::Step.new(name: :ok, type: :ruby,
+      callable: ->(_) { DAG::Success.new(value: "done") })
+    task = DAG::Workflow::Parallel::Task.new(
+      name: :ok, step: step, input: {},
+      executor_class: DAG::Workflow::Steps::Ruby, input_keys: []
+    )
+
+    strategy = DAG::Workflow::Parallel::Sequential.new(clock: fake_clock)
+    _name, result, started_at, finished_at, duration_ms = strategy.run_task(task)
+
+    assert result.success?
+    assert_equal 10.0, started_at
+    assert_equal 10.25, finished_at
+    assert_equal 250.0, duration_ms
   end
 
   def test_processes_decode_payload_handles_corrupt_marshal_data

--- a/spec/runner_test.rb
+++ b/spec/runner_test.rb
@@ -603,7 +603,7 @@ class RunnerTest < Minitest::Test
       def monotonic_now
         @times.shift || @times.last || 0.0
       end
-    end.new([0.0, 0.0, 1.0])
+    end.new([0.0, 0.0, 0.0, 0.0, 1.0])
 
     defn = build_test_workflow(
       first: {type: :ruby, callable: ->(_) { DAG::Success.new(value: "done") }},


### PR DESCRIPTION
## Summary
- move prepared step attempt composition into Runner
- keep strategies focused on executing prepared attempts plus timing
- align the strategy boundary with middleware-ready roadmap foundations

## Testing
- bundle exec rake test