### PR TITLE
feat: add waiting runs for not_before gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,40 @@ Notes:
 - changing the workflow fingerprint for an existing `workflow_id` raises `DAG::ValidationError` before any step runs
 - see `examples/checkpoint_resume.rb` for a runnable end-to-end example that is exercised in the test suite
 
+### Waiting and not_before scheduling
+
+Scheduling is eligibility-based. The runner does not sleep: if a node has a
+future `schedule[:not_before]`, it becomes waiting and the run returns
+`status: :waiting` once no runnable work remains.
+
+```ruby
+clock = Struct.new(:wall_time, :mono_time) do
+  def wall_now = wall_time
+  def monotonic_now = mono_time
+  def advance(seconds) = self.wall_time += seconds
+end.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+
+store = DAG::Workflow::ExecutionStore::MemoryStore.new
+result = DAG::Workflow::Runner.new(definition,
+  parallel: false,
+  clock: clock,
+  workflow_id: "demo-waiting",
+  execution_store: store).call
+
+clock.advance(3600)
+result = DAG::Workflow::Runner.new(definition,
+  parallel: false,
+  clock: clock,
+  workflow_id: "demo-waiting",
+  execution_store: store).call
+```
+
+Notes:
+- `schedule[:not_before]` uses `clock.wall_now`
+- waiting nodes do not emit `Success(nil)` outputs
+- waiting runs persist `workflow_status: :waiting` plus `waiting_nodes` in the execution store
+- see `examples/waiting_not_before.rb` for a runnable example exercised in the test suite
+
 ### Pause and resume
 
 Pause is coordinator-driven through the execution store. The runner checks the

--- a/examples/waiting_not_before.rb
+++ b/examples/waiting_not_before.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Waiting/not_before scheduling: the runner does not sleep. It returns a
+# waiting RunResult until the injected clock reaches the node's not_before time.
+#
+# Run: ruby -Ilib examples/waiting_not_before.rb
+
+require "dag"
+
+clock = Struct.new(:wall_time, :mono_time) do
+  def wall_now = wall_time
+  def monotonic_now = mono_time
+  def advance(seconds) = self.wall_time += seconds
+end.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+
+store = DAG::Workflow::ExecutionStore::MemoryStore.new
+workflow = DAG::Workflow::Loader.from_hash(
+  fetch: {
+    type: :ruby,
+    resume_key: "fetch-v1",
+    callable: ->(_input) { DAG::Success.new(value: "ready") }
+  },
+  scheduled: {
+    type: :ruby,
+    depends_on: [:fetch],
+    resume_key: "scheduled-v1",
+    schedule: {not_before: Time.utc(2026, 4, 15, 10, 0, 0)},
+    callable: ->(input) { DAG::Success.new(value: input[:fetch].upcase) }
+  }
+)
+
+first = DAG::Workflow::Runner.new(workflow,
+  parallel: false,
+  clock: clock,
+  workflow_id: "example-waiting",
+  execution_store: store).call
+
+puts "=== First Run (waiting) ==="
+puts "Status: #{first.status}"
+puts "Waiting nodes: #{first.waiting_nodes.inspect}"
+puts "Outputs so far: #{first.outputs.transform_values(&:value)}"
+puts
+
+clock.advance(3600)
+
+second = DAG::Workflow::Runner.new(workflow,
+  parallel: false,
+  clock: clock,
+  workflow_id: "example-waiting",
+  execution_store: store).call
+
+puts "=== Second Run (ready) ==="
+puts "Status: #{second.status}"
+puts "Outputs: #{second.outputs.transform_values(&:value)}"

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "etc"
+require "time"
 
 module DAG
   module Workflow
@@ -136,6 +137,7 @@ module DAG
         failed_name = nil
         failed_result = nil
         paused = false
+        waiting_nodes = []
 
         layers.each_with_index do |layer, layer_index|
           break if failed_name
@@ -155,34 +157,42 @@ module DAG
             break
           end
 
-          execute_layer(layer, layer_index, outputs, statuses, trace, deadline).each do |name, result|
+          layer_results, layer_waiting_nodes = execute_layer(layer, layer_index, outputs, statuses, trace, deadline)
+          waiting_nodes.concat(layer_waiting_nodes)
+
+          layer_results.each do |name, result|
             outputs[name] = result
             if result.failure? && failed_name.nil?
               failed_name = name
               failed_result = result
             end
           end
+
+          break if layer_waiting_nodes.any? && !failed_name
         end
 
         status = if failed_name
           :failed
         elsif paused
           :paused
+        elsif waiting_nodes.any?
+          :waiting
         else
           :completed
         end
 
         build_run_result(outputs, trace,
           status,
-          failed_name ? {failed_node: failed_name, step_error: failed_result.error} : nil)
+          failed_name ? {failed_node: failed_name, step_error: failed_result.error} : nil,
+          waiting_nodes)
       end
 
       def deadline_passed?(deadline)
         deadline && @clock.monotonic_now >= deadline
       end
 
-      def build_run_result(outputs, trace, status, error)
-        @execution_store&.set_workflow_status(workflow_id: @workflow_id, status: status, waiting_nodes: [])
+      def build_run_result(outputs, trace, status, error, waiting_nodes)
+        @execution_store&.set_workflow_status(workflow_id: @workflow_id, status: status, waiting_nodes: waiting_nodes)
 
         RunResult.new(
           status: status,
@@ -190,7 +200,7 @@ module DAG
           outputs: outputs,
           trace: trace,
           error: error,
-          waiting_nodes: []
+          waiting_nodes: waiting_nodes
         )
       end
 
@@ -202,19 +212,20 @@ module DAG
       # consumer querying strategy identity from inside :start sees the
       # one actually running.
       def execute_layer(layer, layer_index, previous_outputs, statuses, trace, deadline)
-        runnable, immediate_results = partition_layer(layer, previous_outputs, statuses, deadline)
+        runnable, immediate_results, waiting_nodes = partition_layer(layer, previous_outputs, statuses, deadline)
         results = {}
 
         runnable.each { |t| @callbacks.start(t.name, t.step) }
         record_immediate_results(immediate_results, results, statuses, layer_index, trace)
         run_tasks(runnable, layer_index, trace, results, statuses)
 
-        results
+        [results, waiting_nodes]
       end
 
       def partition_layer(layer, previous_outputs, statuses, deadline)
         runnable = []
         immediate_results = []
+        waiting_nodes = []
 
         layer.each do |name|
           step = @registry[name]
@@ -223,7 +234,10 @@ module DAG
           input_keys = input.keys.sort
 
           begin
-            if skip?(step, condition_context)
+            if waiting_for_schedule?(step)
+              waiting_nodes << node_path_for(name)
+              persist_waiting_node(name)
+            elsif skip?(step, condition_context)
               immediate_results << [name, record_skip_result, input_keys, :skipped]
             elsif (reused_result = load_reusable_result(name))
               immediate_results << [name, reused_result, input_keys, :success]
@@ -246,7 +260,7 @@ module DAG
           end
         end
 
-        [runnable, immediate_results]
+        [runnable, immediate_results, waiting_nodes]
       end
 
       # Short-circuits on an empty task list (a layer in which every step
@@ -527,6 +541,34 @@ module DAG
 
       def pause_requested?
         @execution_store && @workflow_id && @execution_store.load_run(@workflow_id)&.fetch(:paused, false)
+      end
+
+      def waiting_for_schedule?(step)
+        not_before = normalized_not_before(step)
+        not_before && @clock.wall_now < not_before
+      end
+
+      def normalized_not_before(step)
+        raw = step.config.dig(:schedule, :not_before)
+        case raw
+        when nil
+          nil
+        when Time
+          raw
+        else
+          Time.parse(raw.to_s)
+        end
+      end
+
+      def persist_waiting_node(name)
+        return unless @execution_store && @workflow_id
+
+        @execution_store.set_node_state(
+          workflow_id: @workflow_id,
+          node_path: node_path_for(name),
+          state: :waiting,
+          metadata: {}
+        )
       end
 
       def blank?(value)

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -73,6 +73,23 @@ class ExamplesTest < Minitest::Test
     assert_includes stdout, "Fetch calls: 1"
   end
 
+  def test_waiting_not_before_example_executes_successfully
+    stdout, stderr, status = run_example("examples/waiting_not_before.rb")
+
+    assert status.success?, <<~MSG
+      expected waiting_not_before example to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "=== First Run (waiting) ==="
+    assert_includes stdout, "Status: waiting"
+    assert_includes stdout, "=== Second Run (ready) ==="
+    assert_includes stdout, "Outputs: {fetch: \"ready\", scheduled: \"READY\"}"
+  end
+
   private
 
   def run_example(path)

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -87,7 +87,9 @@ class ExamplesTest < Minitest::Test
     assert_includes stdout, "=== First Run (waiting) ==="
     assert_includes stdout, "Status: waiting"
     assert_includes stdout, "=== Second Run (ready) ==="
-    assert_includes stdout, "Outputs: {fetch: \"ready\", scheduled: \"READY\"}"
+    assert_includes stdout, "Status: completed"
+    assert_includes stdout, "ready"
+    assert_includes stdout, "READY"
   end
 
   private

--- a/spec/scheduling_test.rb
+++ b/spec/scheduling_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class SchedulingTest < Minitest::Test
+  include TestHelpers
+
+  FakeClock = Struct.new(:wall_time, :mono_time) do
+    def wall_now = wall_time
+    def monotonic_now = mono_time
+    def advance_wall(seconds) = self.wall_time += seconds
+  end
+
+  def test_not_before_returns_waiting_status_and_waiting_nodes
+    clock = FakeClock.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+    future_time = Time.utc(2026, 4, 15, 10, 0, 0)
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+
+    definition = DAG::Workflow::Loader.from_hash(
+      scheduled: {
+        type: :ruby,
+        resume_key: "scheduled-v1",
+        schedule: {not_before: future_time},
+        callable: ->(_input) { DAG::Success.new(value: "done") }
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      clock: clock,
+      workflow_id: "wf-waiting",
+      execution_store: store).call
+
+    assert_equal :waiting, result.status
+    assert result.waiting?
+    assert_equal [[:scheduled]], result.waiting_nodes
+    refute result.outputs.key?(:scheduled)
+
+    run = store.load_run("wf-waiting")
+    assert_equal :waiting, run[:workflow_status]
+    assert_equal [[:scheduled]], run[:waiting_nodes]
+  end
+
+  def test_not_before_does_not_block_other_runnable_layers
+    clock = FakeClock.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+    future_time = Time.utc(2026, 4, 15, 10, 0, 0)
+
+    definition = DAG::Workflow::Loader.from_hash(
+      fetch: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "ready") }
+      },
+      scheduled: {
+        type: :ruby,
+        depends_on: [:fetch],
+        schedule: {not_before: future_time},
+        callable: ->(input) { DAG::Success.new(value: input[:fetch].upcase) }
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(definition, parallel: false, clock: clock).call
+
+    assert_equal :waiting, result.status
+    assert_equal "ready", result.outputs[:fetch].value
+    refute result.outputs.key?(:scheduled)
+    assert_equal [[:scheduled]], result.waiting_nodes
+  end
+
+  def test_not_before_run_completes_after_clock_advances_past_gate
+    clock = FakeClock.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+    future_time = Time.utc(2026, 4, 15, 10, 0, 0)
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    calls = 0
+
+    definition = DAG::Workflow::Loader.from_hash(
+      scheduled: {
+        type: :ruby,
+        resume_key: "scheduled-v1",
+        schedule: {not_before: future_time},
+        callable: ->(_input) do
+          calls += 1
+          DAG::Success.new(value: "done")
+        end
+      }
+    )
+
+    first = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      clock: clock,
+      workflow_id: "wf-waiting-resume",
+      execution_store: store).call
+
+    clock.advance_wall(3600)
+
+    second = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      clock: clock,
+      workflow_id: "wf-waiting-resume",
+      execution_store: store).call
+
+    assert_equal :waiting, first.status
+    assert_equal :completed, second.status
+    assert_equal "done", second.outputs[:scheduled].value
+    assert_equal 1, calls
+  end
+end


### PR DESCRIPTION
## Summary
- add a first waiting slice for schedule.not_before that returns RunResult(status: :waiting) with waiting_nodes
- persist waiting workflow status and waiting node state in the execution store and resume cleanly once the clock passes the gate
- document the behavior and add a runnable waiting_not_before example exercised by the example test suite

## Atomic commits
- `feat: return waiting runs for not_before gates`
- `docs: add runnable waiting not_before example`

## Testing
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/scheduling_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/runner_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/run_result_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/examples_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/waiting_not_before.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake

Closes #29
