### PR TITLE
fix: restore workflow runner example

### DIFF
--- a/examples/workflow_runner.rb
+++ b/examples/workflow_runner.rb
@@ -22,7 +22,7 @@ registry.register(DAG::Workflow::Step.new(name: :shout, type: :ruby,
 
 definition = DAG::Workflow::Definition.new(graph: graph, registry: registry)
 
-puts "Definition: #{definition.inspect}"
+puts "Definition: #{definition}"
 puts "Steps: #{definition.steps.map(&:to_s)}"
 puts "Empty? #{definition.empty?}"
 puts "Execution order: #{definition.execution_order.inspect}"
@@ -54,7 +54,7 @@ yaml = <<~YAML
 YAML
 
 definition = DAG::Workflow::Loader.from_yaml(yaml)
-puts "Loaded: #{definition.inspect}"
+puts "Loaded: #{definition}"
 puts "Layers: #{definition.execution_order.inspect}"
 
 result = DAG::Workflow::Runner.new(definition.graph, definition.registry, parallel: false).call
@@ -74,7 +74,7 @@ definition = DAG::Workflow::Loader.from_hash(
   store: {type: :exec, command: 'echo "stored"', depends_on: [:transform]}
 )
 
-puts "Loaded: #{definition.inspect}"
+puts "Loaded: #{definition}"
 puts "Layers: #{definition.execution_order.inspect}"
 puts "Transform config: #{definition.step(:transform).config.inspect}"
 puts

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "open3"
+require "tmpdir"
+
+class ExamplesTest < Minitest::Test
+  def test_workflow_runner_example_executes_successfully
+    env = {
+      "TMPDIR" => Dir.tmpdir,
+      "HOME" => ENV.fetch("HOME", Dir.pwd)
+    }
+
+    stdout, stderr, status = Open3.capture3(env,
+      Gem.ruby, "-Ilib", "examples/workflow_runner.rb",
+      chdir: File.expand_path("..", __dir__))
+
+    assert status.success?, <<~MSG
+      expected workflow_runner example to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "=== Manual Workflow ==="
+    assert_includes stdout, "=== YAML Workflow ==="
+    assert_includes stdout, "=== from_hash Workflow ==="
+  end
+end


### PR DESCRIPTION
## Summary
- stop calling the private `Definition#inspect` method explicitly in the workflow example
- add a regression test that executes `examples/workflow_runner.rb` end-to-end

## Testing
- TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/workflow_runner.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/examples_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake