### PR TITLE
feat: round-trip schedule metadata through YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,11 @@ result = DAG::Workflow::Runner.new(definition,
 Notes:
 - `schedule[:not_before]` uses `clock.wall_now`
 - `schedule[:not_after]` fails the step with `code: :deadline_exceeded` before late work starts
+- YAML Loader/Dumper round-trip `schedule.not_before`, `schedule.not_after`, `schedule.ttl`, and `schedule.cron` with YAML-safe scalar values
 - waiting nodes do not emit `Success(nil)` outputs
 - waiting nodes do not block independent branches that are still runnable later in the same invocation
 - waiting runs persist `workflow_status: :waiting` plus `waiting_nodes` in the execution store
-- see `examples/waiting_not_before.rb` and `examples/not_after_deadline.rb` for runnable examples exercised in the test suite
+- see `examples/waiting_not_before.rb`, `examples/not_after_deadline.rb`, and `examples/schedule_metadata_roundtrip.rb` for runnable examples exercised in the test suite
 
 ### Pause and resume
 

--- a/examples/schedule_metadata_roundtrip.rb
+++ b/examples/schedule_metadata_roundtrip.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# YAML-safe schedule metadata round-trip: dump a workflow with schedule metadata,
+# load it back, and run it against a fake clock.
+#
+# Run: ruby -Ilib examples/schedule_metadata_roundtrip.rb
+
+require "dag"
+require "tmpdir"
+require "yaml"
+
+clock = Struct.new(:wall_time, :mono_time) do
+  def wall_now = wall_time
+  def monotonic_now = mono_time
+  def advance(seconds) = self.wall_time += seconds
+end.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+
+definition = DAG::Workflow::Loader.from_hash(
+  fetch: {
+    type: :exec,
+    command: "printf payload",
+    schedule: {
+      not_before: Time.utc(2026, 4, 15, 10, 0, 0),
+      not_after: Time.utc(2026, 4, 15, 11, 0, 0),
+      ttl: 3600,
+      cron: "0 * * * *"
+    }
+  }
+)
+
+Dir.mktmpdir("dag-schedule-roundtrip") do |dir|
+  path = File.join(dir, "workflow.yml")
+  DAG::Workflow::Dumper.to_file(definition, path)
+
+  raw_schedule = YAML.safe_load_file(path).fetch("nodes").fetch("fetch").fetch("schedule")
+  loaded = DAG::Workflow::Loader.from_file(path)
+  loaded_schedule = loaded.step(:fetch).config[:schedule]
+
+  first = DAG::Workflow::Runner.new(loaded,
+    parallel: false,
+    clock: clock).call
+
+  clock.advance(3600)
+
+  second = DAG::Workflow::Runner.new(loaded,
+    parallel: false,
+    clock: clock).call
+
+  puts "=== Dumped Schedule Metadata ==="
+  puts raw_schedule.inspect
+  puts "=== Loaded Schedule Metadata ==="
+  puts loaded_schedule.inspect
+  puts "=== First Run ==="
+  puts "Status: #{first.status}"
+  puts "=== Second Run ==="
+  puts "Status: #{second.status}"
+  puts "Output: #{second.outputs[:fetch].value}"
+end

--- a/lib/dag/workflow/dumper.rb
+++ b/lib/dag/workflow/dumper.rb
@@ -66,7 +66,7 @@ module DAG
               "reserved YAML key (#{RESERVED_YAML_KEYS.join(", ")}). " \
               "Rename the config key before dumping."
           end
-          node[key] = v
+          node[key] = dumpable_config_value(k, v)
         end
         deps = @graph.predecessors(name).to_a.sort
         unless deps.empty?
@@ -80,6 +80,32 @@ module DAG
           }
         end
         node
+      end
+
+      def dumpable_config_value(key, value)
+        case key.to_sym
+        when :schedule
+          dumpable_schedule(value)
+        else
+          value
+        end
+      end
+
+      def dumpable_schedule(value)
+        raise SerializationError, "schedule must be a mapping to dump as YAML" unless value.is_a?(Hash)
+
+        value.each_with_object({}) do |(key, nested), dumped|
+          dumped[key.to_s] = dumpable_schedule_value(nested)
+        end
+      end
+
+      def dumpable_schedule_value(value)
+        case value
+        when Time
+          value.utc.iso8601
+        else
+          value
+        end
       end
     end
   end

--- a/lib/dag/workflow/loader.rb
+++ b/lib/dag/workflow/loader.rb
@@ -119,7 +119,25 @@ module DAG
 
       def self.normalize_config_keys(opts, node_name:)
         opts.each_with_object({}) do |(key, value), h|
-          h[coerce_symbol!(key, context: "config key for node '#{node_name}'")] = value
+          key_sym = coerce_symbol!(key, context: "config key for node '#{node_name}'")
+          h[key_sym] = normalize_config_value(key_sym, value, node_name: node_name)
+        end
+      end
+
+      def self.normalize_config_value(key, value, node_name:)
+        case key
+        when :schedule
+          normalize_schedule_config(value, node_name: node_name)
+        else
+          value
+        end
+      end
+
+      def self.normalize_schedule_config(value, node_name:)
+        raise ValidationError, "Node '#{node_name}' schedule must be a mapping, got #{value.inspect}" unless value.is_a?(Hash)
+
+        value.each_with_object({}) do |(key, nested), h|
+          h[coerce_symbol!(key, context: "schedule key for node '#{node_name}'")] = nested
         end
       end
 
@@ -130,7 +148,7 @@ module DAG
       end
 
       private_class_method :build_definition, :validate_type!, :parse_depends_on, :normalize_entries,
-        :normalize_config_keys, :coerce_symbol!
+        :normalize_config_keys, :normalize_config_value, :normalize_schedule_config, :coerce_symbol!
     end
   end
 end

--- a/spec/dumper_test.rb
+++ b/spec/dumper_test.rb
@@ -206,6 +206,35 @@ class DumperTest < Minitest::Test
     assert_equal :strict, defn2.step(:task).config[:mode]
   end
 
+  def test_round_trip_schedule_metadata_with_yaml_safe_values
+    defn1 = build_test_workflow(task: {
+      type: :exec,
+      command: "echo x",
+      schedule: {
+        not_before: Time.utc(2026, 4, 15, 9, 0, 0),
+        not_after: Time.utc(2026, 4, 15, 10, 0, 0),
+        ttl: 3600,
+        cron: "0 * * * *"
+      }
+    })
+
+    dumped = DAG::Workflow::Dumper.to_yaml(defn1)
+    parsed = YAML.safe_load(dumped)
+    schedule = parsed.fetch("nodes").fetch("task").fetch("schedule")
+    defn2 = DAG::Workflow::Loader.from_yaml(dumped)
+
+    assert_equal "2026-04-15T09:00:00Z", schedule["not_before"]
+    assert_equal "2026-04-15T10:00:00Z", schedule["not_after"]
+    assert_equal 3600, schedule["ttl"]
+    assert_equal "0 * * * *", schedule["cron"]
+    assert_equal({
+      not_before: "2026-04-15T09:00:00Z",
+      not_after: "2026-04-15T10:00:00Z",
+      ttl: 3600,
+      cron: "0 * * * *"
+    }, defn2.step(:task).config[:schedule])
+  end
+
   def test_round_trip_sub_workflow_with_definition_path_via_file
     Dir.mktmpdir("dag-dumper-subworkflow") do |dir|
       child_path = File.join(dir, "child.yml")

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -122,7 +122,9 @@ class ExamplesTest < Minitest::Test
     MSG
 
     assert_includes stdout, "=== Dumped Schedule Metadata ==="
-    assert_includes stdout, '"not_before" => "2026-04-15T10:00:00Z"'
+    assert_includes stdout, "2026-04-15T10:00:00Z"
+    assert_includes stdout, "2026-04-15T11:00:00Z"
+    assert_includes stdout, "0 * * * *"
     assert_includes stdout, "=== Loaded Schedule Metadata ==="
     assert_includes stdout, "Status: waiting"
     assert_includes stdout, "Status: completed"

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -110,6 +110,25 @@ class ExamplesTest < Minitest::Test
     assert_includes stdout, "Scheduled calls: 0"
   end
 
+  def test_schedule_metadata_roundtrip_example_executes_successfully
+    stdout, stderr, status = run_example("examples/schedule_metadata_roundtrip.rb")
+
+    assert status.success?, <<~MSG
+      expected schedule_metadata_roundtrip example to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "=== Dumped Schedule Metadata ==="
+    assert_includes stdout, '"not_before" => "2026-04-15T10:00:00Z"'
+    assert_includes stdout, "=== Loaded Schedule Metadata ==="
+    assert_includes stdout, "Status: waiting"
+    assert_includes stdout, "Status: completed"
+    assert_includes stdout, "Output: payload"
+  end
+
   private
 
   def run_example(path)

--- a/spec/loader_test.rb
+++ b/spec/loader_test.rb
@@ -67,6 +67,41 @@ class LoaderTest < Minitest::Test
     assert_equal "custom_value", defn.step(:task).config[:custom_key]
   end
 
+  def test_symbolizes_schedule_metadata_keys_from_yaml
+    defn = load_yaml(<<~YAML)
+      nodes:
+        task:
+          type: exec
+          command: "echo x"
+          schedule:
+            not_before: "2026-04-15T09:00:00Z"
+            not_after: "2026-04-15T10:00:00Z"
+            ttl: 3600
+            cron: "0 * * * *"
+    YAML
+
+    assert_equal({
+      not_before: "2026-04-15T09:00:00Z",
+      not_after: "2026-04-15T10:00:00Z",
+      ttl: 3600,
+      cron: "0 * * * *"
+    }, defn.step(:task).config[:schedule])
+  end
+
+  def test_rejects_non_hash_schedule_config
+    error = assert_raises(DAG::ValidationError) do
+      load_yaml(<<~YAML)
+        nodes:
+          task:
+            type: exec
+            command: "echo x"
+            schedule: later
+      YAML
+    end
+
+    assert_match(/schedule must be a mapping/, error.message)
+  end
+
   def test_loads_declarative_run_if_from_yaml
     defn = load_yaml(<<~YAML)
       nodes:


### PR DESCRIPTION
## Summary
Add the next scheduling slice for YAML-safe schedule metadata round-trips.

## What Changed
- normalize YAML-loaded `schedule` keys to symbols so runtime scheduling logic can use them consistently
- dump `schedule.not_before` and `schedule.not_after` as YAML-safe ISO8601 strings
- preserve `schedule.ttl` and `schedule.cron` through Loader/Dumper round-trips
- reject non-mapping `schedule` configs in YAML input
- add focused loader/dumper coverage plus a runnable `examples/schedule_metadata_roundtrip.rb` example
- update README scheduling notes

## Validation
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/loader_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/dumper_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/examples_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/schedule_metadata_roundtrip.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`

Closes #34