### PR TITLE
feat: expire reusable outputs after schedule ttl

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,12 @@ result = DAG::Workflow::Runner.new(definition,
 Notes:
 - `schedule[:not_before]` uses `clock.wall_now`
 - `schedule[:not_after]` fails the step with `code: :deadline_exceeded` before late work starts
+- `schedule[:ttl]` expires reusable outputs relative to `clock.wall_now`, marks them stale in the execution store, and forces re-execution on the next run
 - YAML Loader/Dumper round-trip `schedule.not_before`, `schedule.not_after`, `schedule.ttl`, and `schedule.cron` with YAML-safe scalar values
 - waiting nodes do not emit `Success(nil)` outputs
 - waiting nodes do not block independent branches that are still runnable later in the same invocation
 - waiting runs persist `workflow_status: :waiting` plus `waiting_nodes` in the execution store
-- see `examples/waiting_not_before.rb`, `examples/not_after_deadline.rb`, and `examples/schedule_metadata_roundtrip.rb` for runnable examples exercised in the test suite
+- see `examples/waiting_not_before.rb`, `examples/not_after_deadline.rb`, `examples/schedule_metadata_roundtrip.rb`, and `examples/ttl_expiry.rb` for runnable examples exercised in the test suite
 
 ### Pause and resume
 

--- a/examples/ttl_expiry.rb
+++ b/examples/ttl_expiry.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# schedule.ttl: reusable outputs expire relative to the injected wall clock,
+# causing the runner to execute the step again instead of reusing stale output.
+#
+# Run: ruby -Ilib examples/ttl_expiry.rb
+
+require "dag"
+
+clock = Struct.new(:wall_time, :mono_time) do
+  def wall_now = wall_time
+  def monotonic_now = mono_time
+  def advance(seconds) = self.wall_time += seconds
+end.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+
+store = DAG::Workflow::ExecutionStore::MemoryStore.new
+calls = 0
+workflow = DAG::Workflow::Loader.from_hash(
+  cached: {
+    type: :ruby,
+    resume_key: "cached-v1",
+    schedule: {ttl: 300},
+    callable: ->(_input) do
+      calls += 1
+      DAG::Success.new(value: "run-#{calls}")
+    end
+  }
+)
+
+first = DAG::Workflow::Runner.new(workflow,
+  parallel: false,
+  clock: clock,
+  workflow_id: "example-ttl",
+  execution_store: store).call
+
+clock.advance(120)
+second = DAG::Workflow::Runner.new(workflow,
+  parallel: false,
+  clock: clock,
+  workflow_id: "example-ttl",
+  execution_store: store).call
+
+clock.advance(240)
+third = DAG::Workflow::Runner.new(workflow,
+  parallel: false,
+  clock: clock,
+  workflow_id: "example-ttl",
+  execution_store: store).call
+
+node = store.load_node(workflow_id: "example-ttl", node_path: [:cached])
+
+puts "=== First Run ==="
+puts "Output: #{first.outputs[:cached].value}"
+puts "=== Second Run (reuse within ttl) ==="
+puts "Output: #{second.outputs[:cached].value}"
+puts "=== Third Run (ttl expired) ==="
+puts "Output: #{third.outputs[:cached].value}"
+puts "Calls: #{calls}"
+puts "Stale cause: #{node[:stale_cause][:code]}"

--- a/lib/dag/workflow/execution_store.rb
+++ b/lib/dag/workflow/execution_store.rb
@@ -52,7 +52,7 @@ module DAG
           nil
         end
 
-        def save_output(workflow_id:, node_path:, version:, result:, reusable:, superseded:)
+        def save_output(workflow_id:, node_path:, version:, result:, reusable:, superseded:, saved_at: Time.now.utc)
           node = ensure_node(workflow_id, node_path)
           node[:outputs] ||= []
           node[:outputs] << {
@@ -60,7 +60,7 @@ module DAG
             result: result,
             reusable: reusable,
             superseded: superseded,
-            saved_at: Time.now.utc
+            saved_at: saved_at
           }
           nil
         end

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -663,6 +663,38 @@ module DAG
         )
       end
 
+      def reusable_output_expired?(name, stored)
+        ttl = normalized_schedule_ttl(@registry[name])
+        return false unless ttl && stored[:saved_at]
+
+        stored[:saved_at] <= (@clock.wall_now - ttl)
+      end
+
+      def normalized_schedule_ttl(step)
+        raw = step.config.dig(:schedule, :ttl)
+        case raw
+        when nil
+          nil
+        when Numeric
+          raw
+        else
+          Float(raw)
+        end
+      end
+
+      def mark_reusable_output_stale(name, stored)
+        return unless @execution_store && @workflow_id
+
+        cause = {
+          code: :ttl_expired,
+          message: "reusable output for step #{name} expired after schedule.ttl",
+          saved_at: stored[:saved_at].utc.iso8601,
+          ttl_seconds: normalized_schedule_ttl(@registry[name])
+        }
+
+        @execution_store.mark_stale(workflow_id: @workflow_id, node_paths: [node_path_for(name)], cause: cause)
+      end
+
       def blank?(value)
         value.nil? || (value.respond_to?(:empty?) && value.empty?)
       end
@@ -681,7 +713,14 @@ module DAG
         return nil unless @execution_store
 
         stored = @execution_store.load_output(workflow_id: @workflow_id, node_path: node_path_for(name))
-        stored && stored[:result]
+        return nil unless stored
+
+        if reusable_output_expired?(name, stored)
+          mark_reusable_output_stale(name, stored)
+          return nil
+        end
+
+        stored[:result]
       end
 
       def persist_step_result!(task, result, entries)
@@ -700,7 +739,8 @@ module DAG
             version: task.execution.attempt,
             result: result,
             reusable: true,
-            superseded: false
+            superseded: false,
+            saved_at: @clock.wall_now
           )
         else
           @execution_store.set_node_state(

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -131,6 +131,26 @@ class ExamplesTest < Minitest::Test
     assert_includes stdout, "Output: payload"
   end
 
+  def test_ttl_expiry_example_executes_successfully
+    stdout, stderr, status = run_example("examples/ttl_expiry.rb")
+
+    assert status.success?, <<~MSG
+      expected ttl_expiry example to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "=== First Run ==="
+    assert_includes stdout, "Output: run-1"
+    assert_includes stdout, "=== Second Run (reuse within ttl) ==="
+    assert_includes stdout, "=== Third Run (ttl expired) ==="
+    assert_includes stdout, "Output: run-2"
+    assert_includes stdout, "Calls: 2"
+    assert_includes stdout, "Stale cause: ttl_expired"
+  end
+
   private
 
   def run_example(path)

--- a/spec/execution_store_test.rb
+++ b/spec/execution_store_test.rb
@@ -46,4 +46,25 @@ class ExecutionStoreTest < Minitest::Test
     reloaded = store.load_run("wf-trace")
     assert_equal [:a], reloaded[:trace].first.input_keys
   end
+
+  def test_load_output_returns_isolated_saved_at_snapshot
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    saved_at = Time.utc(2026, 4, 15, 9, 0, 0)
+    store.begin_run(workflow_id: "wf-saved-at", definition_fingerprint: "fp-1", node_paths: [[:fetch]])
+    store.save_output(
+      workflow_id: "wf-saved-at",
+      node_path: [:fetch],
+      version: 1,
+      result: DAG::Success.new(value: "ok"),
+      reusable: true,
+      superseded: false,
+      saved_at: saved_at
+    )
+
+    loaded = store.load_output(workflow_id: "wf-saved-at", node_path: [:fetch])
+    loaded[:saved_at] = saved_at + 3600
+
+    reloaded = store.load_output(workflow_id: "wf-saved-at", node_path: [:fetch])
+    assert_equal saved_at, reloaded[:saved_at]
+  end
 end

--- a/spec/scheduling_test.rb
+++ b/spec/scheduling_test.rb
@@ -228,4 +228,87 @@ class SchedulingTest < Minitest::Test
     refute result.outputs.key?(:waiting)
     refute result.outputs.key?(:expired)
   end
+
+  def test_ttl_expiry_reexecutes_instead_of_reusing_output
+    clock = FakeClock.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    calls = 0
+
+    definition = DAG::Workflow::Loader.from_hash(
+      cached: {
+        type: :ruby,
+        resume_key: "cached-v1",
+        schedule: {ttl: 300},
+        callable: ->(_input) do
+          calls += 1
+          DAG::Success.new(value: "run-#{calls}")
+        end
+      }
+    )
+
+    first = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      clock: clock,
+      workflow_id: "wf-ttl",
+      execution_store: store).call
+
+    clock.advance_wall(120)
+    second = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      clock: clock,
+      workflow_id: "wf-ttl",
+      execution_store: store).call
+
+    clock.advance_wall(240)
+    third = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      clock: clock,
+      workflow_id: "wf-ttl",
+      execution_store: store).call
+
+    node = store.load_node(workflow_id: "wf-ttl", node_path: [:cached])
+
+    assert_equal "run-1", first.outputs[:cached].value
+    assert_equal "run-1", second.outputs[:cached].value
+    assert_equal "run-2", third.outputs[:cached].value
+    assert_equal 2, calls
+    assert_equal :completed, node[:state]
+    assert_equal :ttl_expired, node[:stale_cause][:code]
+  end
+
+  def test_ttl_string_values_are_supported
+    clock = FakeClock.new(Time.utc(2026, 4, 15, 9, 0, 0), 0.0)
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    calls = 0
+
+    definition = DAG::Workflow::Loader.from_hash(
+      cached: {
+        type: :ruby,
+        resume_key: "cached-v1",
+        schedule: {ttl: "5"},
+        callable: ->(_input) do
+          calls += 1
+          DAG::Success.new(value: "run-#{calls}")
+        end
+      }
+    )
+
+    first = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      clock: clock,
+      workflow_id: "wf-ttl-string",
+      execution_store: store).call
+
+    clock.advance_wall(10)
+
+    second = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      clock: clock,
+      workflow_id: "wf-ttl-string",
+      execution_store: store).call
+
+    assert_equal "run-1", first.outputs[:cached].value
+    assert_equal "run-2", second.outputs[:cached].value
+    assert_equal 2, calls
+  end
 end


### PR DESCRIPTION
## Summary
Add the next scheduling slice for `schedule.ttl`.

## What Changed
- expire reusable outputs relative to `clock.wall_now` when a step declares `schedule.ttl`
- mark expired cached outputs as stale in the execution store with `code: :ttl_expired`
- use the injected clock wall time when persisting reusable output timestamps for deterministic durable scheduling behavior
- support numeric and string TTL values
- add focused scheduling + execution-store coverage plus a runnable `examples/ttl_expiry.rb` example
- update README scheduling notes

## Validation
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/scheduling_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/execution_store_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/examples_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag ruby -Ilib examples/ttl_expiry.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`

Closes #36