### PR TITLE
feat: add runner context injection

### DIFF
--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -28,6 +28,7 @@ module DAG
         max_parallelism: DEFAULT_MAX_PARALLELISM,
         timeout: nil,
         clock: Clock.new,
+        context: nil,
         middleware: [],
         on_step_start: nil, on_step_finish: nil)
         graph, registry = unpack_definition(graph_or_definition, registry)
@@ -35,7 +36,9 @@ module DAG
         @registry = registry
         @timeout = timeout
         @clock = clock
+        @context = context
         @middleware = Array(middleware).freeze
+        validate_context_parallelism!(parallel, context)
         @callbacks = RunCallbacks.new(on_step_start: on_step_start, on_step_finish: on_step_finish)
         @strategy = build_strategy(parallel, max_parallelism)
         validate_coverage!(graph, registry)
@@ -48,6 +51,12 @@ module DAG
       end
 
       private
+
+      def validate_context_parallelism!(parallel, context)
+        return if context.nil? || parallel != :processes
+
+        raise ValidationError, "Runner context is not supported with parallel: :processes without explicit context serialization hooks"
+      end
 
       def build_strategy(parallel, max_parallelism)
         case parallel
@@ -213,12 +222,28 @@ module DAG
           build_middleware_invoker(middleware, next_step)
         end
 
-        -> { chain.call(step, input, context: nil, execution: execution) }
+        -> { chain.call(step, input, context: @context, execution: execution) }
       end
 
       def core_step_invoker(step)
         executor = executor_class(step.type).new
-        ->(current_step, current_input, context:, execution:) { executor.call(current_step, current_input) }
+        ->(current_step, current_input, context:, execution:) do
+          invoke_step_executor(executor, current_step, current_input, context: context)
+        end
+      end
+
+      def invoke_step_executor(executor, step, input, context:)
+        call_method = executor.method(:call)
+        if accepts_context_keyword?(call_method)
+          executor.call(step, input, context: context)
+        else
+          executor.call(step, input)
+        end
+      end
+
+      def accepts_context_keyword?(call_method)
+        call_method.parameters.any? { |kind, name| [:key, :keyreq].include?(kind) && name == :context } ||
+          call_method.parameters.any? { |kind, _name| kind == :keyrest }
       end
 
       def build_middleware_invoker(middleware, next_step)

--- a/lib/dag/workflow/steps/ruby.rb
+++ b/lib/dag/workflow/steps/ruby.rb
@@ -4,7 +4,7 @@ module DAG
   module Workflow
     module Steps
       class Ruby
-        def call(step, input)
+        def call(step, input, context: nil)
           callable = step.config[:callable]
           unless callable
             return Failure.new(error: {
@@ -13,10 +13,26 @@ module DAG
             })
           end
 
-          callable.call(input)
+          invoke_callable(callable, input, context)
         rescue => e
           Result.exception_failure(:ruby_callable_raised, e,
             message: "ruby step #{step.name} callable raised: #{e.message}")
+        end
+
+        private
+
+        def invoke_callable(callable, input, context)
+          if accepts_context?(callable)
+            callable.call(input, context)
+          else
+            callable.call(input)
+          end
+        end
+
+        def accepts_context?(callable)
+          parameters = callable.parameters
+          positional = parameters.count { |kind, _name| [:req, :opt].include?(kind) }
+          positional >= 2 || parameters.any? { |kind, _name| kind == :rest }
         end
       end
     end

--- a/spec/runner_test.rb
+++ b/spec/runner_test.rb
@@ -323,6 +323,111 @@ class RunnerTest < Minitest::Test
     assert_match(/middleware .* returned String/, result.error[:step_error][:message])
   end
 
+  # --- Context injection ---
+
+  def test_runner_passes_context_to_compatible_step_handlers
+    klass = Class.new do
+      def call(step, input, context: nil)
+        DAG::Success.new(value: [step.name, input, context])
+      end
+    end
+    type = :"_test_context_handler_#{object_id}"
+    DAG::Workflow::Steps.register(type, klass, yaml_safe: false)
+
+    graph = DAG::Graph.new.add_node(:ctx)
+    registry = DAG::Workflow::Registry.new
+    registry.register(DAG::Workflow::Step.new(name: :ctx, type: type))
+
+    context = {request_id: "abc-123"}
+    result = DAG::Workflow::Runner.new(graph, registry, parallel: false, context: context).call
+
+    assert result.success?
+    assert_equal [:ctx, {}, context], result.outputs[:ctx].value
+  end
+
+  def test_runner_keeps_old_step_handlers_working_without_context_keyword
+    klass = Class.new do
+      def call(step, input)
+        DAG::Success.new(value: [step.name, input])
+      end
+    end
+    type = :"_test_legacy_handler_#{object_id}"
+    DAG::Workflow::Steps.register(type, klass, yaml_safe: false)
+
+    graph = DAG::Graph.new.add_node(:legacy)
+    registry = DAG::Workflow::Registry.new
+    registry.register(DAG::Workflow::Step.new(name: :legacy, type: type))
+
+    result = DAG::Workflow::Runner.new(graph, registry,
+      parallel: false,
+      context: {ignored: true}).call
+
+    assert result.success?
+    assert_equal [:legacy, {}], result.outputs[:legacy].value
+  end
+
+  def test_ruby_step_passes_context_when_callable_accepts_second_positional_argument
+    defn = build_test_workflow(
+      ruby_ctx: {type: :ruby, callable: ->(input, context) { DAG::Success.new(value: [input, context]) }}
+    )
+
+    result = DAG::Workflow::Runner.new(defn.graph, defn.registry,
+      parallel: false,
+      context: {tenant: "acme"}).call
+
+    assert result.success?
+    assert_equal [{}, {tenant: "acme"}], result.outputs[:ruby_ctx].value
+  end
+
+  def test_ruby_step_ignores_context_when_callable_only_accepts_input
+    defn = build_test_workflow(
+      ruby_ctx: {type: :ruby, callable: ->(input) { DAG::Success.new(value: input) }}
+    )
+
+    result = DAG::Workflow::Runner.new(defn.graph, defn.registry,
+      parallel: false,
+      context: {tenant: "acme"}).call
+
+    assert result.success?
+    assert_equal({}, result.outputs[:ruby_ctx].value)
+  end
+
+  def test_threads_mode_passes_context_to_compatible_handlers
+    klass = Class.new do
+      def call(step, input, context: nil)
+        DAG::Success.new(value: context.fetch(:tenant))
+      end
+    end
+    type = :"_test_thread_context_handler_#{object_id}"
+    DAG::Workflow::Steps.register(type, klass, yaml_safe: false)
+
+    graph = DAG::Graph.new.add_node(:a).add_node(:b)
+    registry = DAG::Workflow::Registry.new
+    registry.register(DAG::Workflow::Step.new(name: :a, type: type))
+    registry.register(DAG::Workflow::Step.new(name: :b, type: type))
+
+    result = DAG::Workflow::Runner.new(graph, registry,
+      parallel: :threads,
+      context: {tenant: "acme"}).call
+
+    assert result.success?
+    assert_equal "acme", result.outputs[:a].value
+    assert_equal "acme", result.outputs[:b].value
+  end
+
+  def test_processes_mode_rejects_context_at_initialization
+    defn = build_test_workflow(a: {type: :ruby, callable: ->(_input) { DAG::Success.new(value: "ok") }})
+
+    error = assert_raises(DAG::ValidationError) do
+      DAG::Workflow::Runner.new(defn.graph, defn.registry,
+        parallel: :processes,
+        context: {tenant: "acme"})
+    end
+
+    assert_match(/parallel: :processes/, error.message)
+    assert_match(/context serialization hooks/, error.message)
+  end
+
   # --- Definition convenience methods ---
 
   def test_definition_empty


### PR DESCRIPTION
## Summary
- add explicit runner context injection for compatible step handlers
- keep backward compatibility for legacy handlers
- reject context with parallel: :processes until serialization hooks exist
- follow-up retry work is tracked in #4

## Testing
- bundle exec rake test