### PR TITLE
feat: add subtree replacement impact helper

### DIFF
--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -3,6 +3,25 @@
 module DAG
   module Workflow
     class << self
+      def subtree_replacement_impact(workflow_id:, definition:, root_node:, execution_store:)
+        raise ArgumentError, "definition must be a DAG::Workflow::Definition" unless definition.is_a?(Definition)
+
+        run = execution_store.load_run(workflow_id)
+        return {obsolete_nodes: [], stale_nodes: []} unless run
+
+        root = mutation_node_path(root_node)
+        obsolete_nodes = node_completed?(run, root) ? [root] : []
+        stale_nodes = definition.graph.descendants(root.last).sort.each_with_object([]) do |name, nodes|
+          node_path = mutation_node_path(name)
+          nodes << node_path if node_completed?(run, node_path)
+        end
+
+        {
+          obsolete_nodes: obsolete_nodes.sort_by { |node_path| node_path.map(&:to_s) },
+          stale_nodes: stale_nodes.sort_by { |node_path| node_path.map(&:to_s) }
+        }
+      end
+
       def replace_subtree(definition, root_node:, replacement:, reconnect: [])
         raise ArgumentError, "definition must be a DAG::Workflow::Definition" unless definition.is_a?(Definition)
         raise ArgumentError, "replacement must be a DAG::Workflow::Definition" unless replacement.is_a?(Definition)
@@ -71,6 +90,14 @@ module DAG
 
       def effective_input_key(from, metadata)
         (metadata[:as] || from).to_sym
+      end
+
+      def node_completed?(run, node_path)
+        run.dig(:nodes, node_path, :state) == :completed
+      end
+
+      def mutation_node_path(node_path)
+        Array(node_path).map(&:to_sym).freeze
       end
     end
   end

--- a/spec/mutation_impact_test.rb
+++ b/spec/mutation_impact_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class MutationImpactTest < Minitest::Test
+  include TestHelpers
+
+  def test_subtree_replacement_impact_returns_obsolete_root_and_completed_stale_descendants
+    store = build_memory_store
+    definition = build_test_workflow(
+      source: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :source) }},
+      process: {type: :ruby, depends_on: [:source], callable: ->(_) { DAG::Success.new(value: :process) }},
+      report: {type: :ruby, depends_on: [:process], callable: ->(_) { DAG::Success.new(value: :report) }},
+      notify: {type: :ruby, depends_on: [:report], callable: ->(_) { DAG::Success.new(value: :notify) }}
+    )
+
+    store.begin_run(
+      workflow_id: "wf-mutation-impact",
+      definition_fingerprint: "fp-1",
+      node_paths: [[:source], [:process], [:report], [:notify]]
+    )
+    store.set_node_state(workflow_id: "wf-mutation-impact", node_path: [:process], state: :completed)
+    store.set_node_state(workflow_id: "wf-mutation-impact", node_path: [:report], state: :completed)
+    store.set_node_state(workflow_id: "wf-mutation-impact", node_path: [:notify], state: :waiting)
+
+    impact = DAG::Workflow.subtree_replacement_impact(
+      workflow_id: "wf-mutation-impact",
+      definition: definition,
+      root_node: :process,
+      execution_store: store
+    )
+
+    assert_equal [[:process]], impact[:obsolete_nodes]
+    assert_equal [[:report]], impact[:stale_nodes]
+  end
+
+  def test_subtree_replacement_impact_returns_empty_arrays_when_run_missing
+    definition = build_test_workflow(
+      process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :process) }}
+    )
+
+    impact = DAG::Workflow.subtree_replacement_impact(
+      workflow_id: "wf-missing",
+      definition: definition,
+      root_node: :process,
+      execution_store: build_memory_store
+    )
+
+    assert_equal [], impact[:obsolete_nodes]
+    assert_equal [], impact[:stale_nodes]
+  end
+end


### PR DESCRIPTION
## Summary
- add `DAG::Workflow.subtree_replacement_impact(...)` as a read-only helper for planning immutable subtree replacement against persisted execution state
- report completed root nodes as `obsolete_nodes`
- report completed downstream descendants as `stale_nodes`

## Test Plan
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/mutation_impact_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/mutation_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake