### PR TITLE
feat: add pause and resume layer gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,38 @@ Notes:
 - changing the workflow fingerprint for an existing `workflow_id` raises `DAG::ValidationError` before any step runs
 - see `examples/checkpoint_resume.rb` for a runnable end-to-end example that is exercised in the test suite
 
+### Pause and resume
+
+Pause is coordinator-driven through the execution store. The runner checks the
+pause flag between layers, never in the middle of a running layer.
+
+```ruby
+store = DAG::Workflow::ExecutionStore::MemoryStore.new
+
+first = DAG::Workflow::Runner.new(definition,
+  parallel: false,
+  workflow_id: "demo-pause",
+  execution_store: store,
+  on_step_finish: lambda do |name, _result|
+    store.set_pause_flag(workflow_id: "demo-pause", paused: true) if name == :fetch
+  end).call
+
+store.set_pause_flag(workflow_id: "demo-pause", paused: false)
+second = DAG::Workflow::Runner.new(definition,
+  parallel: false,
+  workflow_id: "demo-pause",
+  execution_store: store).call
+
+puts first.status   # => :paused
+puts second.status  # => :completed
+```
+
+Notes:
+- pause is observed before the next layer starts
+- completed reusable outputs are reused after resume
+- paused runs persist `workflow_status: :paused` in the execution store
+- see `examples/pause_resume.rb` for a runnable end-to-end example exercised in the test suite
+
 ### Sub-workflow composition
 
 A step can run a nested workflow with type `:sub_workflow`. The child can come

--- a/examples/pause_resume.rb
+++ b/examples/pause_resume.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Pause/resume is coordinator-driven: set a durable pause flag in the execution
+# store, let the runner stop cleanly between layers, then clear the flag and run
+# the same workflow_id again.
+#
+# Run: ruby -Ilib examples/pause_resume.rb
+
+require "dag"
+
+store = DAG::Workflow::ExecutionStore::MemoryStore.new
+fetch_calls = 0
+transform_calls = 0
+
+workflow = DAG::Workflow::Loader.from_hash(
+  fetch: {
+    type: :ruby,
+    resume_key: "fetch-v1",
+    callable: ->(_input) do
+      fetch_calls += 1
+      DAG::Success.new(value: "payload")
+    end
+  },
+  transform: {
+    type: :ruby,
+    depends_on: [:fetch],
+    resume_key: "transform-v1",
+    callable: ->(input) do
+      transform_calls += 1
+      DAG::Success.new(value: input[:fetch].upcase)
+    end
+  }
+)
+
+first = DAG::Workflow::Runner.new(workflow,
+  parallel: false,
+  workflow_id: "example-pause-resume",
+  execution_store: store,
+  on_step_finish: lambda do |name, _result|
+    store.set_pause_flag(workflow_id: "example-pause-resume", paused: true) if name == :fetch
+  end).call
+
+puts "=== First Run (pause requested) ==="
+puts "Status: #{first.status}"
+puts "Outputs so far: #{first.outputs.transform_values(&:value)}"
+puts "Stored workflow status: #{store.load_run("example-pause-resume")[:workflow_status]}"
+puts
+
+store.set_pause_flag(workflow_id: "example-pause-resume", paused: false)
+
+second = DAG::Workflow::Runner.new(workflow,
+  parallel: false,
+  workflow_id: "example-pause-resume",
+  execution_store: store).call
+
+puts "=== Second Run (resume) ==="
+puts "Status: #{second.status}"
+puts "Outputs: #{second.outputs.transform_values(&:value)}"
+puts "Fetch calls: #{fetch_calls}"
+puts "Transform calls: #{transform_calls}"

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -135,6 +135,7 @@ module DAG
         trace = []
         failed_name = nil
         failed_result = nil
+        paused = false
 
         layers.each_with_index do |layer, layer_index|
           break if failed_name
@@ -149,6 +150,11 @@ module DAG
             break
           end
 
+          if pause_requested?
+            paused = true
+            break
+          end
+
           execute_layer(layer, layer_index, outputs, statuses, trace, deadline).each do |name, result|
             outputs[name] = result
             if result.failure? && failed_name.nil?
@@ -158,8 +164,16 @@ module DAG
           end
         end
 
+        status = if failed_name
+          :failed
+        elsif paused
+          :paused
+        else
+          :completed
+        end
+
         build_run_result(outputs, trace,
-          failed_name ? :failed : :completed,
+          status,
           failed_name ? {failed_node: failed_name, step_error: failed_result.error} : nil)
       end
 
@@ -509,6 +523,10 @@ module DAG
         return path.first if path.length == 1
 
         path.join(".").to_sym
+      end
+
+      def pause_requested?
+        @execution_store && @workflow_id && @execution_store.load_run(@workflow_id)&.fetch(:paused, false)
       end
 
       def blank?(value)

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -56,6 +56,23 @@ class ExamplesTest < Minitest::Test
     assert_includes stdout, "Stored YAML child output: yaml-grandchild"
   end
 
+  def test_pause_resume_example_executes_successfully
+    stdout, stderr, status = run_example("examples/pause_resume.rb")
+
+    assert status.success?, <<~MSG
+      expected pause_resume example to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "=== First Run (pause requested) ==="
+    assert_includes stdout, "Status: paused"
+    assert_includes stdout, "=== Second Run (resume) ==="
+    assert_includes stdout, "Fetch calls: 1"
+  end
+
   private
 
   def run_example(path)

--- a/spec/pause_resume_test.rb
+++ b/spec/pause_resume_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class PauseResumeTest < Minitest::Test
+  include TestHelpers
+
+  def test_pause_flag_stops_before_next_layer_and_persists_paused_status
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    definition = DAG::Workflow::Loader.from_hash(
+      fetch: {
+        type: :ruby,
+        resume_key: "fetch-v1",
+        callable: ->(_input) { DAG::Success.new(value: "fetched") }
+      },
+      transform: {
+        type: :ruby,
+        depends_on: [:fetch],
+        resume_key: "transform-v1",
+        callable: ->(input) { DAG::Success.new(value: input[:fetch].upcase) }
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      workflow_id: "wf-pause",
+      execution_store: store,
+      on_step_finish: lambda do |name, _result|
+        store.set_pause_flag(workflow_id: "wf-pause", paused: true) if name == :fetch
+      end).call
+
+    assert_equal :paused, result.status
+    assert result.paused?
+    assert_equal "fetched", result.outputs[:fetch].value
+    refute result.outputs.key?(:transform)
+    assert_equal :paused, store.load_run("wf-pause")[:workflow_status]
+  end
+
+  def test_pause_flag_is_observed_between_layers_not_mid_layer
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    definition = DAG::Workflow::Loader.from_hash(
+      a: {
+        type: :ruby,
+        resume_key: "a-v1",
+        callable: ->(_input) { DAG::Success.new(value: "A") }
+      },
+      b: {
+        type: :ruby,
+        resume_key: "b-v1",
+        callable: ->(_input) { DAG::Success.new(value: "B") }
+      },
+      c: {
+        type: :ruby,
+        depends_on: [:a, :b],
+        resume_key: "c-v1",
+        callable: ->(input) { DAG::Success.new(value: input.values.join("+")) }
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      workflow_id: "wf-pause-layer",
+      execution_store: store,
+      on_step_finish: lambda do |name, _result|
+        store.set_pause_flag(workflow_id: "wf-pause-layer", paused: true) if name == :a
+      end).call
+
+    assert_equal :paused, result.status
+    assert_equal "A", result.outputs[:a].value
+    assert_equal "B", result.outputs[:b].value
+    refute result.outputs.key?(:c)
+  end
+
+  def test_resume_after_clearing_pause_flag_reuses_completed_outputs
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    fetch_calls = 0
+    transform_calls = 0
+    definition = DAG::Workflow::Loader.from_hash(
+      fetch: {
+        type: :ruby,
+        resume_key: "fetch-v1",
+        callable: ->(_input) do
+          fetch_calls += 1
+          DAG::Success.new(value: "payload")
+        end
+      },
+      transform: {
+        type: :ruby,
+        depends_on: [:fetch],
+        resume_key: "transform-v1",
+        callable: ->(input) do
+          transform_calls += 1
+          DAG::Success.new(value: input[:fetch].upcase)
+        end
+      }
+    )
+
+    paused = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      workflow_id: "wf-resume",
+      execution_store: store,
+      on_step_finish: lambda do |name, _result|
+        store.set_pause_flag(workflow_id: "wf-resume", paused: true) if name == :fetch
+      end).call
+
+    store.set_pause_flag(workflow_id: "wf-resume", paused: false)
+    resumed = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      workflow_id: "wf-resume",
+      execution_store: store).call
+
+    assert_equal :paused, paused.status
+    assert_equal :completed, resumed.status
+    assert_equal "PAYLOAD", resumed.outputs[:transform].value
+    assert_equal 1, fetch_calls
+    assert_equal 1, transform_calls
+  end
+end


### PR DESCRIPTION
## Summary
- add a first pause/resume slice that observes a persisted pause flag between layers only
- return RunResult(status: :paused), persist workflow_status :paused, and resume from reusable outputs after clearing the flag
- document the behavior and add a runnable pause/resume example exercised by the example test suite

## Testing
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/pause_resume_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/examples_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/pause_resume.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake

Closes #27
