### PR TITLE
feat: tighten immutable subtree replacement validation

### DIFF
--- a/examples/immutable_subtree_replacement.rb
+++ b/examples/immutable_subtree_replacement.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Immutable graph mutation: derive a new definition by replacing one workflow
+# node with a new subgraph, while leaving the original definition untouched.
+#
+# Run: ruby -Ilib examples/immutable_subtree_replacement.rb
+
+require "dag"
+
+original = DAG::Workflow::Loader.from_hash(
+  source: {
+    type: :ruby,
+    callable: ->(_input) { DAG::Success.new(value: "payload") }
+  },
+  config: {
+    type: :ruby,
+    callable: ->(_input) { DAG::Success.new(value: "v1") }
+  },
+  process: {
+    type: :ruby,
+    depends_on: [:source],
+    callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+  },
+  report: {
+    type: :ruby,
+    depends_on: [{from: :process, as: :summary}, :config],
+    callable: ->(input) { DAG::Success.new(value: "report:#{input[:summary]}|#{input[:config]}") }
+  }
+)
+
+replacement = DAG::Workflow::Loader.from_hash(
+  normalize: {
+    type: :ruby,
+    callable: ->(input) { DAG::Success.new(value: "#{input[:source]}-normalized") }
+  },
+  summarize: {
+    type: :ruby,
+    depends_on: [:normalize],
+    callable: ->(input) { DAG::Success.new(value: input[:normalize].upcase) }
+  }
+)
+
+mutated = DAG::Workflow.replace_subtree(
+  original,
+  root_node: :process,
+  replacement: replacement,
+  reconnect: [{from: :summarize, to: :report, metadata: {as: :summary}}]
+)
+
+original_result = DAG::Workflow::Runner.new(original, parallel: false).call
+mutated_result = DAG::Workflow::Runner.new(mutated, parallel: false).call
+
+puts "=== Original Definition ==="
+puts "Original output: report:#{original_result.outputs[:process].value}"
+puts
+puts "=== Mutated Definition ==="
+puts "Mutated output: #{mutated_result.outputs[:report].value}"
+puts "Original still has process? #{original.graph.node?(:process)}"
+puts "Mutated has process? #{mutated.graph.node?(:process)}"
+puts "Mutated has summarize? #{mutated.graph.node?(:summarize)}"

--- a/lib/dag/graph.rb
+++ b/lib/dag/graph.rb
@@ -173,15 +173,10 @@ module DAG
       removed = Set.new([root_sym])
       downstream = each_successor(root_sym).to_set
       normalized_reconnect = Array(reconnect).map do |descriptor|
-        raise ArgumentError, "reconnect entries must be Hashes" unless descriptor.is_a?(Hash)
-
-        entry = descriptor.transform_keys(&:to_sym)
-        from = entry.fetch(:from).to_sym
-        to = entry.fetch(:to).to_sym
-        raise ArgumentError, "reconnect from #{from.inspect} must reference a replacement leaf" unless replacement_graph.leaves.include?(from)
-        raise ArgumentError, "reconnect to #{to.inspect} must reference a downstream node outside the removed subtree" unless downstream.include?(to)
-
-        {from: from, to: to, metadata: merged_edge_metadata(root_sym, to, entry[:metadata])}
+        normalize_reconnect_entry(descriptor,
+          replacement_graph: replacement_graph,
+          downstream: downstream,
+          root: root_sym)
       end
 
       dup.tap do |graph|
@@ -259,6 +254,21 @@ module DAG
 
     def merged_edge_metadata(from, to, overrides = nil)
       edge_metadata(from, to).merge((overrides || {}).transform_keys(&:to_sym))
+    end
+
+    def normalize_reconnect_entry(descriptor, replacement_graph:, downstream:, root:)
+      raise ArgumentError, "reconnect entries must be Hashes" unless descriptor.is_a?(Hash)
+
+      entry = descriptor.transform_keys(&:to_sym)
+      raise ArgumentError, "reconnect entries must include :from" unless entry.key?(:from)
+      raise ArgumentError, "reconnect entries must include :to" unless entry.key?(:to)
+
+      from = entry.fetch(:from).to_sym
+      to = entry.fetch(:to).to_sym
+      raise ArgumentError, "reconnect from #{from.inspect} must reference a replacement leaf" unless replacement_graph.leaves.include?(from)
+      raise ArgumentError, "reconnect to #{to.inspect} must reference a downstream node outside the removed subtree" unless downstream.include?(to)
+
+      {from: from, to: to, metadata: merged_edge_metadata(root, to, entry[:metadata])}
     end
 
     # --- Neighbor queries ---

--- a/lib/dag/graph.rb
+++ b/lib/dag/graph.rb
@@ -178,9 +178,14 @@ module DAG
         entry = descriptor.transform_keys(&:to_sym)
         from = entry.fetch(:from).to_sym
         to = entry.fetch(:to).to_sym
-        metadata = (entry[:metadata] || {}).transform_keys(&:to_sym)
         raise ArgumentError, "reconnect from #{from.inspect} must reference a replacement leaf" unless replacement_graph.leaves.include?(from)
         raise ArgumentError, "reconnect to #{to.inspect} must reference a downstream node outside the removed subtree" unless downstream.include?(to)
+
+        # Default to the original root→to edge's metadata so downstream
+        # input aliases (`:as`, `:version`, etc.) survive the reconnect.
+        # Explicit entry metadata still overrides per-key.
+        explicit = (entry[:metadata] || {}).transform_keys(&:to_sym)
+        metadata = edge_metadata(root_sym, to).merge(explicit)
 
         {from: from, to: to, metadata: metadata}
       end

--- a/lib/dag/graph.rb
+++ b/lib/dag/graph.rb
@@ -181,13 +181,7 @@ module DAG
         raise ArgumentError, "reconnect from #{from.inspect} must reference a replacement leaf" unless replacement_graph.leaves.include?(from)
         raise ArgumentError, "reconnect to #{to.inspect} must reference a downstream node outside the removed subtree" unless downstream.include?(to)
 
-        # Default to the original root→to edge's metadata so downstream
-        # input aliases (`:as`, `:version`, etc.) survive the reconnect.
-        # Explicit entry metadata still overrides per-key.
-        explicit = (entry[:metadata] || {}).transform_keys(&:to_sym)
-        metadata = edge_metadata(root_sym, to).merge(explicit)
-
-        {from: from, to: to, metadata: metadata}
+        {from: from, to: to, metadata: merged_edge_metadata(root_sym, to, entry[:metadata])}
       end
 
       dup.tap do |graph|
@@ -261,6 +255,10 @@ module DAG
 
     def edge_metadata(from, to)
       @edge_metadata.dig(from.to_sym, to.to_sym) || {}
+    end
+
+    def merged_edge_metadata(from, to, overrides = nil)
+      edge_metadata(from, to).merge((overrides || {}).transform_keys(&:to_sym))
     end
 
     # --- Neighbor queries ---

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -43,10 +43,14 @@ module DAG
         Array(reconnect).each do |descriptor|
           entry = descriptor.transform_keys(&:to_sym)
           target = entry.fetch(:to).to_sym
-          # Match the merge that `Graph#with_subtree_replaced` applies to
-          # reconnect metadata — otherwise the validator's idea of the
-          # effective alias drifts from the edge actually written.
-          merged = graph.edge_metadata(root, target).merge(entry[:metadata] || {})
+          # Match the normalization `Graph#with_subtree_replaced` performs —
+          # symbolize the inner metadata keys and then merge user-supplied
+          # values over the original root→target edge — otherwise the
+          # validator's idea of the effective alias drifts from the edge
+          # actually written (a String key like `"as"` would bypass the
+          # alias-collision check but still end up symbolized on the edge).
+          explicit = (entry[:metadata] || {}).transform_keys(&:to_sym)
+          merged = graph.edge_metadata(root, target).merge(explicit)
           alias_key = effective_input_key(entry.fetch(:from), merged)
 
           if aliases_by_target[target].include?(alias_key)

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -43,14 +43,7 @@ module DAG
         Array(reconnect).each do |descriptor|
           entry = descriptor.transform_keys(&:to_sym)
           target = entry.fetch(:to).to_sym
-          # Match the normalization `Graph#with_subtree_replaced` performs —
-          # symbolize the inner metadata keys and then merge user-supplied
-          # values over the original root→target edge — otherwise the
-          # validator's idea of the effective alias drifts from the edge
-          # actually written (a String key like `"as"` would bypass the
-          # alias-collision check but still end up symbolized on the edge).
-          explicit = (entry[:metadata] || {}).transform_keys(&:to_sym)
-          merged = graph.edge_metadata(root, target).merge(explicit)
+          merged = graph.merged_edge_metadata(root, target, entry[:metadata])
           alias_key = effective_input_key(entry.fetch(:from), merged)
 
           if aliases_by_target[target].include?(alias_key)

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -43,7 +43,11 @@ module DAG
         Array(reconnect).each do |descriptor|
           entry = descriptor.transform_keys(&:to_sym)
           target = entry.fetch(:to).to_sym
-          alias_key = effective_input_key(entry.fetch(:from), entry[:metadata] || {})
+          # Match the merge that `Graph#with_subtree_replaced` applies to
+          # reconnect metadata — otherwise the validator's idea of the
+          # effective alias drifts from the edge actually written.
+          merged = graph.edge_metadata(root, target).merge(entry[:metadata] || {})
+          alias_key = effective_input_key(entry.fetch(:from), merged)
 
           if aliases_by_target[target].include?(alias_key)
             raise ArgumentError, "duplicate effective downstream alias for #{target}: #{alias_key}"

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -27,10 +27,12 @@ module DAG
 
       def validate_reconnect_aliases!(graph, root, reconnect)
         aliases_by_target = Hash.new { |hash, key| hash[key] = Set.new }
+        normalized_reconnect = Array(reconnect).map do |descriptor|
+          normalize_reconnect_alias_entry(descriptor, graph: graph, root: root)
+        end
 
-        Array(reconnect).each do |descriptor|
-          entry = descriptor.transform_keys(&:to_sym)
-          target = entry.fetch(:to).to_sym
+        normalized_reconnect.each do |entry|
+          target = entry.fetch(:to)
           aliases = aliases_by_target[target]
 
           graph.each_predecessor(target) do |predecessor|
@@ -40,9 +42,8 @@ module DAG
           end
         end
 
-        Array(reconnect).each do |descriptor|
-          entry = descriptor.transform_keys(&:to_sym)
-          target = entry.fetch(:to).to_sym
+        normalized_reconnect.each do |entry|
+          target = entry.fetch(:to)
           merged = graph.merged_edge_metadata(root, target, entry[:metadata])
           alias_key = effective_input_key(entry.fetch(:from), merged)
 
@@ -52,6 +53,20 @@ module DAG
 
           aliases_by_target[target] << alias_key
         end
+      end
+
+      def normalize_reconnect_alias_entry(descriptor, graph:, root:)
+        raise ArgumentError, "reconnect entries must be Hashes" unless descriptor.is_a?(Hash)
+
+        entry = descriptor.transform_keys(&:to_sym)
+        raise ArgumentError, "reconnect entries must include :from" unless entry.key?(:from)
+        raise ArgumentError, "reconnect entries must include :to" unless entry.key?(:to)
+
+        {
+          from: entry.fetch(:from).to_sym,
+          to: entry.fetch(:to).to_sym,
+          metadata: graph.merged_edge_metadata(root, entry.fetch(:to), entry[:metadata])
+        }
       end
 
       def effective_input_key(from, metadata)

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -9,6 +9,7 @@ module DAG
 
         root = root_node.to_sym
         removed = [root]
+        validate_reconnect_aliases!(definition.graph, root, reconnect)
 
         new_graph = definition.graph.with_subtree_replaced(
           root: root,
@@ -20,6 +21,40 @@ module DAG
         replacement.registry.steps.each { |step| new_registry.register(step) }
 
         Definition.new(graph: new_graph, registry: new_registry, source_path: definition.source_path)
+      end
+
+      private
+
+      def validate_reconnect_aliases!(graph, root, reconnect)
+        aliases_by_target = Hash.new { |hash, key| hash[key] = Set.new }
+
+        Array(reconnect).each do |descriptor|
+          entry = descriptor.transform_keys(&:to_sym)
+          target = entry.fetch(:to).to_sym
+          aliases = aliases_by_target[target]
+
+          graph.each_predecessor(target) do |predecessor|
+            next if predecessor == root
+
+            aliases << effective_input_key(predecessor, graph.edge_metadata(predecessor, target))
+          end
+        end
+
+        Array(reconnect).each do |descriptor|
+          entry = descriptor.transform_keys(&:to_sym)
+          target = entry.fetch(:to).to_sym
+          alias_key = effective_input_key(entry.fetch(:from), entry[:metadata] || {})
+
+          if aliases_by_target[target].include?(alias_key)
+            raise ArgumentError, "duplicate effective downstream alias for #{target}: #{alias_key}"
+          end
+
+          aliases_by_target[target] << alias_key
+        end
+      end
+
+      def effective_input_key(from, metadata)
+        (metadata[:as] || from).to_sym
       end
     end
   end

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -361,6 +361,26 @@ class ExamplesTest < Minitest::Test
     assert_includes stdout, "Publish calls: 2"
   end
 
+  def test_immutable_subtree_replacement_example_executes_successfully
+    stdout, stderr, status = run_example("examples/immutable_subtree_replacement.rb")
+
+    assert status.success?, <<~MSG
+      expected immutable_subtree_replacement example to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "=== Original Definition ==="
+    assert_includes stdout, "Original output: report:PAYLOAD"
+    assert_includes stdout, "=== Mutated Definition ==="
+    assert_includes stdout, "Mutated output: report:PAYLOAD-NORMALIZED|v1"
+    assert_includes stdout, "Original still has process? true"
+    assert_includes stdout, "Mutated has process? false"
+    assert_includes stdout, "Mutated has summarize? true"
+  end
+
   def test_graph_basics_example_executes_successfully
     stdout, stderr, status = run_example("examples/graph_basics.rb")
 

--- a/spec/mutation_test.rb
+++ b/spec/mutation_test.rb
@@ -192,4 +192,258 @@ class MutationTest < Minitest::Test
     assert_includes error.message, "report"
     assert_includes error.message, "summary"
   end
+
+  def test_graph_with_subtree_replaced_rejects_unknown_root
+    graph = DAG::Graph.new.add_node(:a).freeze
+    replacement = DAG::Graph.new.add_node(:b).freeze
+
+    assert_raises(DAG::UnknownNodeError) do
+      graph.with_subtree_replaced(root: :missing, replacement_graph: replacement)
+    end
+  end
+
+  def test_graph_with_subtree_replaced_rejects_non_graph_replacement
+    graph = DAG::Graph.new.add_node(:a).freeze
+
+    error = assert_raises(ArgumentError) do
+      graph.with_subtree_replaced(root: :a, replacement_graph: Object.new)
+    end
+
+    assert_includes error.message, "replacement_graph must be a DAG::Graph"
+  end
+
+  def test_graph_with_subtree_replaced_rejects_non_hash_reconnect_descriptor
+    graph = DAG::Graph.new
+    %i[root down].each { |n| graph.add_node(n) }
+    graph.add_edge(:root, :down)
+    graph.freeze
+    replacement = DAG::Graph.new.add_node(:leaf).freeze
+
+    error = assert_raises(ArgumentError) do
+      graph.with_subtree_replaced(
+        root: :root,
+        replacement_graph: replacement,
+        reconnect: [:oops]
+      )
+    end
+
+    assert_includes error.message, "reconnect entries must be Hashes"
+  end
+
+  def test_graph_with_subtree_replaced_rejects_reconnect_from_non_replacement_leaf
+    graph = DAG::Graph.new
+    %i[root down].each { |n| graph.add_node(n) }
+    graph.add_edge(:root, :down)
+    graph.freeze
+
+    replacement = DAG::Graph.new
+    %i[normalize summarize].each { |n| replacement.add_node(n) }
+    replacement.add_edge(:normalize, :summarize)
+    replacement.freeze
+
+    error = assert_raises(ArgumentError) do
+      graph.with_subtree_replaced(
+        root: :root,
+        replacement_graph: replacement,
+        reconnect: [{from: :normalize, to: :down, metadata: {}}]
+      )
+    end
+
+    assert_includes error.message, "must reference a replacement leaf"
+  end
+
+  def test_graph_with_subtree_replaced_rejects_reconnect_to_non_downstream_node
+    graph = DAG::Graph.new
+    %i[root down sibling].each { |n| graph.add_node(n) }
+    graph.add_edge(:root, :down)
+    graph.freeze
+
+    replacement = DAG::Graph.new.add_node(:leaf).freeze
+
+    error = assert_raises(ArgumentError) do
+      graph.with_subtree_replaced(
+        root: :root,
+        replacement_graph: replacement,
+        reconnect: [{from: :leaf, to: :sibling, metadata: {}}]
+      )
+    end
+
+    assert_includes error.message, "must reference a downstream node"
+  end
+
+  def test_graph_with_subtree_replaced_can_replace_a_root_level_node
+    graph = DAG::Graph.new
+    %i[root down].each { |n| graph.add_node(n) }
+    graph.add_edge(:root, :down, weight: 2)
+    graph.freeze
+
+    replacement = DAG::Graph.new
+    %i[normalize summarize].each { |n| replacement.add_node(n) }
+    replacement.add_edge(:normalize, :summarize)
+    replacement.freeze
+
+    result = graph.with_subtree_replaced(
+      root: :root,
+      replacement_graph: replacement,
+      reconnect: [{from: :summarize, to: :down, metadata: {weight: 2}}]
+    )
+
+    refute result.node?(:root)
+    assert_includes result.roots.to_a, :normalize
+    assert result.edge?(:summarize, :down)
+    assert_equal({weight: 2}, result.edge_metadata(:summarize, :down))
+  end
+
+  def test_graph_with_subtree_replaced_can_replace_a_leaf_node
+    graph = DAG::Graph.new
+    %i[upstream leaf].each { |n| graph.add_node(n) }
+    graph.add_edge(:upstream, :leaf, weight: 9)
+    graph.freeze
+
+    replacement = DAG::Graph.new
+    %i[normalize summarize].each { |n| replacement.add_node(n) }
+    replacement.add_edge(:normalize, :summarize, tag: :inner)
+    replacement.freeze
+
+    result = graph.with_subtree_replaced(
+      root: :leaf,
+      replacement_graph: replacement,
+      reconnect: []
+    )
+
+    refute result.node?(:leaf)
+    assert result.node?(:normalize)
+    assert result.node?(:summarize)
+    assert_equal({weight: 9}, result.edge_metadata(:upstream, :normalize))
+    assert_equal({tag: :inner}, result.edge_metadata(:normalize, :summarize))
+  end
+
+  def test_graph_with_subtree_replaced_preserves_replacement_internal_edge_metadata
+    graph = DAG::Graph.new
+    %i[source root].each { |n| graph.add_node(n) }
+    graph.add_edge(:source, :root)
+    graph.freeze
+
+    replacement = DAG::Graph.new
+    %i[a b].each { |n| replacement.add_node(n) }
+    replacement.add_edge(:a, :b, weight: 7, as: :payload)
+    replacement.freeze
+
+    result = graph.with_subtree_replaced(
+      root: :root,
+      replacement_graph: replacement,
+      reconnect: []
+    )
+
+    assert_equal({weight: 7, as: :payload}, result.edge_metadata(:a, :b))
+  end
+
+  def test_graph_with_subtree_replaced_preserves_unrelated_subgraph
+    graph = DAG::Graph.new
+    %i[source root down other1 other2].each { |n| graph.add_node(n) }
+    graph.add_edge(:source, :root)
+    graph.add_edge(:root, :down)
+    graph.add_edge(:other1, :other2, label: :independent)
+    graph.freeze
+
+    replacement = DAG::Graph.new.add_node(:leaf).freeze
+
+    result = graph.with_subtree_replaced(
+      root: :root,
+      replacement_graph: replacement,
+      reconnect: [{from: :leaf, to: :down, metadata: {}}]
+    )
+
+    assert result.node?(:other1)
+    assert result.node?(:other2)
+    assert result.edge?(:other1, :other2)
+    assert_equal({label: :independent}, result.edge_metadata(:other1, :other2))
+  end
+
+  def test_graph_with_subtree_replaced_preserves_per_predecessor_metadata_on_rewiring
+    graph = DAG::Graph.new
+    %i[p1 p2 root].each { |n| graph.add_node(n) }
+    graph.add_edge(:p1, :root, as: :left)
+    graph.add_edge(:p2, :root, as: :right)
+    graph.freeze
+
+    replacement = DAG::Graph.new.add_node(:new_root).freeze
+
+    result = graph.with_subtree_replaced(
+      root: :root,
+      replacement_graph: replacement,
+      reconnect: []
+    )
+
+    assert_equal({as: :left}, result.edge_metadata(:p1, :new_root))
+    assert_equal({as: :right}, result.edge_metadata(:p2, :new_root))
+  end
+
+  def test_workflow_replace_subtree_rejects_non_definition_first_arg
+    replacement = build_test_workflow(
+      x: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }}
+    )
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.replace_subtree(Object.new, root_node: :foo, replacement: replacement)
+    end
+
+    assert_includes error.message, "definition must be a DAG::Workflow::Definition"
+  end
+
+  def test_workflow_replace_subtree_rejects_non_definition_replacement
+    definition = build_test_workflow(
+      a: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }}
+    )
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.replace_subtree(definition, root_node: :a, replacement: Object.new)
+    end
+
+    assert_includes error.message, "replacement must be a DAG::Workflow::Definition"
+  end
+
+  def test_workflow_replace_subtree_removes_old_step_and_registers_replacement_steps
+    definition = build_test_workflow(
+      old_root: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }}
+    )
+
+    replacement = build_test_workflow(
+      new_a: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :a) }},
+      new_b: {
+        type: :ruby,
+        depends_on: [:new_a],
+        callable: ->(_) { DAG::Success.new(value: :b) }
+      }
+    )
+
+    mutated = DAG::Workflow.replace_subtree(
+      definition,
+      root_node: :old_root,
+      replacement: replacement
+    )
+
+    refute mutated.registry.key?(:old_root)
+    assert mutated.registry.key?(:new_a)
+    assert mutated.registry.key?(:new_b)
+  end
+
+  def test_workflow_replace_subtree_preserves_source_path
+    base = build_test_workflow(
+      root: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }}
+    )
+    definition = base.with(source_path: "/tmp/example.yml")
+
+    replacement = build_test_workflow(
+      new_root: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }}
+    )
+
+    mutated = DAG::Workflow.replace_subtree(
+      definition,
+      root_node: :root,
+      replacement: replacement
+    )
+
+    assert_equal "/tmp/example.yml", mutated.source_path
+  end
 end

--- a/spec/mutation_test.rb
+++ b/spec/mutation_test.rb
@@ -501,6 +501,38 @@ class MutationTest < Minitest::Test
     assert_equal "report:PAYLOAD", result.outputs[:report].value
   end
 
+  def test_workflow_replace_subtree_detects_duplicate_alias_with_string_keyed_metadata
+    definition = build_test_workflow(
+      source: {type: :ruby, callable: ->(_) { DAG::Success.new(value: "payload") }},
+      config: {type: :ruby, callable: ->(_) { DAG::Success.new(value: "v1") }},
+      process: {
+        type: :ruby,
+        depends_on: [:source],
+        callable: ->(_) { DAG::Success.new(value: "ok") }
+      },
+      report: {
+        type: :ruby,
+        depends_on: [:process, {from: :config, as: :summary}],
+        callable: ->(input) { DAG::Success.new(value: input[:summary]) }
+      }
+    )
+
+    replacement = build_test_workflow(
+      summarize: {type: :ruby, callable: ->(_) { DAG::Success.new(value: "s") }}
+    )
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.replace_subtree(
+        definition,
+        root_node: :process,
+        replacement: replacement,
+        reconnect: [{from: :summarize, to: :report, metadata: {"as" => :summary}}]
+      )
+    end
+
+    assert_includes error.message, "duplicate effective downstream alias"
+  end
+
   def test_workflow_replace_subtree_preserves_source_path
     base = build_test_workflow(
       root: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }}

--- a/spec/mutation_test.rb
+++ b/spec/mutation_test.rb
@@ -428,6 +428,79 @@ class MutationTest < Minitest::Test
     assert mutated.registry.key?(:new_b)
   end
 
+  def test_graph_with_subtree_replaced_preserves_original_edge_metadata_when_reconnect_omits_metadata
+    graph = DAG::Graph.new
+    %i[root down].each { |n| graph.add_node(n) }
+    graph.add_edge(:root, :down, as: :summary, weight: 3)
+    graph.freeze
+
+    replacement = DAG::Graph.new.add_node(:leaf).freeze
+
+    result = graph.with_subtree_replaced(
+      root: :root,
+      replacement_graph: replacement,
+      reconnect: [{from: :leaf, to: :down}]
+    )
+
+    assert_equal({as: :summary, weight: 3}, result.edge_metadata(:leaf, :down))
+  end
+
+  def test_graph_with_subtree_replaced_merges_explicit_reconnect_metadata_over_original
+    graph = DAG::Graph.new
+    %i[root down].each { |n| graph.add_node(n) }
+    graph.add_edge(:root, :down, as: :old_alias, weight: 1)
+    graph.freeze
+
+    replacement = DAG::Graph.new.add_node(:leaf).freeze
+
+    result = graph.with_subtree_replaced(
+      root: :root,
+      replacement_graph: replacement,
+      reconnect: [{from: :leaf, to: :down, metadata: {as: :new_alias}}]
+    )
+
+    assert_equal({as: :new_alias, weight: 1}, result.edge_metadata(:leaf, :down))
+  end
+
+  def test_workflow_replace_subtree_preserves_downstream_alias_without_explicit_metadata
+    definition = build_test_workflow(
+      source: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "payload") }
+      },
+      process: {
+        type: :ruby,
+        depends_on: [:source],
+        callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+      },
+      report: {
+        type: :ruby,
+        depends_on: [{from: :process, as: :summary}],
+        callable: ->(input) { DAG::Success.new(value: "report:#{input[:summary]}") }
+      }
+    )
+
+    replacement = build_test_workflow(
+      summary: {
+        type: :ruby,
+        callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+      }
+    )
+
+    mutated = DAG::Workflow.replace_subtree(
+      definition,
+      root_node: :process,
+      replacement: replacement,
+      reconnect: [{from: :summary, to: :report}]
+    )
+
+    assert_equal({as: :summary}, mutated.graph.edge_metadata(:summary, :report))
+
+    result = DAG::Workflow::Runner.new(mutated, parallel: false).call
+    assert result.success?
+    assert_equal "report:PAYLOAD", result.outputs[:report].value
+  end
+
   def test_workflow_replace_subtree_preserves_source_path
     base = build_test_workflow(
       root: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }}

--- a/spec/mutation_test.rb
+++ b/spec/mutation_test.rb
@@ -102,4 +102,94 @@ class MutationTest < Minitest::Test
     assert definition.graph.node?(:process)
     refute definition.graph.node?(:normalize)
   end
+
+  def test_workflow_replace_subtree_preserves_unaffected_downstream_inputs
+    definition = build_test_workflow(
+      source: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "payload") }
+      },
+      config: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "v1") }
+      },
+      process: {
+        type: :ruby,
+        depends_on: [:source],
+        callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+      },
+      report: {
+        type: :ruby,
+        depends_on: [{from: :process, as: :summary}, :config],
+        callable: ->(input) { DAG::Success.new(value: "#{input[:summary]}|#{input[:config]}") }
+      }
+    )
+
+    replacement = build_test_workflow(
+      normalize: {
+        type: :ruby,
+        callable: ->(input) { DAG::Success.new(value: "#{input[:source]}-normalized") }
+      },
+      summarize: {
+        type: :ruby,
+        depends_on: [:normalize],
+        callable: ->(input) { DAG::Success.new(value: input[:normalize].upcase) }
+      }
+    )
+
+    mutated = DAG::Workflow.replace_subtree(
+      definition,
+      root_node: :process,
+      replacement: replacement,
+      reconnect: [{from: :summarize, to: :report, metadata: {as: :summary}}]
+    )
+
+    result = DAG::Workflow::Runner.new(mutated, parallel: false).call
+
+    assert result.success?
+    assert_equal "PAYLOAD-NORMALIZED|v1", result.outputs[:report].value
+  end
+
+  def test_workflow_replace_subtree_rejects_duplicate_effective_downstream_aliases
+    definition = build_test_workflow(
+      source: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "payload") }
+      },
+      config: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "v1") }
+      },
+      process: {
+        type: :ruby,
+        depends_on: [:source],
+        callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+      },
+      report: {
+        type: :ruby,
+        depends_on: [:process, {from: :config, as: :summary}],
+        callable: ->(input) { DAG::Success.new(value: input[:summary]) }
+      }
+    )
+
+    replacement = build_test_workflow(
+      summarize: {
+        type: :ruby,
+        callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+      }
+    )
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.replace_subtree(
+        definition,
+        root_node: :process,
+        replacement: replacement,
+        reconnect: [{from: :summarize, to: :report, metadata: {as: :summary}}]
+      )
+    end
+
+    assert_includes error.message, "duplicate effective downstream alias"
+    assert_includes error.message, "report"
+    assert_includes error.message, "summary"
+  end
 end

--- a/spec/mutation_test.rb
+++ b/spec/mutation_test.rb
@@ -569,6 +569,48 @@ class MutationTest < Minitest::Test
     assert_includes error.message, "duplicate effective downstream alias"
   end
 
+  def test_workflow_replace_subtree_rejects_reconnect_without_from
+    definition = build_test_workflow(
+      process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }},
+      report: {type: :ruby, depends_on: [:process], callable: ->(_) { DAG::Success.new(value: :ok) }}
+    )
+    replacement = build_test_workflow(
+      leaf: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }}
+    )
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.replace_subtree(
+        definition,
+        root_node: :process,
+        replacement: replacement,
+        reconnect: [{to: :report}]
+      )
+    end
+
+    assert_includes error.message, "reconnect entries must include :from"
+  end
+
+  def test_workflow_replace_subtree_rejects_reconnect_without_to
+    definition = build_test_workflow(
+      process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }},
+      report: {type: :ruby, depends_on: [:process], callable: ->(_) { DAG::Success.new(value: :ok) }}
+    )
+    replacement = build_test_workflow(
+      leaf: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }}
+    )
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.replace_subtree(
+        definition,
+        root_node: :process,
+        replacement: replacement,
+        reconnect: [{from: :leaf}]
+      )
+    end
+
+    assert_includes error.message, "reconnect entries must include :to"
+  end
+
   def test_workflow_replace_subtree_preserves_source_path
     base = build_test_workflow(
       root: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :ok) }}

--- a/spec/mutation_test.rb
+++ b/spec/mutation_test.rb
@@ -230,6 +230,42 @@ class MutationTest < Minitest::Test
     assert_includes error.message, "reconnect entries must be Hashes"
   end
 
+  def test_graph_with_subtree_replaced_rejects_reconnect_without_from
+    graph = DAG::Graph.new
+    %i[root down].each { |n| graph.add_node(n) }
+    graph.add_edge(:root, :down)
+    graph.freeze
+    replacement = DAG::Graph.new.add_node(:leaf).freeze
+
+    error = assert_raises(ArgumentError) do
+      graph.with_subtree_replaced(
+        root: :root,
+        replacement_graph: replacement,
+        reconnect: [{to: :down}]
+      )
+    end
+
+    assert_includes error.message, "reconnect entries must include :from"
+  end
+
+  def test_graph_with_subtree_replaced_rejects_reconnect_without_to
+    graph = DAG::Graph.new
+    %i[root down].each { |n| graph.add_node(n) }
+    graph.add_edge(:root, :down)
+    graph.freeze
+    replacement = DAG::Graph.new.add_node(:leaf).freeze
+
+    error = assert_raises(ArgumentError) do
+      graph.with_subtree_replaced(
+        root: :root,
+        replacement_graph: replacement,
+        reconnect: [{from: :leaf}]
+      )
+    end
+
+    assert_includes error.message, "reconnect entries must include :to"
+  end
+
   def test_graph_with_subtree_replaced_rejects_reconnect_from_non_replacement_leaf
     graph = DAG::Graph.new
     %i[root down].each { |n| graph.add_node(n) }


### PR DESCRIPTION
## Summary
- validate duplicate effective downstream aliases when using immutable subtree replacement
- preserve unaffected downstream inputs while reconnecting replacement leaves
- add a runnable example for immutable subtree replacement

## Test Plan
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/mutation_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/examples_test.rb TESTOPTS='--name=/immutable_subtree_replacement/'
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake