### PR TITLE
[codex] Fix workflow runtime invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ end
 
 - `result.status` — `:completed`, `:failed`, `:waiting`, or `:paused`
 - `result.success?` / `result.failure?`
-- `result.outputs` — completed step results keyed by node name
+- `result.outputs` — completed or intentionally skipped step results keyed by node name
 - `result.trace` — append-only attempt trace
 - `result.error` — `nil` on success, `{failed_node:, step_error:}` on failure
 - `result.workflow_id` — `nil` for in-memory runs unless you set one explicitly
@@ -262,6 +262,7 @@ result = DAG::Workflow::Runner.new(definition,
 Notes:
 - `schedule[:not_before]` uses `clock.wall_now`
 - waiting nodes do not emit `Success(nil)` outputs
+- waiting nodes do not block independent branches that are still runnable later in the same invocation
 - waiting runs persist `workflow_status: :waiting` plus `waiting_nodes` in the execution store
 - see `examples/waiting_not_before.rb` for a runnable example exercised in the test suite
 
@@ -360,6 +361,7 @@ Notes:
 - `:sub_workflow` must declare exactly one of `definition:` or `definition_path:`
 - child trace entries are flattened into the parent trace with names like `:"process.summarize"`
 - default sub-workflow output is a hash of child leaf values; `output_key:` selects one leaf
+- if the child run returns `:waiting` or `:paused`, the parent run propagates that workflow status and the parent step does not emit an output
 - durable child outputs are stored under the parent node path, e.g. `[:process, :summarize]`
 - the dumper emits YAML-safe sub-workflows when they use `definition_path:` and rejects programmatic `definition:` children
 - see `examples/sub_workflow.rb` and `examples/sub_workflow_parent.yml` for runnable examples exercised in the test suite

--- a/README.md
+++ b/README.md
@@ -679,7 +679,8 @@ Step inputs are **always** hashes keyed by dependency step name (e.g., `{ fetch:
 
 - Step inputs are always hashes keyed by dependency step name. Zero-dependency steps receive `{}`.
 - Step output constraints depend on which Strategy you pick (see [Step result constraints by strategy](#step-result-constraints-by-strategy)). Default `:threads` has none; `:processes` requires Marshal-able results.
-- Callback ordering is per-step but not globally deterministic across nodes in the same parallel layer. `on_step_start` fires when the runner submits a step to the strategy (before actual execution begins); `on_step_finish` fires when the strategy yields back the completed result.
+- Callback ordering is per-step but not globally deterministic across nodes in the same parallel layer. `on_step_start` fires when the runner submits a step to the strategy (before actual execution begins); every started step gets a matching `on_step_finish`.
+- For parent `:sub_workflow` steps that propagate child `:waiting` or `:paused`, `on_step_finish` receives `Success(nil)`. This is observational only: the parent step still emits no parent output and no parent trace entry for that invocation.
 - On first step failure the workflow halts. Already-completed outputs from earlier layers (and from sibling steps in the same layer that finished before the failure was observed) are still returned.
 - The runner returns `DAG::Workflow::RunResult`, so outputs and trace always live directly on `result.outputs` and `result.trace`. Failure details, when present, live in `result.error` as `{failed_node:, step_error:}`.
 - Trace entries are `TraceEntry` records with `:name`, `:layer`, `:started_at`, `:finished_at`, `:duration_ms`, `:status` (`:success`, `:failure`, or `:skipped`), `:input_keys`, `:attempt`, and `:retried`. Skipped steps record `nil` timestamps and `0` duration.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -326,7 +326,7 @@ milestone, not Feature 0.
 - Time-based tests can run against a fake clock without real sleeping.
 - Trace and node-path invariants hold across retries and nested sub-workflows.
 
-**Status:** `not-started` | **Complexity:** large
+**Status:** `partial` | **Complexity:** large
 
 ---
 
@@ -382,7 +382,7 @@ runner = Runner.new(definition, middleware: [DAG::Workflow::RetryMiddleware.new]
 - With `max_parallelism: 1`, a step in backoff prevents another runnable step
   from starting until that retry chain completes or fails.
 
-**Status:** `not-started` | **Priority:** high
+**Status:** `implemented` | **Priority:** high
 
 ---
 
@@ -443,7 +443,7 @@ Minimum `FileStore` guarantees in v1:
 - Expired reusable output is ignored.
 - Two runs with the same `workflow_id` but different graph structure do not silently share checkpoints.
 
-**Status:** `not-started` | **Priority:** high
+**Status:** `partial` | **Priority:** high
 
 ---
 
@@ -518,7 +518,7 @@ nodes:
 - Child persistence uses the same logical `workflow_id` as the parent run.
 - Inline `definition:` is rejected by YAML dumper.
 
-**Status:** `not-started` | **Priority:** high
+**Status:** `partial` | **Priority:** high
 
 ---
 
@@ -560,7 +560,7 @@ end
   present and no explicit context-serialization strategy exists.
 - Built-in steps that do not accept context still run unchanged.
 
-**Status:** `not-started` | **Priority:** high
+**Status:** `implemented` | **Priority:** high
 
 ---
 
@@ -606,7 +606,7 @@ runner = Runner.new(definition, clock: my_clock)
 - `cron` metadata round-trips through Loader/Dumper for YAML-safe step types.
 - Scheduling tests can run against a fake clock without real sleeping.
 
-**Status:** `not-started` | **Priority:** medium
+**Status:** `partial` | **Priority:** medium
 
 ---
 
@@ -933,7 +933,7 @@ result = Runner.new(definition,
 - Resume does not rerun completed nodes.
 - A paused workflow can later move to `:completed`, `:failed`, or `:waiting`.
 
-**Status:** `not-started` | **Priority:** medium
+**Status:** `implemented` | **Priority:** medium
 
 ---
 
@@ -992,7 +992,7 @@ runner = Runner.new(definition,
 - Short-circuit middleware still produces valid trace/state transitions.
 - Non-`DAG::Result` middleware returns are treated as contract violations.
 
-**Status:** `not-started` | **Priority:** medium
+**Status:** `implemented` | **Priority:** medium
 
 ---
 
@@ -1004,24 +1004,24 @@ The feature table below assumes Milestone 0 has landed first.
 
 | Milestone | Scope | Status | Complexity |
 |-----------|-------|--------|------------|
-| 0 | `RunResult`, `ExecutionStore`, fingerprinting, `Clock`, middleware handoff | `not-started` | large |
+| 0 | `RunResult`, `ExecutionStore`, fingerprinting, `Clock`, middleware handoff | `partial` | large |
 
 ### Feature summary
 
 | # | Feature | Priority | Status | Complexity |
 |---|---------|----------|--------|------------|
-| 1 | Step retry with backoff | high | `not-started` | small |
-| 2 | Checkpointing and resume | high | `not-started` | medium |
-| 3 | Sub-workflow composition | high | `not-started` | medium |
-| 4 | Runner context injection | high | `not-started` | small |
-| 5 | Node scheduling constraints | medium | `not-started` | medium |
+| 1 | Step retry with backoff | high | `implemented` | small |
+| 2 | Checkpointing and resume | high | `partial` | medium |
+| 3 | Sub-workflow composition | high | `partial` | medium |
+| 4 | Runner context injection | high | `implemented` | small |
+| 5 | Node scheduling constraints | medium | `partial` | medium |
 | 6 | Versioned step outputs | medium | `not-started` | medium |
 | 7 | Invalidation cascade | medium | `not-started` | small |
 | 8 | Dynamic graph mutation | medium | `not-started` | large |
 | 9 | Event emission from steps | low | `not-started` | small |
 | 10 | Cross-workflow dependencies | low | `not-started` | medium |
-| 11 | Pause and resume | medium | `not-started` | medium |
-| 12 | Step middleware | medium | `not-started` | small |
+| 11 | Pause and resume | medium | `implemented` | medium |
+| 12 | Step middleware | medium | `implemented` | small |
 
 ## Dependency graph
 

--- a/lib/dag/workflow/execution_store.rb
+++ b/lib/dag/workflow/execution_store.rb
@@ -137,6 +137,22 @@ module DAG
             end
           when Array
             value.map { |nested| deep_copy(nested) }
+          when Success
+            Success.new(value: deep_copy(value.value))
+          when Failure
+            Failure.new(error: deep_copy(value.error))
+          when TraceEntry
+            TraceEntry.new(
+              name: deep_copy(value.name),
+              layer: deep_copy(value.layer),
+              started_at: deep_copy(value.started_at),
+              finished_at: deep_copy(value.finished_at),
+              duration_ms: deep_copy(value.duration_ms),
+              status: deep_copy(value.status),
+              input_keys: deep_copy(value.input_keys),
+              attempt: deep_copy(value.attempt),
+              retried: deep_copy(value.retried)
+            )
           else
             value
           end

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -289,6 +289,7 @@ module DAG
           if lifecycle
             waiting_nodes.concat(lifecycle[:waiting_nodes]) if lifecycle[:status] == :waiting
             paused ||= lifecycle[:status] == :paused
+            @callbacks.finish(name, callback_result_for_lifecycle(lifecycle))
             next
           end
 
@@ -537,6 +538,10 @@ module DAG
           trace: result.value[:__sub_workflow_trace__] || [],
           waiting_nodes: result.value[:__sub_workflow_waiting_nodes__] || []
         }
+      end
+
+      def callback_result_for_lifecycle(_lifecycle)
+        Success.new(value: nil)
       end
 
       def accepts_context_keyword?(call_method)

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -182,7 +182,7 @@ module DAG
           :completed
         end
 
-        waiting_nodes = status == :waiting ? waiting_nodes : []
+        waiting_nodes = (status == :waiting) ? waiting_nodes : []
         build_run_result(outputs, trace,
           status,
           failed_name ? {failed_node: failed_name, step_error: failed_result.error} : nil,

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -157,18 +157,19 @@ module DAG
             break
           end
 
-          layer_results, layer_waiting_nodes = execute_layer(layer, layer_index, outputs, statuses, trace, deadline)
+          layer_results, layer_waiting_nodes, layer_paused = execute_layer(layer, layer_index, outputs, statuses, trace, deadline)
           waiting_nodes.concat(layer_waiting_nodes)
 
           layer_results.each do |name, result|
-            outputs[name] = result
             if result.failure? && failed_name.nil?
               failed_name = name
               failed_result = result
+            elsif !result.failure?
+              outputs[name] = result
             end
           end
 
-          break if layer_waiting_nodes.any? && !failed_name
+          paused ||= layer_paused
         end
 
         status = if failed_name
@@ -181,6 +182,7 @@ module DAG
           :completed
         end
 
+        waiting_nodes = status == :waiting ? waiting_nodes : []
         build_run_result(outputs, trace,
           status,
           failed_name ? {failed_node: failed_name, step_error: failed_result.error} : nil,
@@ -217,9 +219,10 @@ module DAG
 
         runnable.each { |t| @callbacks.start(t.name, t.step) }
         record_immediate_results(immediate_results, results, statuses, layer_index, trace)
-        run_tasks(runnable, layer_index, trace, results, statuses)
+        task_waiting_nodes, paused = run_tasks(runnable, layer_index, trace, results, statuses)
+        waiting_nodes.concat(task_waiting_nodes)
 
-        [results, waiting_nodes]
+        [results, waiting_nodes, paused]
       end
 
       def partition_layer(layer, previous_outputs, statuses, deadline)
@@ -228,6 +231,8 @@ module DAG
         waiting_nodes = []
 
         layer.each do |name|
+          next unless dependency_outputs_ready?(name, previous_outputs)
+
           step = @registry[name]
           condition_context = resolve_condition_context(name, previous_outputs, statuses)
           input = extract_input(condition_context)
@@ -267,20 +272,32 @@ module DAG
       # was filtered by `run_if`): no point handing an empty array to the
       # strategy, and it keeps the trace ordering tidy.
       def run_tasks(tasks, layer_index, trace, results, statuses)
-        return if tasks.empty?
+        return [[], false] if tasks.empty?
 
         tasks_by_name = tasks.to_h { |task| [task.name, task] }
+        waiting_nodes = []
+        paused = false
 
         @strategy.execute(tasks) do |name, result, started_at, finished_at, duration_ms|
           task = tasks_by_name.fetch(name)
+          lifecycle = sub_workflow_lifecycle_payload(result)
           entries = build_trace_entries_for_task(task, layer_index, result,
             started_at: started_at, finished_at: finished_at, duration_ms: duration_ms)
           trace.concat(entries)
           persist_step_result!(task, result, entries)
+
+          if lifecycle
+            waiting_nodes.concat(lifecycle[:waiting_nodes]) if lifecycle[:status] == :waiting
+            paused ||= lifecycle[:status] == :paused
+            next
+          end
+
           statuses[name] = entries.last.status
           @callbacks.finish(name, result)
           results[name] = result
         end
+
+        [waiting_nodes, paused]
       end
 
       def build_step_execution(name, current_attempt:, deadline:)
@@ -324,16 +341,19 @@ module DAG
           end
           result, child_trace = unwrap_sub_workflow_result(result)
           attempt_log.concat(child_trace)
+          lifecycle = sub_workflow_lifecycle_payload(result)
           finished_at = @clock.monotonic_now
-          attempt_log << {
-            attempt: execution.attempt,
-            node_path: execution.node_path,
-            started_at: started_at,
-            finished_at: finished_at,
-            duration_ms: ((finished_at - started_at) * 1000).round(2),
-            status: result.success? ? :success : :failure,
-            retried: false
-          }
+          unless lifecycle
+            attempt_log << {
+              attempt: execution.attempt,
+              node_path: execution.node_path,
+              started_at: started_at,
+              finished_at: finished_at,
+              duration_ms: ((finished_at - started_at) * 1000).round(2),
+              status: result.success? ? :success : :failure,
+              retried: false
+            }
+          end
           result
         rescue => e
           finished_at = @clock.monotonic_now
@@ -389,6 +409,21 @@ module DAG
             message: "sub_workflow step #{step.name} failed",
             child_error: child_result.error,
             child_trace: child_result.trace
+          })
+        end
+
+        if child_result.waiting?
+          return Success.new(value: {
+            __sub_workflow_status__: :waiting,
+            __sub_workflow_trace__: child_result.trace,
+            __sub_workflow_waiting_nodes__: child_result.waiting_nodes
+          })
+        end
+
+        if child_result.paused?
+          return Success.new(value: {
+            __sub_workflow_status__: :paused,
+            __sub_workflow_trace__: child_result.trace
           })
         end
 
@@ -480,13 +515,28 @@ module DAG
       end
 
       def unwrap_sub_workflow_result(result)
-        if result.success? && result.value.is_a?(Hash) && result.value[:__sub_workflow_output__]
+        if (payload = sub_workflow_lifecycle_payload(result))
+          [result, payload[:trace]]
+        elsif result.success? && result.value.is_a?(Hash) && result.value[:__sub_workflow_output__]
           [Success.new(value: result.value[:__sub_workflow_output__]), result.value[:__sub_workflow_trace__] || []]
         elsif result.failure? && result.error.is_a?(Hash) && result.error[:child_trace]
           [Failure.new(error: result.error.except(:child_trace)), result.error[:child_trace] || []]
         else
           [result, []]
         end
+      end
+
+      def sub_workflow_lifecycle_payload(result)
+        return nil unless result.success? && result.value.is_a?(Hash)
+
+        status = result.value[:__sub_workflow_status__]
+        return nil unless %i[waiting paused].include?(status)
+
+        {
+          status: status,
+          trace: result.value[:__sub_workflow_trace__] || [],
+          waiting_nodes: result.value[:__sub_workflow_waiting_nodes__] || []
+        }
       end
 
       def accepts_context_keyword?(call_method)
@@ -581,6 +631,10 @@ module DAG
         end
       end
 
+      def dependency_outputs_ready?(name, outputs)
+        @graph.each_predecessor(name).all? { |dep| outputs.key?(dep) }
+      end
+
       def load_reusable_result(name)
         return nil unless @execution_store
 
@@ -590,6 +644,7 @@ module DAG
 
       def persist_step_result!(task, result, entries)
         return unless @execution_store
+        return if sub_workflow_lifecycle_payload(result)
 
         entries.each do |entry|
           @execution_store.append_trace(workflow_id: @workflow_id, entry: entry)
@@ -618,6 +673,8 @@ module DAG
 
       def build_trace_entries_for_task(task, layer_index, result, started_at:, finished_at:, duration_ms:)
         if task.attempt_log.empty?
+          return [] if sub_workflow_lifecycle_payload(result)
+
           return [build_trace_entry(task.execution.node_path, layer_index, result,
             started_at: started_at, finished_at: finished_at, duration_ms: duration_ms,
             input_keys: task.input_keys)]
@@ -649,8 +706,9 @@ module DAG
         )
       end
 
-      # Predecessors always have a Result in `outputs` by the time we
-      # resolve a downstream layer — skipped steps still record Success(nil).
+      # Downstream layers only resolve nodes whose direct predecessors already
+      # produced outputs in this invocation or via reuse. Waiting/paused nodes
+      # intentionally do not materialize placeholder outputs.
       def resolve_condition_context(name, outputs, statuses)
         dependency_context = @root_input.transform_values { |value| {value: value, status: :success} }
 

--- a/spec/execution_store_test.rb
+++ b/spec/execution_store_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class ExecutionStoreTest < Minitest::Test
+  def test_load_output_returns_isolated_result_snapshot
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    store.begin_run(workflow_id: "wf-store", definition_fingerprint: "fp-1", node_paths: [[:fetch]])
+    store.save_output(
+      workflow_id: "wf-store",
+      node_path: [:fetch],
+      version: 1,
+      result: DAG::Success.new(value: {payload: ["a"]}),
+      reusable: true,
+      superseded: false
+    )
+
+    loaded = store.load_output(workflow_id: "wf-store", node_path: [:fetch])
+    loaded[:result].value[:payload] << "b"
+
+    reloaded = store.load_output(workflow_id: "wf-store", node_path: [:fetch])
+    assert_equal ["a"], reloaded[:result].value[:payload]
+  end
+
+  def test_load_run_returns_isolated_trace_entries
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    store.begin_run(workflow_id: "wf-trace", definition_fingerprint: "fp-1", node_paths: [[:fetch]])
+    store.append_trace(
+      workflow_id: "wf-trace",
+      entry: DAG::Workflow::TraceEntry.new(
+        name: :fetch,
+        layer: 0,
+        started_at: 1.0,
+        finished_at: 2.0,
+        duration_ms: 1000.0,
+        status: :success,
+        input_keys: [:a],
+        attempt: 1,
+        retried: false
+      )
+    )
+
+    loaded = store.load_run("wf-trace")
+    loaded[:trace].first.input_keys << :b
+
+    reloaded = store.load_run("wf-trace")
+    assert_equal [:a], reloaded[:trace].first.input_keys
+  end
+end

--- a/spec/runner_test.rb
+++ b/spec/runner_test.rb
@@ -66,6 +66,26 @@ class RunnerTest < Minitest::Test
     assert_equal 42, result.error[:step_error][:exit_status]
   end
 
+  def test_failed_nodes_are_not_exposed_in_outputs
+    definition = build_test_workflow(
+      fetch: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "ready") }
+      },
+      explode: {
+        type: :ruby,
+        depends_on: [:fetch],
+        callable: ->(_input) { DAG::Failure.new(error: {code: :boom, message: "explode"}) }
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(definition, parallel: false).call
+
+    assert_equal :failed, result.status
+    assert_equal "ready", result.outputs[:fetch].value
+    refute result.outputs.key?(:explode)
+  end
+
   def test_runner_returns_workflow_run_result
     success = run_workflow({good: {command: "echo good"}})
     failure = run_workflow({bad: {command: "exit 1"}})

--- a/spec/scheduling_test.rb
+++ b/spec/scheduling_test.rb
@@ -66,6 +66,67 @@ class SchedulingTest < Minitest::Test
     assert_equal [[:scheduled]], result.waiting_nodes
   end
 
+  def test_waiting_nodes_do_not_stop_independent_runnable_future_layers
+    clock = FakeClock.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+    future_time = Time.utc(2026, 4, 15, 10, 0, 0)
+
+    definition = DAG::Workflow::Loader.from_hash(
+      gated: {
+        type: :ruby,
+        schedule: {not_before: future_time},
+        callable: ->(_input) { DAG::Success.new(value: "later") }
+      },
+      fetch: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "ready") }
+      },
+      transform: {
+        type: :ruby,
+        depends_on: [:fetch],
+        callable: ->(input) { DAG::Success.new(value: input[:fetch].upcase) }
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(definition, parallel: false, clock: clock).call
+
+    assert_equal :waiting, result.status
+    assert_equal "ready", result.outputs[:fetch].value
+    assert_equal "READY", result.outputs[:transform].value
+    refute result.outputs.key?(:gated)
+    assert_equal [[:gated]], result.waiting_nodes
+  end
+
+  def test_failure_takes_precedence_over_waiting_and_clears_waiting_nodes
+    clock = FakeClock.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+    future_time = Time.utc(2026, 4, 15, 10, 0, 0)
+
+    definition = DAG::Workflow::Loader.from_hash(
+      gated: {
+        type: :ruby,
+        schedule: {not_before: future_time},
+        callable: ->(_input) { DAG::Success.new(value: "later") }
+      },
+      fetch: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "ready") }
+      },
+      explode: {
+        type: :ruby,
+        depends_on: [:fetch],
+        callable: ->(_input) { DAG::Failure.new(error: {code: :boom, message: "explode"}) }
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(definition, parallel: false, clock: clock).call
+
+    assert_equal :failed, result.status
+    assert_equal :explode, result.error[:failed_node]
+    assert_equal [], result.waiting_nodes
+    assert_equal "ready", result.outputs[:fetch].value
+    refute result.outputs.key?(:explode)
+    refute result.outputs.key?(:gated)
+  end
+
   def test_not_before_run_completes_after_clock_advances_past_gate
     clock = FakeClock.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
     future_time = Time.utc(2026, 4, 15, 10, 0, 0)

--- a/spec/sub_workflow_test.rb
+++ b/spec/sub_workflow_test.rb
@@ -242,6 +242,45 @@ class SubWorkflowTest < Minitest::Test
     refute_includes result.trace.map(&:name), :"process.gated"
   end
 
+  def test_sub_workflow_waiting_still_fires_finish_callback_with_nil_success
+    clock = Struct.new(:wall_time, :mono_time) do
+      def wall_now = wall_time
+      def monotonic_now = mono_time
+    end.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+    future_time = Time.utc(2026, 4, 15, 10, 0, 0)
+    started = []
+    finished = []
+
+    child = DAG::Workflow::Loader.from_hash(
+      gated: {
+        type: :ruby,
+        schedule: {not_before: future_time},
+        callable: ->(_input) { DAG::Success.new(value: "later") }
+      }
+    )
+
+    parent = DAG::Workflow::Loader.from_hash(
+      process: {
+        type: :sub_workflow,
+        definition: child
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(parent,
+      parallel: false,
+      clock: clock,
+      on_step_start: ->(name, _step) { started << name },
+      on_step_finish: ->(name, callback_result) { finished << [name, callback_result] }).call
+
+    assert_equal :waiting, result.status
+    assert_equal [:process], started
+    assert_equal 1, finished.size
+    assert_equal :process, finished.first[0]
+    assert_kind_of DAG::Success, finished.first[1]
+    assert_nil finished.first[1].value
+    refute result.outputs.key?(:process)
+  end
+
   def test_sub_workflow_propagates_paused_status_without_parent_output
     store = DAG::Workflow::ExecutionStore::MemoryStore.new
 
@@ -283,6 +322,53 @@ class SubWorkflowTest < Minitest::Test
     assert_includes result.trace.map(&:name), :"process.inner_fetch"
     refute_includes result.trace.map(&:name), :process
     refute_includes result.trace.map(&:name), :"process.inner_transform"
+  end
+
+  def test_sub_workflow_paused_still_fires_finish_callback_with_nil_success
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    started = []
+    finished = []
+
+    child = DAG::Workflow::Loader.from_hash(
+      inner_fetch: {
+        type: :ruby,
+        resume_key: "inner-fetch-v1",
+        callable: ->(_input) do
+          store.set_pause_flag(workflow_id: "wf-child-pause-callback", paused: true)
+          DAG::Success.new(value: "raw")
+        end
+      },
+      inner_transform: {
+        type: :ruby,
+        depends_on: [:inner_fetch],
+        resume_key: "inner-transform-v1",
+        callable: ->(input) { DAG::Success.new(value: input[:inner_fetch].upcase) }
+      }
+    )
+
+    parent = DAG::Workflow::Loader.from_hash(
+      process: {
+        type: :sub_workflow,
+        definition: child,
+        output_key: :inner_transform,
+        resume_key: "process-v1"
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(parent,
+      parallel: false,
+      workflow_id: "wf-child-pause-callback",
+      execution_store: store,
+      on_step_start: ->(name, _step) { started << name },
+      on_step_finish: ->(name, callback_result) { finished << [name, callback_result] }).call
+
+    assert_equal :paused, result.status
+    assert_equal [:process], started
+    assert_equal 1, finished.size
+    assert_equal :process, finished.first[0]
+    assert_kind_of DAG::Success, finished.first[1]
+    assert_nil finished.first[1].value
+    refute result.outputs.key?(:process)
   end
 
   def test_sub_workflow_uses_parent_context_and_execution_store_namespace

--- a/spec/sub_workflow_test.rb
+++ b/spec/sub_workflow_test.rb
@@ -205,6 +205,86 @@ class SubWorkflowTest < Minitest::Test
     assert_equal :sub_workflow_invalid_output_key, result.error[:step_error][:code]
   end
 
+  def test_sub_workflow_propagates_waiting_status_and_namespaced_waiting_nodes
+    clock = Struct.new(:wall_time, :mono_time) do
+      def wall_now = wall_time
+      def monotonic_now = mono_time
+    end.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+    future_time = Time.utc(2026, 4, 15, 10, 0, 0)
+
+    child = DAG::Workflow::Loader.from_hash(
+      gated: {
+        type: :ruby,
+        schedule: {not_before: future_time},
+        callable: ->(_input) { DAG::Success.new(value: "later") }
+      }
+    )
+
+    parent = DAG::Workflow::Loader.from_hash(
+      fetch: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "hello") }
+      },
+      process: {
+        type: :sub_workflow,
+        definition: child,
+        depends_on: [:fetch]
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(parent, parallel: false, clock: clock).call
+
+    assert_equal :waiting, result.status
+    assert_equal "hello", result.outputs[:fetch].value
+    refute result.outputs.key?(:process)
+    assert_equal [[:process, :gated]], result.waiting_nodes
+    refute_includes result.trace.map(&:name), :process
+    refute_includes result.trace.map(&:name), :"process.gated"
+  end
+
+  def test_sub_workflow_propagates_paused_status_without_parent_output
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+
+    child = DAG::Workflow::Loader.from_hash(
+      inner_fetch: {
+        type: :ruby,
+        resume_key: "inner-fetch-v1",
+        callable: ->(_input) do
+          store.set_pause_flag(workflow_id: "wf-child-pause", paused: true)
+          DAG::Success.new(value: "raw")
+        end
+      },
+      inner_transform: {
+        type: :ruby,
+        depends_on: [:inner_fetch],
+        resume_key: "inner-transform-v1",
+        callable: ->(input) { DAG::Success.new(value: input[:inner_fetch].upcase) }
+      }
+    )
+
+    parent = DAG::Workflow::Loader.from_hash(
+      process: {
+        type: :sub_workflow,
+        definition: child,
+        output_key: :inner_transform,
+        resume_key: "process-v1"
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(parent,
+      parallel: false,
+      workflow_id: "wf-child-pause",
+      execution_store: store).call
+
+    assert_equal :paused, result.status
+    assert result.paused?
+    refute result.outputs.key?(:process)
+    assert_equal [], result.waiting_nodes
+    assert_includes result.trace.map(&:name), :"process.inner_fetch"
+    refute_includes result.trace.map(&:name), :process
+    refute_includes result.trace.map(&:name), :"process.inner_transform"
+  end
+
   def test_sub_workflow_uses_parent_context_and_execution_store_namespace
     child_calls = 0
     child = DAG::Workflow::Loader.from_hash(

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -12,6 +12,7 @@ end
 require "minitest/autorun"
 require "securerandom"
 require "tempfile"
+require "tmpdir"
 
 require_relative "../lib/dag"
 
@@ -55,8 +56,7 @@ module TestHelpers
   end
 
   def temp_path(prefix: "dag_test", suffix: ".txt")
-    dir = File.expand_path("~/tmp")
-    Dir.mkdir(dir) unless Dir.exist?(dir)
+    dir = Dir.tmpdir
     File.join(dir, "#{prefix}_#{$$}_#{SecureRandom.hex(6)}#{suffix}")
   end
 end


### PR DESCRIPTION
## Summary
Fix workflow runtime invariants around waiting, paused sub-workflows, result exposure, and execution-store snapshots.

## What Changed
- let `Runner` continue past waiting nodes when independent branches are still runnable
- propagate `:waiting` and `:paused` from `sub_workflow` children instead of degrading into parent step failures
- keep failed nodes out of `RunResult.outputs`
- return isolated snapshots from `ExecutionStore::MemoryStore`
- switch test temp paths to `Dir.tmpdir`
- add regression coverage for scheduling, sub-workflow lifecycle propagation, output invariants, and execution-store isolation
- align `README.md` and `ROADMAP.md` with the corrected runtime behavior and current implementation status

## Root Cause
The runner treated waiting as an immediate stop condition for the whole invocation, assumed every non-failed child workflow had produced final outputs, and exposed mutable persisted objects back to callers. Those mismatches also leaked into the documented contract.

## Impact
This makes scheduling and nested workflows behave consistently with the intended execution model, removes a misleading failure mode for waiting/paused child workflows, and hardens the in-memory execution store against accidental state corruption.

## Validation
- `bundle exec rake test`
