### PR TITLE
feat: add not_after scheduling failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,11 @@ result = DAG::Workflow::Runner.new(definition,
 
 Notes:
 - `schedule[:not_before]` uses `clock.wall_now`
+- `schedule[:not_after]` fails the step with `code: :deadline_exceeded` before late work starts
 - waiting nodes do not emit `Success(nil)` outputs
 - waiting nodes do not block independent branches that are still runnable later in the same invocation
 - waiting runs persist `workflow_status: :waiting` plus `waiting_nodes` in the execution store
-- see `examples/waiting_not_before.rb` for a runnable example exercised in the test suite
+- see `examples/waiting_not_before.rb` and `examples/not_after_deadline.rb` for runnable examples exercised in the test suite
 
 ### Pause and resume
 

--- a/examples/not_after_deadline.rb
+++ b/examples/not_after_deadline.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# not_after scheduling: the runner fails deterministically when a step is already
+# past its latest allowed start/completion window before the invocation reaches it.
+#
+# Run: ruby -Ilib examples/not_after_deadline.rb
+
+require "dag"
+
+clock = Struct.new(:wall_time, :mono_time) do
+  def wall_now = wall_time
+  def monotonic_now = mono_time
+end.new(Time.utc(2026, 4, 15, 10, 0, 1), 0.0)
+
+store = DAG::Workflow::ExecutionStore::MemoryStore.new
+calls = 0
+workflow = DAG::Workflow::Loader.from_hash(
+  fetch: {
+    type: :ruby,
+    resume_key: "fetch-v1",
+    callable: ->(_input) { DAG::Success.new(value: "payload") }
+  },
+  scheduled: {
+    type: :ruby,
+    depends_on: [:fetch],
+    resume_key: "scheduled-v1",
+    schedule: {not_after: Time.utc(2026, 4, 15, 10, 0, 0)},
+    callable: ->(_input) do
+      calls += 1
+      DAG::Success.new(value: "too-late")
+    end
+  }
+)
+
+result = DAG::Workflow::Runner.new(workflow,
+  parallel: false,
+  clock: clock,
+  workflow_id: "example-not-after",
+  execution_store: store).call
+
+puts "=== Run (expired) ==="
+puts "Status: #{result.status}"
+puts "Failed node: #{result.error[:failed_node]}"
+puts "Error code: #{result.error.dig(:step_error, :code)}"
+puts "Outputs so far: #{result.outputs.transform_values(&:value)}"
+puts "Scheduled calls: #{calls}"

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -242,6 +242,10 @@ module DAG
             if waiting_for_schedule?(step)
               waiting_nodes << node_path_for(name)
               persist_waiting_node(name)
+            elsif schedule_expired?(step)
+              result = schedule_deadline_exceeded_result(name, normalized_not_after(step))
+              persist_expired_schedule_node(name, result.error)
+              immediate_results << [name, result, input_keys, nil]
             elsif skip?(step, condition_context)
               immediate_results << [name, record_skip_result, input_keys, :skipped]
             elsif (reused_result = load_reusable_result(name))
@@ -603,8 +607,21 @@ module DAG
         not_before && @clock.wall_now < not_before
       end
 
+      def schedule_expired?(step)
+        not_after = normalized_not_after(step)
+        not_after && @clock.wall_now > not_after
+      end
+
       def normalized_not_before(step)
-        raw = step.config.dig(:schedule, :not_before)
+        normalized_schedule_time(step, :not_before)
+      end
+
+      def normalized_not_after(step)
+        normalized_schedule_time(step, :not_after)
+      end
+
+      def normalized_schedule_time(step, key)
+        raw = step.config.dig(:schedule, key)
         case raw
         when nil
           nil
@@ -615,6 +632,14 @@ module DAG
         end
       end
 
+      def schedule_deadline_exceeded_result(name, not_after)
+        Failure.new(error: {
+          code: :deadline_exceeded,
+          message: "step #{name} missed schedule.not_after #{not_after.utc.iso8601}",
+          not_after: not_after.utc.iso8601
+        })
+      end
+
       def persist_waiting_node(name)
         return unless @execution_store && @workflow_id
 
@@ -622,6 +647,18 @@ module DAG
           workflow_id: @workflow_id,
           node_path: node_path_for(name),
           state: :waiting,
+          metadata: {}
+        )
+      end
+
+      def persist_expired_schedule_node(name, error)
+        return unless @execution_store && @workflow_id
+
+        @execution_store.set_node_state(
+          workflow_id: @workflow_id,
+          node_path: node_path_for(name),
+          state: :failed,
+          reason: error,
           metadata: {}
         )
       end

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -92,6 +92,24 @@ class ExamplesTest < Minitest::Test
     assert_includes stdout, "READY"
   end
 
+  def test_not_after_deadline_example_executes_successfully
+    stdout, stderr, status = run_example("examples/not_after_deadline.rb")
+
+    assert status.success?, <<~MSG
+      expected not_after_deadline example to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "=== Run (expired) ==="
+    assert_includes stdout, "Status: failed"
+    assert_includes stdout, "Failed node: scheduled"
+    assert_includes stdout, "Error code: deadline_exceeded"
+    assert_includes stdout, "Scheduled calls: 0"
+  end
+
   private
 
   def run_example(path)

--- a/spec/scheduling_test.rb
+++ b/spec/scheduling_test.rb
@@ -164,4 +164,68 @@ class SchedulingTest < Minitest::Test
     assert_equal "done", second.outputs[:scheduled].value
     assert_equal 1, calls
   end
+
+  def test_not_after_fails_before_executing_late_work
+    clock = FakeClock.new(Time.utc(2026, 4, 15, 10, 0, 1), 0.0)
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    calls = 0
+
+    definition = DAG::Workflow::Loader.from_hash(
+      scheduled: {
+        type: :ruby,
+        resume_key: "scheduled-v1",
+        schedule: {not_after: Time.utc(2026, 4, 15, 10, 0, 0)},
+        callable: ->(_input) do
+          calls += 1
+          DAG::Success.new(value: "too-late")
+        end
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      clock: clock,
+      workflow_id: "wf-not-after",
+      execution_store: store).call
+
+    assert_equal :failed, result.status
+    assert_equal :scheduled, result.error[:failed_node]
+    assert_equal :deadline_exceeded, result.error[:step_error][:code]
+    assert_match(/schedule\.not_after/, result.error[:step_error][:message])
+    assert_equal [], result.waiting_nodes
+    refute result.outputs.key?(:scheduled)
+    assert_equal 0, calls
+
+    run = store.load_run("wf-not-after")
+    node = store.load_node(workflow_id: "wf-not-after", node_path: [:scheduled])
+    assert_equal :failed, run[:workflow_status]
+    assert_equal :failed, node[:state]
+    assert_equal :deadline_exceeded, node[:reason][:code]
+  end
+
+  def test_not_after_failure_wins_over_waiting_nodes
+    clock = FakeClock.new(Time.utc(2026, 4, 15, 10, 0, 1), 0.0)
+
+    definition = DAG::Workflow::Loader.from_hash(
+      waiting: {
+        type: :ruby,
+        schedule: {not_before: Time.utc(2026, 4, 15, 11, 0, 0)},
+        callable: ->(_input) { DAG::Success.new(value: "later") }
+      },
+      expired: {
+        type: :ruby,
+        schedule: {not_after: Time.utc(2026, 4, 15, 10, 0, 0)},
+        callable: ->(_input) { DAG::Success.new(value: "too-late") }
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(definition, parallel: false, clock: clock).call
+
+    assert_equal :failed, result.status
+    assert_equal :expired, result.error[:failed_node]
+    assert_equal :deadline_exceeded, result.error[:step_error][:code]
+    assert_equal [], result.waiting_nodes
+    refute result.outputs.key?(:waiting)
+    refute result.outputs.key?(:expired)
+  end
 end


### PR DESCRIPTION
## Summary
Add the next scheduling slice for `schedule.not_after`.

## What Changed
- fail steps with `code: :deadline_exceeded` when `clock.wall_now` is already past `schedule.not_after` before execution
- persist expired scheduled nodes as failed in the execution store
- keep failed/waiting precedence aligned with current `RunResult` invariants
- add regression coverage for single-step expiry and failure-vs-waiting precedence
- add README notes plus a runnable `examples/not_after_deadline.rb` example

## Validation
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/scheduling_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/examples_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/not_after_deadline.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`

Closes #32