### PR TITLE
feat: add programmatic sub-workflow steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,54 @@ Notes:
 - changing the workflow fingerprint for an existing `workflow_id` raises `DAG::ValidationError` before any step runs
 - see `examples/checkpoint_resume.rb` for a runnable end-to-end example that is exercised in the test suite
 
+### Sub-workflow composition
+
+A step can run a nested programmatic `Definition` with type `:sub_workflow`.
+The child run inherits the parent runner's parallel mode, middleware, context,
+remaining timeout budget, workflow ID, and execution store.
+
+```ruby
+child = DAG::Workflow::Loader.from_hash(
+  analyze: {
+    type: :ruby,
+    callable: ->(input) { DAG::Success.new(value: input[:raw].upcase) }
+  },
+  summarize: {
+    type: :ruby,
+    depends_on: [:analyze],
+    callable: ->(input, context) { DAG::Success.new(value: "#{input[:analyze]}#{context[:suffix]}") }
+  }
+)
+
+parent = DAG::Workflow::Loader.from_hash(
+  fetch: {
+    type: :ruby,
+    callable: ->(_input) { DAG::Success.new(value: "hello") }
+  },
+  process: {
+    type: :sub_workflow,
+    definition: child,
+    depends_on: [:fetch],
+    input_mapping: {fetch: :raw},
+    output_key: :summarize
+  }
+)
+
+result = DAG::Workflow::Runner.new(parent,
+  parallel: false,
+  context: {suffix: "!"}).call
+
+puts result.outputs[:process].value  # => "HELLO!"
+puts result.trace.map(&:name)        # => [:fetch, :"process.analyze", :"process.summarize", :process]
+```
+
+Notes:
+- this first slice supports programmatic `definition:` only
+- child trace entries are flattened into the parent trace with names like `:"process.summarize"`
+- default sub-workflow output is a hash of child leaf values; `output_key:` selects one leaf
+- durable child outputs are stored under the parent node path, e.g. `[:process, :summarize]`
+- see `examples/sub_workflow.rb` for a runnable example that is exercised in the test suite
+
 ## Graph API
 
 Pure DAG with no workflow awareness. The ONLY iteration entry points are

--- a/examples/sub_workflow.rb
+++ b/examples/sub_workflow.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Sub-workflow composition: a parent step can execute a child Definition,
+# flatten child trace entries, and optionally persist child outputs under the
+# parent node path.
+#
+# Run: ruby -Ilib examples/sub_workflow.rb
+
+require "dag"
+
+child_calls = 0
+child_definition = DAG::Workflow::Loader.from_hash(
+  analyze: {
+    type: :ruby,
+    resume_key: "analyze-v1",
+    callable: ->(input) { DAG::Success.new(value: input[:raw].upcase) }
+  },
+  summarize: {
+    type: :ruby,
+    depends_on: [:analyze],
+    resume_key: "summarize-v1",
+    callable: ->(input, context) do
+      child_calls += 1
+      DAG::Success.new(value: "#{input[:analyze]}#{context[:suffix]}")
+    end
+  }
+)
+
+parent_definition = DAG::Workflow::Loader.from_hash(
+  fetch: {
+    type: :ruby,
+    resume_key: "fetch-v1",
+    callable: ->(_input) { DAG::Success.new(value: "hello") }
+  },
+  process: {
+    type: :sub_workflow,
+    definition: child_definition,
+    depends_on: [:fetch],
+    input_mapping: {fetch: :raw},
+    output_key: :summarize,
+    resume_key: "process-v1"
+  }
+)
+
+puts "=== Parent Workflow ==="
+parent_result = DAG::Workflow::Runner.new(parent_definition,
+  parallel: false,
+  context: {suffix: "!"}).call
+puts "Status: #{parent_result.status}"
+puts "Output: #{parent_result.outputs[:process].value}"
+puts "Trace names: #{parent_result.trace.map(&:name).inspect}"
+puts
+
+puts "=== Durable Run ==="
+child_calls = 0
+store = DAG::Workflow::ExecutionStore::MemoryStore.new
+runner = lambda do
+  DAG::Workflow::Runner.new(parent_definition,
+    parallel: false,
+    context: {suffix: "!"},
+    workflow_id: "example-sub-workflow",
+    execution_store: store)
+end
+
+first = runner.call.call
+second = runner.call.call
+puts "First output: #{first.outputs[:process].value}"
+puts "Second output: #{second.outputs[:process].value}"
+puts "Child calls: #{child_calls}"
+puts "Stored child output: #{store.load_output(workflow_id: "example-sub-workflow", node_path: [:process, :summarize])[:result].value}"

--- a/lib/dag/workflow/definition_fingerprint.rb
+++ b/lib/dag/workflow/definition_fingerprint.rb
@@ -33,10 +33,27 @@ module DAG
             raise ValidationError, "Step #{step.name} (type: :ruby) requires resume_key when durable execution is enabled" if blank?(resume_key)
 
             {resume_key: resume_key.to_s}
+          elsif step.type == :sub_workflow
+            fingerprint_sub_workflow_step(step)
           else
             raise ValidationError,
               "Step #{step.name} (type: #{step.type}) cannot be fingerprinted for durable execution"
           end
+        end
+
+        def fingerprint_sub_workflow_step(step)
+          definition = step.config[:definition]
+          resume_key = step.config[:resume_key]
+
+          raise ValidationError, "Step #{step.name} (type: :sub_workflow) requires a programmatic definition for durable execution" unless definition.is_a?(Definition)
+          raise ValidationError, "Step #{step.name} (type: :sub_workflow) requires resume_key when durable execution is enabled" if blank?(resume_key)
+
+          {
+            resume_key: resume_key.to_s,
+            input_mapping: normalize(step.config[:input_mapping] || {}),
+            output_key: step.config[:output_key]&.to_sym,
+            definition_fingerprint: self.for(definition)
+          }
         end
 
         def normalize(value)

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -36,6 +36,9 @@ module DAG
         middleware: [],
         workflow_id: nil,
         execution_store: nil,
+        node_path_prefix: [],
+        root_input: {},
+        register_execution_store: true,
         on_step_start: nil, on_step_finish: nil)
         graph, registry = unpack_definition(graph_or_definition, registry)
         @graph = graph
@@ -46,6 +49,9 @@ module DAG
         @middleware = Array(middleware).freeze
         @workflow_id = workflow_id
         @execution_store = execution_store
+        @node_path_prefix = Array(node_path_prefix).map(&:to_sym).freeze
+        @root_input = root_input.transform_keys(&:to_sym).freeze
+        @register_execution_store = register_execution_store
         validate_context_parallelism!(parallel, context)
         @callbacks = RunCallbacks.new(on_step_start: on_step_start, on_step_finish: on_step_finish)
         @strategy = build_strategy(parallel, max_parallelism)
@@ -56,9 +62,13 @@ module DAG
       end
 
       def call
+        call_with_initial_outputs({})
+      end
+
+      def call_with_initial_outputs(initial_outputs)
         deadline = @timeout ? @clock.monotonic_now + @timeout : nil
         prepare_execution_store!
-        execute_layers(@graph.topological_layers, deadline)
+        execute_layers(@graph.topological_layers, deadline, initial_outputs: initial_outputs)
       end
 
       private
@@ -70,7 +80,7 @@ module DAG
       end
 
       def prepare_execution_store!
-        return unless @execution_store
+        return unless @execution_store && @register_execution_store
 
         existing = @execution_store.load_run(@workflow_id)
         if existing && existing[:definition_fingerprint] != @definition_fingerprint
@@ -81,7 +91,7 @@ module DAG
         @execution_store.begin_run(
           workflow_id: @workflow_id,
           definition_fingerprint: @definition_fingerprint,
-          node_paths: @graph.topological_sort.zip
+          node_paths: @graph.topological_sort.map { |name| node_path_for(name) }
         )
       end
 
@@ -118,9 +128,9 @@ module DAG
 
       def executor_class(type) = Steps.class_for(type)
 
-      def execute_layers(layers, deadline)
-        outputs = {}
-        statuses = {}
+      def execute_layers(layers, deadline, initial_outputs: {})
+        outputs = normalize_initial_outputs(initial_outputs)
+        statuses = outputs.transform_values { |_result| :success }
         trace = []
         failed_name = nil
         failed_result = nil
@@ -247,10 +257,10 @@ module DAG
       def build_step_execution(name, current_attempt:, deadline:)
         StepExecution.new(
           workflow_id: @workflow_id,
-          node_path: [name],
+          node_path: node_path_for(name),
           attempt: current_attempt,
           deadline: deadline,
-          depth: 0,
+          depth: @node_path_prefix.length,
           parallel: @strategy.name,
           execution_store: @execution_store,
           event_bus: nil
@@ -266,10 +276,14 @@ module DAG
       end
 
       def core_step_invoker(step, attempt_log)
-        executor = executor_class(step.type).new
+        executor = (step.type == :sub_workflow) ? nil : executor_class(step.type).new
         ->(current_step, current_input, context:, execution:) do
           started_at = @clock.monotonic_now
-          result = invoke_step_executor(executor, current_step, current_input, context: context)
+          result = if current_step.type == :sub_workflow
+            run_sub_workflow_step(current_step, current_input, context: context, execution: execution)
+          else
+            invoke_step_executor(executor, current_step, current_input, context: context)
+          end
           unless result.is_a?(Result)
             result = Failure.new(error: {
               code: :step_bad_return,
@@ -279,9 +293,12 @@ module DAG
               strategy: @strategy.name
             })
           end
+          result, child_trace = unwrap_sub_workflow_result(result)
+          attempt_log.concat(child_trace)
           finished_at = @clock.monotonic_now
           attempt_log << {
             attempt: execution.attempt,
+            node_path: execution.node_path,
             started_at: started_at,
             finished_at: finished_at,
             duration_ms: ((finished_at - started_at) * 1000).round(2),
@@ -296,6 +313,7 @@ module DAG
             strategy: @strategy.name)
           attempt_log << {
             attempt: execution.attempt,
+            node_path: execution.node_path,
             started_at: started_at,
             finished_at: finished_at,
             duration_ms: ((finished_at - started_at) * 1000).round(2),
@@ -312,6 +330,109 @@ module DAG
           executor.call(step, input, context: context)
         else
           executor.call(step, input)
+        end
+      end
+
+      def run_sub_workflow_step(step, input, context:, execution:)
+        definition = step.config[:definition]
+        definition_path = step.config[:definition_path]
+
+        unless definition.is_a?(Definition) && definition_path.nil?
+          return Failure.new(error: {
+            code: :sub_workflow_invalid_definition,
+            message: "sub_workflow step #{step.name} requires a programmatic definition: and does not yet support definition_path:"
+          })
+        end
+
+        mapped_input = map_sub_workflow_input(step, input)
+        register_child_node_paths(definition, execution)
+
+        child_result = Runner.new(definition,
+          parallel: execution.parallel,
+          max_parallelism: @strategy.max_parallelism,
+          timeout: remaining_timeout_for(execution.deadline),
+          clock: @clock,
+          context: context,
+          middleware: @middleware,
+          workflow_id: execution.workflow_id,
+          execution_store: execution.execution_store,
+          node_path_prefix: execution.node_path,
+          root_input: mapped_input,
+          register_execution_store: false).call
+
+        if child_result.failure?
+          return Failure.new(error: {
+            code: :sub_workflow_failed,
+            message: "sub_workflow step #{step.name} failed",
+            child_error: child_result.error,
+            child_trace: child_result.trace
+          })
+        end
+
+        selected_output = select_sub_workflow_output(step, definition, child_result.outputs)
+        return selected_output if selected_output.is_a?(Failure)
+
+        Success.new(value: {
+          __sub_workflow_output__: selected_output,
+          __sub_workflow_trace__: child_result.trace
+        })
+      end
+
+      def register_child_node_paths(definition, execution)
+        return unless execution.execution_store && execution.workflow_id
+
+        fingerprint = execution.execution_store.load_run(execution.workflow_id)&.fetch(:definition_fingerprint)
+        execution.execution_store.begin_run(
+          workflow_id: execution.workflow_id,
+          definition_fingerprint: fingerprint || @definition_fingerprint,
+          node_paths: definition.graph.topological_sort.map { |name| execution.node_path + [name] }
+        )
+      end
+
+      def remaining_timeout_for(deadline)
+        return nil unless deadline
+
+        remaining = deadline - @clock.monotonic_now
+        remaining.positive? ? remaining : 0
+      end
+
+      def map_sub_workflow_input(step, input)
+        mapping = step.config[:input_mapping]
+        return input unless mapping
+
+        mapping.each_with_object({}) do |(from, to), mapped|
+          mapped[to.to_sym] = input.fetch(from.to_sym)
+        end
+      end
+
+      def select_sub_workflow_output(step, definition, outputs)
+        leaves = definition.graph.leaves.to_a.sort
+        output_key = step.config[:output_key]&.to_sym
+
+        if output_key
+          unless leaves.include?(output_key)
+            raise ValidationError,
+              "sub_workflow step #{step.name} output_key #{output_key.inspect} must reference a leaf node (leaves: #{leaves.inspect})"
+          end
+
+          return outputs.fetch(output_key).value
+        end
+
+        leaves.to_h { |leaf| [leaf, outputs.fetch(leaf).value] }
+      rescue ValidationError => e
+        Failure.new(error: {
+          code: :sub_workflow_invalid_output_key,
+          message: e.message
+        })
+      end
+
+      def unwrap_sub_workflow_result(result)
+        if result.success? && result.value.is_a?(Hash) && result.value[:__sub_workflow_output__]
+          [Success.new(value: result.value[:__sub_workflow_output__]), result.value[:__sub_workflow_trace__] || []]
+        elsif result.failure? && result.error.is_a?(Hash) && result.error[:child_trace]
+          [Failure.new(error: result.error.except(:child_trace)), result.error[:child_trace] || []]
+        else
+          [result, []]
         end
       end
 
@@ -342,7 +463,7 @@ module DAG
 
       def record_immediate_results(entries, results, statuses, layer_index, trace)
         entries.each do |name, result, input_keys, status|
-          entry = build_trace_entry(name, layer_index, result,
+          entry = build_trace_entry(node_path_for(name), layer_index, result,
             started_at: nil, finished_at: nil, duration_ms: 0,
             input_keys: input_keys, status: status)
           trace << entry
@@ -354,10 +475,27 @@ module DAG
 
       def record_skip_result = Success.new(value: nil)
 
+      def node_path_for(name)
+        @node_path_prefix + [name.to_sym]
+      end
+
+      def trace_name_for(node_path)
+        path = Array(node_path).map(&:to_sym)
+        return path.first if path.length == 1
+
+        path.join(".").to_sym
+      end
+
+      def normalize_initial_outputs(initial_outputs)
+        initial_outputs.transform_values do |value|
+          value.is_a?(Result) ? value : Success.new(value: value)
+        end
+      end
+
       def load_reusable_result(name)
         return nil unless @execution_store
 
-        stored = @execution_store.load_output(workflow_id: @workflow_id, node_path: [name])
+        stored = @execution_store.load_output(workflow_id: @workflow_id, node_path: node_path_for(name))
         stored && stored[:result]
       end
 
@@ -391,26 +529,28 @@ module DAG
 
       def build_trace_entries_for_task(task, layer_index, result, started_at:, finished_at:, duration_ms:)
         if task.attempt_log.empty?
-          return [build_trace_entry(task.name, layer_index, result,
+          return [build_trace_entry(task.execution.node_path, layer_index, result,
             started_at: started_at, finished_at: finished_at, duration_ms: duration_ms,
             input_keys: task.input_keys)]
         end
 
         task.attempt_log.each_with_index.map do |entry, index|
-          build_trace_entry(task.name, layer_index, result,
+          next entry if entry.is_a?(TraceEntry)
+
+          build_trace_entry(entry[:node_path] || task.execution.node_path, layer_index, result,
             started_at: entry[:started_at],
             finished_at: entry[:finished_at],
             duration_ms: entry[:duration_ms],
-            input_keys: task.input_keys,
+            input_keys: entry[:input_keys] || task.input_keys,
             status: entry[:status],
             attempt: entry[:attempt],
             retried: index < (task.attempt_log.length - 1))
         end
       end
 
-      def build_trace_entry(name, layer_index, result, started_at:, finished_at:, duration_ms:, input_keys:, status: nil, attempt: 1, retried: false)
+      def build_trace_entry(node_path, layer_index, result, started_at:, finished_at:, duration_ms:, input_keys:, status: nil, attempt: 1, retried: false)
         TraceEntry.new(
-          name: name, layer: layer_index,
+          name: trace_name_for(node_path), layer: layer_index,
           started_at: started_at, finished_at: finished_at,
           duration_ms: duration_ms,
           status: status || (result.success? ? :success : :failure),
@@ -423,9 +563,11 @@ module DAG
       # Predecessors always have a Result in `outputs` by the time we
       # resolve a downstream layer — skipped steps still record Success(nil).
       def resolve_condition_context(name, outputs, statuses)
-        @graph.each_predecessor(name).to_h do |dep|
+        dependency_context = @root_input.transform_values { |value| {value: value, status: :success} }
+
+        dependency_context.merge(@graph.each_predecessor(name).to_h do |dep|
           [dep, {value: outputs.fetch(dep).value, status: statuses.fetch(dep)}]
-        end
+        end)
       end
 
       def extract_input(condition_context)

--- a/lib/dag/workflow/steps.rb
+++ b/lib/dag/workflow/steps.rb
@@ -5,6 +5,7 @@ require_relative "steps/ruby_script"
 require_relative "steps/file_read"
 require_relative "steps/file_write"
 require_relative "steps/ruby"
+require_relative "steps/sub_workflow"
 
 module DAG
   module Workflow
@@ -55,6 +56,7 @@ module DAG
       register(:file_read, FileRead, yaml_safe: true)
       register(:file_write, FileWrite, yaml_safe: true)
       register(:ruby, Ruby, yaml_safe: false)
+      register(:sub_workflow, SubWorkflow, yaml_safe: false)
     end
   end
 end

--- a/lib/dag/workflow/steps/sub_workflow.rb
+++ b/lib/dag/workflow/steps/sub_workflow.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module DAG
+  module Workflow
+    module Steps
+      class SubWorkflow
+        def call(_step, _input, **_kwargs)
+          Failure.new(error: {
+            code: :sub_workflow_runner_required,
+            message: "sub_workflow steps are executed by DAG::Workflow::Runner internals"
+          })
+        end
+      end
+    end
+  end
+end

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -37,6 +37,22 @@ class ExamplesTest < Minitest::Test
     assert_includes stdout, "Fetch calls: 1"
   end
 
+  def test_sub_workflow_example_executes_successfully
+    stdout, stderr, status = run_example("examples/sub_workflow.rb")
+
+    assert status.success?, <<~MSG
+      expected sub_workflow example to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "=== Parent Workflow ==="
+    assert_includes stdout, "=== Durable Run ==="
+    assert_includes stdout, "Child calls: 1"
+  end
+
   private
 
   def run_example(path)

--- a/spec/sub_workflow_test.rb
+++ b/spec/sub_workflow_test.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class SubWorkflowTest < Minitest::Test
+  include TestHelpers
+
+  def test_programmatic_sub_workflow_returns_child_leaf_outputs_and_namespaced_trace
+    child = DAG::Workflow::Loader.from_hash(
+      analyze: {
+        type: :ruby,
+        callable: ->(input) { DAG::Success.new(value: input[:raw].upcase) }
+      },
+      summarize: {
+        type: :ruby,
+        depends_on: [:analyze],
+        callable: ->(input) { DAG::Success.new(value: "#{input[:analyze]}!") }
+      }
+    )
+
+    parent = DAG::Workflow::Loader.from_hash(
+      fetch: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "hello") }
+      },
+      process: {
+        type: :sub_workflow,
+        definition: child,
+        depends_on: [:fetch],
+        input_mapping: {fetch: :raw}
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(parent, parallel: false).call
+
+    assert result.success?
+    assert_equal({summarize: "HELLO!"}, result.outputs[:process].value)
+    assert_includes result.trace.map(&:name), :"process.analyze"
+    assert_includes result.trace.map(&:name), :"process.summarize"
+  end
+
+  def test_sub_workflow_output_key_returns_selected_leaf_value
+    child = DAG::Workflow::Loader.from_hash(
+      analyze: {
+        type: :ruby,
+        callable: ->(input) { DAG::Success.new(value: input[:raw].upcase) }
+      },
+      summarize: {
+        type: :ruby,
+        depends_on: [:analyze],
+        callable: ->(input) { DAG::Success.new(value: "#{input[:analyze]}!") }
+      }
+    )
+
+    parent = DAG::Workflow::Loader.from_hash(
+      fetch: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "hello") }
+      },
+      process: {
+        type: :sub_workflow,
+        definition: child,
+        depends_on: [:fetch],
+        input_mapping: {fetch: :raw},
+        output_key: :summarize
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(parent, parallel: false).call
+
+    assert result.success?
+    assert_equal "HELLO!", result.outputs[:process].value
+  end
+
+  def test_sub_workflow_rejects_non_leaf_output_key
+    child = DAG::Workflow::Loader.from_hash(
+      analyze: {
+        type: :ruby,
+        callable: ->(input) { DAG::Success.new(value: input[:raw].upcase) }
+      },
+      summarize: {
+        type: :ruby,
+        depends_on: [:analyze],
+        callable: ->(input) { DAG::Success.new(value: "#{input[:analyze]}!") }
+      }
+    )
+
+    parent = DAG::Workflow::Loader.from_hash(
+      fetch: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "hello") }
+      },
+      process: {
+        type: :sub_workflow,
+        definition: child,
+        depends_on: [:fetch],
+        input_mapping: {fetch: :raw},
+        output_key: :analyze
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(parent, parallel: false).call
+
+    assert result.failure?
+    assert_equal :process, result.error[:failed_node]
+    assert_equal :sub_workflow_invalid_output_key, result.error[:step_error][:code]
+  end
+
+  def test_sub_workflow_uses_parent_context_and_execution_store_namespace
+    child_calls = 0
+    child = DAG::Workflow::Loader.from_hash(
+      inner_fetch: {
+        type: :ruby,
+        resume_key: "inner-fetch-v1",
+        callable: ->(input, context) do
+          child_calls += 1
+          DAG::Success.new(value: "#{input[:raw]}#{context[:suffix]}")
+        end
+      }
+    )
+
+    parent = DAG::Workflow::Loader.from_hash(
+      fetch: {
+        type: :ruby,
+        resume_key: "fetch-v1",
+        callable: ->(_input) { DAG::Success.new(value: "hello") }
+      },
+      process: {
+        type: :sub_workflow,
+        definition: child,
+        depends_on: [:fetch],
+        input_mapping: {fetch: :raw},
+        output_key: :inner_fetch,
+        resume_key: "process-v1"
+      }
+    )
+
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    runner = lambda do
+      DAG::Workflow::Runner.new(parent,
+        parallel: false,
+        context: {suffix: "!"},
+        workflow_id: "wf-sub",
+        execution_store: store)
+    end
+
+    first = runner.call.call
+    second = runner.call.call
+    run = store.load_run("wf-sub")
+
+    assert first.success?
+    assert second.success?
+    assert_equal "hello!", first.outputs[:process].value
+    assert_equal "hello!", second.outputs[:process].value
+    assert_equal 1, child_calls
+    assert_includes run[:node_paths], [:process, :inner_fetch]
+    assert_equal "hello!", store.load_output(workflow_id: "wf-sub", node_path: [:process, :inner_fetch])[:result].value
+  end
+end


### PR DESCRIPTION
## Summary
- add a first programmatic `:sub_workflow` step slice with flattened child trace entries
- inherit parent runner settings into child workflows and namespace durable child outputs under the parent node path
- extend fingerprinting for durable sub-workflow steps
- add sub-workflow docs plus a runnable example exercised by the example test suite

## Testing
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/sub_workflow_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/examples_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/sub_workflow.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`
- `TMPDIR=$HOME/.tmp/ruby-dag ruby script/soak.rb --all --short`
- `TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/checkpoint_resume.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/workflow_runner.rb`

Closes #23