### PR TITLE
feat: add YAML sub-workflow definition paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,12 @@ Notes:
 
 ### Sub-workflow composition
 
-A step can run a nested programmatic `Definition` with type `:sub_workflow`.
+A step can run a nested workflow with type `:sub_workflow`. The child can come
+from either a programmatic `definition:` or a YAML-safe `definition_path:`.
 The child run inherits the parent runner's parallel mode, middleware, context,
 remaining timeout budget, workflow ID, and execution store.
+
+Programmatic form:
 
 ```ruby
 child = DAG::Workflow::Loader.from_hash(
@@ -272,12 +275,28 @@ puts result.outputs[:process].value  # => "HELLO!"
 puts result.trace.map(&:name)        # => [:fetch, :"process.analyze", :"process.summarize", :process]
 ```
 
+YAML-safe form:
+
+```yaml
+nodes:
+  process:
+    type: sub_workflow
+    definition_path: sub_workflows/child.yml
+    output_key: nested
+    resume_key: process-v1
+```
+
+`definition_path:` is resolved relative to the YAML file that declares it, so a
+child workflow can itself use relative `definition_path:` entries for deeper
+nesting.
+
 Notes:
-- this first slice supports programmatic `definition:` only
+- `:sub_workflow` must declare exactly one of `definition:` or `definition_path:`
 - child trace entries are flattened into the parent trace with names like `:"process.summarize"`
 - default sub-workflow output is a hash of child leaf values; `output_key:` selects one leaf
 - durable child outputs are stored under the parent node path, e.g. `[:process, :summarize]`
-- see `examples/sub_workflow.rb` for a runnable example that is exercised in the test suite
+- the dumper emits YAML-safe sub-workflows when they use `definition_path:` and rejects programmatic `definition:` children
+- see `examples/sub_workflow.rb` and `examples/sub_workflow_parent.yml` for runnable examples exercised in the test suite
 
 ## Graph API
 

--- a/examples/sub_workflow.rb
+++ b/examples/sub_workflow.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-# Sub-workflow composition: a parent step can execute a child Definition,
-# flatten child trace entries, and optionally persist child outputs under the
-# parent node path.
+# Sub-workflow composition: a parent step can execute either a programmatic
+# child Definition or a YAML child loaded via definition_path. Child trace
+# entries are flattened into the parent trace, and durable outputs stay
+# namespaced under the parent node path.
 #
 # Run: ruby -Ilib examples/sub_workflow.rb
 
@@ -42,7 +43,7 @@ parent_definition = DAG::Workflow::Loader.from_hash(
   }
 )
 
-puts "=== Parent Workflow ==="
+puts "=== Programmatic Parent Workflow ==="
 parent_result = DAG::Workflow::Runner.new(parent_definition,
   parallel: false,
   context: {suffix: "!"}).call
@@ -51,7 +52,7 @@ puts "Output: #{parent_result.outputs[:process].value}"
 puts "Trace names: #{parent_result.trace.map(&:name).inspect}"
 puts
 
-puts "=== Durable Run ==="
+puts "=== Durable Programmatic Run ==="
 child_calls = 0
 store = DAG::Workflow::ExecutionStore::MemoryStore.new
 runner = lambda do
@@ -68,3 +69,28 @@ puts "First output: #{first.outputs[:process].value}"
 puts "Second output: #{second.outputs[:process].value}"
 puts "Child calls: #{child_calls}"
 puts "Stored child output: #{store.load_output(workflow_id: "example-sub-workflow", node_path: [:process, :summarize])[:result].value}"
+puts
+
+puts "=== YAML Parent Workflow ==="
+yaml_parent = File.expand_path("sub_workflow_parent.yml", __dir__)
+yaml_definition = DAG::Workflow::Loader.from_file(yaml_parent)
+yaml_result = DAG::Workflow::Runner.new(yaml_definition, parallel: false).call
+puts "Status: #{yaml_result.status}"
+puts "Output: #{yaml_result.outputs[:process].value}"
+puts "Trace names: #{yaml_result.trace.map(&:name).inspect}"
+puts
+
+puts "=== Durable YAML Run ==="
+yaml_store = DAG::Workflow::ExecutionStore::MemoryStore.new
+yaml_runner = lambda do
+  DAG::Workflow::Runner.new(yaml_definition,
+    parallel: false,
+    workflow_id: "example-yaml-sub-workflow",
+    execution_store: yaml_store)
+end
+
+yaml_first = yaml_runner.call.call
+yaml_second = yaml_runner.call.call
+puts "First YAML output: #{yaml_first.outputs[:process].value}"
+puts "Second YAML output: #{yaml_second.outputs[:process].value}"
+puts "Stored YAML child output: #{yaml_store.load_output(workflow_id: "example-yaml-sub-workflow", node_path: [:process, :nested, :summarize])[:result].value}"

--- a/examples/sub_workflow_parent.yml
+++ b/examples/sub_workflow_parent.yml
@@ -1,0 +1,6 @@
+nodes:
+  process:
+    type: sub_workflow
+    definition_path: sub_workflows/child.yml
+    output_key: nested
+    resume_key: process-v1

--- a/examples/sub_workflows/child.yml
+++ b/examples/sub_workflows/child.yml
@@ -1,0 +1,6 @@
+nodes:
+  nested:
+    type: sub_workflow
+    definition_path: nested/grandchild.yml
+    output_key: summarize
+    resume_key: nested-v1

--- a/examples/sub_workflows/nested/grandchild.yml
+++ b/examples/sub_workflows/nested/grandchild.yml
@@ -1,0 +1,4 @@
+nodes:
+  summarize:
+    type: exec
+    command: "printf yaml-grandchild"

--- a/lib/dag/workflow/definition.rb
+++ b/lib/dag/workflow/definition.rb
@@ -8,7 +8,11 @@ module DAG
     #   definition = DAG::Loader.from_file("workflow.yml")
     #   result = DAG::Runner.new(definition.graph, definition.registry).call
 
-    Definition = Data.define(:graph, :registry) do
+    Definition = Data.define(:graph, :registry, :source_path) do
+      def initialize(graph:, registry:, source_path: nil)
+        super(graph: graph, registry: registry, source_path: source_path&.to_s)
+      end
+
       def size = graph.size
       def empty? = graph.empty? && registry.empty?
       def steps = registry.steps
@@ -16,6 +20,8 @@ module DAG
       def execution_order = graph.topological_layers
 
       def step(name) = registry[name]
+
+      def source_dir = source_path && File.dirname(source_path)
 
       def replace_step(old_name, new_step)
         old_sym = old_name.to_sym
@@ -31,7 +37,7 @@ module DAG
           new_registry.replace(new_step)
         end
 
-        Definition.new(graph: new_graph, registry: new_registry)
+        Definition.new(graph: new_graph, registry: new_registry, source_path: source_path)
       end
 
       private

--- a/lib/dag/workflow/definition_fingerprint.rb
+++ b/lib/dag/workflow/definition_fingerprint.rb
@@ -15,7 +15,7 @@ module DAG
               {
                 name: step.name,
                 type: step.type,
-                fingerprint: fingerprint_step(step)
+                fingerprint: fingerprint_step(step, source_path: definition.source_path)
               }
             end
           }
@@ -25,34 +25,42 @@ module DAG
 
         private
 
-        def fingerprint_step(step)
-          if Steps.yaml_types.include?(step.type)
-            normalize(step.config)
+        def fingerprint_step(step, source_path: nil)
+          if step.type == :sub_workflow
+            fingerprint_sub_workflow_step(step, source_path: source_path)
           elsif step.type == :ruby
             resume_key = step.config[:resume_key]
             raise ValidationError, "Step #{step.name} (type: :ruby) requires resume_key when durable execution is enabled" if blank?(resume_key)
 
             {resume_key: resume_key.to_s}
-          elsif step.type == :sub_workflow
-            fingerprint_sub_workflow_step(step)
+          elsif Steps.yaml_types.include?(step.type)
+            normalize(step.config)
           else
             raise ValidationError,
               "Step #{step.name} (type: #{step.type}) cannot be fingerprinted for durable execution"
           end
         end
 
-        def fingerprint_sub_workflow_step(step)
+        def fingerprint_sub_workflow_step(step, source_path: nil)
           definition = step.config[:definition]
+          definition_path = step.config[:definition_path]
           resume_key = step.config[:resume_key]
 
-          raise ValidationError, "Step #{step.name} (type: :sub_workflow) requires a programmatic definition for durable execution" unless definition.is_a?(Definition)
           raise ValidationError, "Step #{step.name} (type: :sub_workflow) requires resume_key when durable execution is enabled" if blank?(resume_key)
+
+          child_definition = if definition.is_a?(Definition) && blank?(definition_path)
+            definition
+          elsif definition.nil? && !blank?(definition_path)
+            Loader.from_file(resolve_path(definition_path, source_path: source_path))
+          else
+            raise ValidationError, "Step #{step.name} (type: :sub_workflow) must define exactly one of definition or definition_path"
+          end
 
           {
             resume_key: resume_key.to_s,
             input_mapping: normalize(step.config[:input_mapping] || {}),
             output_key: step.config[:output_key]&.to_sym,
-            definition_fingerprint: self.for(definition)
+            definition_fingerprint: self.for(child_definition)
           }
         end
 
@@ -67,6 +75,13 @@ module DAG
           else
             value
           end
+        end
+
+        def resolve_path(path, source_path: nil)
+          return path if Pathname.new(path).absolute?
+
+          base_dir = source_path && File.dirname(source_path)
+          File.expand_path(path, base_dir || Dir.pwd)
         end
 
         def blank?(value)

--- a/lib/dag/workflow/dumper.rb
+++ b/lib/dag/workflow/dumper.rb
@@ -30,7 +30,7 @@ module DAG
         data = {}
         @graph.topological_sort.each do |name|
           step = @registry[name]
-          raise SerializationError, "Step #{name} (type: #{step.type}) is not YAML-serializable" if NON_SERIALIZABLE_TYPES.include?(step.type)
+          validate_serializable_step!(name, step)
 
           data[name.to_s] = build_step(name, step)
         end
@@ -38,6 +38,19 @@ module DAG
       end
 
       private
+
+      def validate_serializable_step!(name, step)
+        raise SerializationError, "Step #{name} (type: #{step.type}) is not YAML-serializable" if NON_SERIALIZABLE_TYPES.include?(step.type)
+
+        return unless step.type == :sub_workflow
+
+        definition = step.config[:definition]
+        definition_path = step.config[:definition_path]
+        return if definition.nil? && definition_path.is_a?(String) && !definition_path.empty?
+
+        raise SerializationError,
+          "Step #{name} (type: :sub_workflow) is YAML-serializable only when it uses definition_path"
+      end
 
       def build_step(name, step)
         node = {"type" => step.type.to_s}

--- a/lib/dag/workflow/loader.rb
+++ b/lib/dag/workflow/loader.rb
@@ -12,22 +12,23 @@ module DAG
 
     class Loader
       def self.from_file(path)
-        from_yaml(File.read(path))
+        expanded_path = File.expand_path(path)
+        from_yaml(File.read(expanded_path), source_path: expanded_path)
       rescue Errno::ENOENT
         raise ArgumentError, "File not found: #{path}"
       end
 
       # Symbols permitted so step configs with `:symbol` values round-trip
       # through Dumper. Nothing else — keep the surface tight.
-      def self.from_yaml(yaml_string)
+      def self.from_yaml(yaml_string, source_path: nil)
         data = YAML.safe_load(yaml_string, permitted_classes: [Symbol])
         raise ValidationError, "YAML must contain a 'nodes' mapping" unless data.is_a?(Hash) && data["nodes"].is_a?(Hash)
 
-        build_definition(normalize_entries(data["nodes"], string_keys: true))
+        build_definition(normalize_entries(data["nodes"], string_keys: true), source_path: source_path)
       end
 
       def self.from_hash(**node_defs)
-        build_definition(normalize_entries(node_defs, string_keys: false))
+        build_definition(normalize_entries(node_defs, string_keys: false), source_path: nil)
       end
 
       def self.normalize_entries(node_defs, string_keys:)
@@ -61,7 +62,7 @@ module DAG
       # and edges second makes declaration order irrelevant; the resulting
       # error for a typoed dependency is also clearer (`unknown node X`) than
       # the bare `UnknownNodeError` you'd get from edge insertion mid-pass.
-      def self.build_definition(entries)
+      def self.build_definition(entries, source_path: nil)
         graph = Graph.new
         registry = Registry.new
         deferred_edges = []
@@ -85,7 +86,7 @@ module DAG
         end
 
         Validator.validate!(graph, registry)
-        Definition.new(graph: graph, registry: registry)
+        Definition.new(graph: graph, registry: registry, source_path: source_path)
       end
 
       def self.validate_type!(name, type, valid_types: Steps.types)

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -40,9 +40,10 @@ module DAG
         root_input: {},
         register_execution_store: true,
         on_step_start: nil, on_step_finish: nil)
-        graph, registry = unpack_definition(graph_or_definition, registry)
+        graph, registry, definition_source_path = unpack_definition(graph_or_definition, registry)
         @graph = graph
         @registry = registry
+        @definition_source_path = definition_source_path
         @timeout = timeout
         @clock = clock
         @context = context
@@ -58,7 +59,7 @@ module DAG
         validate_coverage!(graph, registry)
         validate_workflow!(graph, registry)
         validate_durable_execution!
-        @definition_fingerprint = @execution_store ? DefinitionFingerprint.for(Definition.new(graph: @graph, registry: @registry)) : nil
+        @definition_fingerprint = @execution_store ? DefinitionFingerprint.for(Definition.new(graph: @graph, registry: @registry, source_path: @definition_source_path)) : nil
       end
 
       def call
@@ -119,10 +120,10 @@ module DAG
         case graph
         when Definition
           raise ArgumentError, "Runner.new(definition) takes no registry argument" if registry
-          graph.deconstruct
+          [graph.graph, graph.registry, graph.source_path]
         else
           raise ArgumentError, "Runner.new(graph, registry) requires a registry" if registry.nil?
-          [graph, registry]
+          [graph, registry, nil]
         end
       end
 
@@ -334,16 +335,10 @@ module DAG
       end
 
       def run_sub_workflow_step(step, input, context:, execution:)
-        definition = step.config[:definition]
-        definition_path = step.config[:definition_path]
+        definition_result = resolve_sub_workflow_definition(step)
+        return definition_result if definition_result.is_a?(Failure)
 
-        unless definition.is_a?(Definition) && definition_path.nil?
-          return Failure.new(error: {
-            code: :sub_workflow_invalid_definition,
-            message: "sub_workflow step #{step.name} requires a programmatic definition: and does not yet support definition_path:"
-          })
-        end
-
+        definition = definition_result.value
         mapped_input = map_sub_workflow_input(step, input)
         register_child_node_paths(definition, execution)
 
@@ -387,6 +382,36 @@ module DAG
           definition_fingerprint: fingerprint || @definition_fingerprint,
           node_paths: definition.graph.topological_sort.map { |name| execution.node_path + [name] }
         )
+      end
+
+      def resolve_sub_workflow_definition(step)
+        definition = step.config[:definition]
+        definition_path = step.config[:definition_path]
+
+        if definition.is_a?(Definition) && blank?(definition_path)
+          return Success.new(value: definition)
+        end
+
+        if definition.nil? && !blank?(definition_path)
+          return Success.new(value: Loader.from_file(resolve_sub_workflow_path(definition_path)))
+        end
+
+        Failure.new(error: {
+          code: :sub_workflow_invalid_definition,
+          message: "sub_workflow step #{step.name} must define exactly one of definition or definition_path"
+        })
+      rescue ArgumentError, ValidationError => e
+        Failure.new(error: {
+          code: :sub_workflow_invalid_definition,
+          message: e.message
+        })
+      end
+
+      def resolve_sub_workflow_path(definition_path)
+        return definition_path if Pathname.new(definition_path).absolute?
+
+        base_dir = @definition_source_path && File.dirname(@definition_source_path)
+        File.expand_path(definition_path, base_dir || Dir.pwd)
       end
 
       def remaining_timeout_for(deadline)
@@ -484,6 +509,10 @@ module DAG
         return path.first if path.length == 1
 
         path.join(".").to_sym
+      end
+
+      def blank?(value)
+        value.nil? || (value.respond_to?(:empty?) && value.empty?)
       end
 
       def normalize_initial_outputs(initial_outputs)

--- a/lib/dag/workflow/steps.rb
+++ b/lib/dag/workflow/steps.rb
@@ -56,7 +56,7 @@ module DAG
       register(:file_read, FileRead, yaml_safe: true)
       register(:file_write, FileWrite, yaml_safe: true)
       register(:ruby, Ruby, yaml_safe: false)
-      register(:sub_workflow, SubWorkflow, yaml_safe: false)
+      register(:sub_workflow, SubWorkflow, yaml_safe: true)
     end
   end
 end

--- a/lib/dag/workflow/validator.rb
+++ b/lib/dag/workflow/validator.rb
@@ -17,7 +17,9 @@ module DAG
         graph.each_node do |node|
           next unless registry.key?(node)
 
-          errors.concat(Condition.validate(registry[node].config[:run_if], node_name: node, graph: graph))
+          step = registry[node]
+          errors.concat(Condition.validate(step.config[:run_if], node_name: node, graph: graph))
+          errors.concat(validate_sub_workflow(step, node_name: node)) if step.type == :sub_workflow
         end
 
         ValidationReport.new(errors: errors)
@@ -28,6 +30,26 @@ module DAG
         raise ValidationError, report.errors unless report.valid?
 
         [graph, registry]
+      end
+
+      def self.validate_sub_workflow(step, node_name:)
+        has_definition = step.config[:definition].is_a?(Definition)
+        has_definition_path = !blank?(step.config[:definition_path])
+        errors = []
+
+        unless has_definition ^ has_definition_path
+          errors << "Node '#{node_name}' type 'sub_workflow' must define exactly one of definition or definition_path"
+        end
+
+        if step.config.key?(:definition_path) && !step.config[:definition_path].is_a?(String)
+          errors << "Node '#{node_name}' definition_path must be a String"
+        end
+
+        errors
+      end
+
+      def self.blank?(value)
+        value.nil? || (value.respond_to?(:empty?) && value.empty?)
       end
     end
   end

--- a/spec/dumper_test.rb
+++ b/spec/dumper_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "tmpdir"
 
 class DumperTest < Minitest::Test
   include TestHelpers
@@ -203,6 +204,42 @@ class DumperTest < Minitest::Test
     defn2 = DAG::Workflow::Loader.from_yaml(dumped)
 
     assert_equal :strict, defn2.step(:task).config[:mode]
+  end
+
+  def test_round_trip_sub_workflow_with_definition_path_via_file
+    Dir.mktmpdir("dag-dumper-subworkflow") do |dir|
+      child_path = File.join(dir, "child.yml")
+      parent_path = File.join(dir, "parent.yml")
+
+      File.write(child_path, <<~YAML)
+        nodes:
+          summarize:
+            type: exec
+            command: "printf dumped-child"
+      YAML
+
+      graph = DAG::Graph.new.add_node(:process)
+      registry = DAG::Workflow::Registry.new
+      registry.register(DAG::Workflow::Step.new(name: :process, type: :sub_workflow,
+        definition_path: "child.yml", output_key: :summarize))
+      defn = DAG::Workflow::Definition.new(graph: graph, registry: registry, source_path: parent_path)
+
+      DAG::Workflow::Dumper.to_file(defn, parent_path)
+      loaded = DAG::Workflow::Loader.from_file(parent_path)
+      result = DAG::Workflow::Runner.new(loaded, parallel: false).call
+
+      assert result.success?
+      assert_equal "child.yml", loaded.step(:process).config[:definition_path]
+      assert_equal "dumped-child", result.outputs[:process].value
+    end
+  end
+
+  def test_raises_on_programmatic_sub_workflow_definition
+    child = build_test_workflow(done: {type: :exec, command: "printf ok"})
+    defn = build_test_workflow(process: {type: :sub_workflow, definition: child, output_key: :done})
+
+    error = assert_raises(DAG::SerializationError) { DAG::Workflow::Dumper.to_yaml(defn) }
+    assert_match(/definition_path/, error.message)
   end
 
   def test_empty_workflow

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -48,9 +48,12 @@ class ExamplesTest < Minitest::Test
       #{stderr}
     MSG
 
-    assert_includes stdout, "=== Parent Workflow ==="
-    assert_includes stdout, "=== Durable Run ==="
+    assert_includes stdout, "=== Programmatic Parent Workflow ==="
+    assert_includes stdout, "=== Durable Programmatic Run ==="
     assert_includes stdout, "Child calls: 1"
+    assert_includes stdout, "=== YAML Parent Workflow ==="
+    assert_includes stdout, "=== Durable YAML Run ==="
+    assert_includes stdout, "Stored YAML child output: yaml-grandchild"
   end
 
   private

--- a/spec/sub_workflow_test.rb
+++ b/spec/sub_workflow_test.rb
@@ -1,9 +1,108 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "fileutils"
+require "tmpdir"
 
 class SubWorkflowTest < Minitest::Test
   include TestHelpers
+
+  def test_yaml_sub_workflow_definition_path_executes_child_workflow_from_parent_file
+    Dir.mktmpdir("dag-subworkflow") do |dir|
+      child_path = File.join(dir, "child.yml")
+      File.write(child_path, <<~YAML)
+        nodes:
+          summarize:
+            type: exec
+            command: "printf yaml-child"
+      YAML
+
+      parent_path = File.join(dir, "parent.yml")
+      File.write(parent_path, <<~YAML)
+        nodes:
+          process:
+            type: sub_workflow
+            definition_path: child.yml
+            output_key: summarize
+      YAML
+
+      definition = DAG::Workflow::Loader.from_file(parent_path)
+      result = DAG::Workflow::Runner.new(definition, parallel: false).call
+
+      assert result.success?
+      assert_equal "yaml-child", result.outputs[:process].value
+      assert_includes result.trace.map(&:name), :"process.summarize"
+    end
+  end
+
+  def test_nested_definition_paths_resolve_relative_to_each_caller_file
+    Dir.mktmpdir("dag-subworkflow-nested") do |dir|
+      workflows_dir = File.join(dir, "workflows")
+      nested_dir = File.join(workflows_dir, "nested")
+      FileUtils.mkdir_p(nested_dir)
+
+      File.write(File.join(nested_dir, "grandchild.yml"), <<~YAML)
+        nodes:
+          summarize:
+            type: exec
+            command: "printf nested-child"
+      YAML
+
+      File.write(File.join(workflows_dir, "child.yml"), <<~YAML)
+        nodes:
+          nested:
+            type: sub_workflow
+            definition_path: nested/grandchild.yml
+            output_key: summarize
+      YAML
+
+      parent_path = File.join(dir, "parent.yml")
+      File.write(parent_path, <<~YAML)
+        nodes:
+          process:
+            type: sub_workflow
+            definition_path: workflows/child.yml
+            output_key: nested
+      YAML
+
+      definition = DAG::Workflow::Loader.from_file(parent_path)
+      result = DAG::Workflow::Runner.new(definition, parallel: false).call
+
+      assert result.success?
+      assert_equal "nested-child", result.outputs[:process].value
+      assert_includes result.trace.map(&:name), :"process.nested.summarize"
+    end
+  end
+
+  def test_sub_workflow_requires_exactly_one_definition_source
+    error = assert_raises(DAG::ValidationError) do
+      DAG::Workflow::Loader.from_hash(
+        process: {
+          type: :sub_workflow,
+          output_key: :done
+        }
+      )
+    end
+
+    assert_match(/exactly one/, error.message)
+  end
+
+  def test_sub_workflow_rejects_both_definition_and_definition_path
+    child = DAG::Workflow::Loader.from_hash(done: {type: :exec, command: "printf ok"})
+
+    error = assert_raises(DAG::ValidationError) do
+      DAG::Workflow::Loader.from_hash(
+        process: {
+          type: :sub_workflow,
+          definition: child,
+          definition_path: "child.yml",
+          output_key: :done
+        }
+      )
+    end
+
+    assert_match(/exactly one/, error.message)
+  end
 
   def test_programmatic_sub_workflow_returns_child_leaf_outputs_and_namespaced_trace
     child = DAG::Workflow::Loader.from_hash(
@@ -155,5 +254,47 @@ class SubWorkflowTest < Minitest::Test
     assert_equal 1, child_calls
     assert_includes run[:node_paths], [:process, :inner_fetch]
     assert_equal "hello!", store.load_output(workflow_id: "wf-sub", node_path: [:process, :inner_fetch])[:result].value
+  end
+
+  def test_definition_path_supports_durable_execution_fingerprints_and_child_namespaces
+    Dir.mktmpdir("dag-subworkflow-store") do |dir|
+      File.write(File.join(dir, "child.yml"), <<~YAML)
+        nodes:
+          summarize:
+            type: exec
+            command: "printf stored-child"
+      YAML
+
+      parent_path = File.join(dir, "parent.yml")
+      File.write(parent_path, <<~YAML)
+        nodes:
+          process:
+            type: sub_workflow
+            definition_path: child.yml
+            output_key: summarize
+            resume_key: process-v1
+      YAML
+
+      definition = DAG::Workflow::Loader.from_file(parent_path)
+      store = DAG::Workflow::ExecutionStore::MemoryStore.new
+
+      runner = lambda do
+        DAG::Workflow::Runner.new(definition,
+          parallel: false,
+          workflow_id: "wf-yaml-sub",
+          execution_store: store)
+      end
+
+      first = runner.call.call
+      second = runner.call.call
+      run = store.load_run("wf-yaml-sub")
+
+      assert first.success?
+      assert second.success?
+      assert_equal "stored-child", first.outputs[:process].value
+      assert_equal "stored-child", second.outputs[:process].value
+      assert_includes run[:node_paths], [:process, :summarize]
+      assert_equal "stored-child", store.load_output(workflow_id: "wf-yaml-sub", node_path: [:process, :summarize])[:result].value
+    end
   end
 end


### PR DESCRIPTION
## Summary
- allow YAML-safe :sub_workflow steps via definition_path and resolve child paths relative to the caller file
- validate that sub-workflows declare exactly one of definition or definition_path and extend durable fingerprinting to nested YAML children
- add dumper support for YAML-safe sub-workflows plus docs and runnable examples for nested YAML composition

## Testing
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/sub_workflow_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/dumper_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/examples_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/sub_workflow.rb
- TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/workflow_runner.rb
- TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/checkpoint_resume.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake
- TMPDIR=$HOME/.tmp/ruby-dag ruby script/soak.rb --all --short

Closes #25
