### PR TITLE
test: cover step execution and middleware

### DIFF
--- a/spec/step_execution_test.rb
+++ b/spec/step_execution_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class StepExecutionTest < Minitest::Test
+  def test_rejects_attempts_below_one
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow::StepExecution.new(
+        workflow_id: "wf-1",
+        node_path: [:build],
+        attempt: 0,
+        deadline: nil,
+        depth: 0,
+        parallel: :sequential,
+        execution_store: nil,
+        event_bus: nil
+      )
+    end
+
+    assert_equal "attempt must be >= 1", error.message
+  end
+
+  def test_rejects_negative_depth
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow::StepExecution.new(
+        workflow_id: "wf-1",
+        node_path: [:build],
+        attempt: 1,
+        deadline: nil,
+        depth: -1,
+        parallel: :sequential,
+        execution_store: nil,
+        event_bus: nil
+      )
+    end
+
+    assert_equal "depth must be >= 0", error.message
+  end
+end

--- a/spec/step_middleware_test.rb
+++ b/spec/step_middleware_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class StepMiddlewareTest < Minitest::Test
+  def test_base_middleware_delegates_to_next_step
+    middleware = DAG::Workflow::StepMiddleware.new
+    step = Object.new
+    input = {source: "value"}
+    context = {request_id: "abc"}
+    execution = Object.new
+    expected = DAG::Success.new(value: :ok)
+    received = nil
+
+    result = middleware.call(step, input, context: context, execution: execution, next_step: lambda { |passed_step, passed_input, context:, execution:|
+      received = [passed_step, passed_input, context, execution]
+      expected
+    })
+
+    assert_same expected, result
+    assert_equal [step, input, context, execution], received
+  end
+end


### PR DESCRIPTION
## What changed
Adds focused tests for the remaining uncovered workflow infrastructure paths:

- `StepExecution` argument validation for invalid `attempt` and `depth`
- base `StepMiddleware#call` delegation behavior

## Why
`bundle exec rake coverage` was failing because total coverage was at 99.92% line coverage and 99.48% branch coverage even though the test suite itself was green.

## Validation
- `bundle exec ruby -I spec spec/step_execution_test.rb spec/step_middleware_test.rb`
- `bundle exec rake coverage`