### PR TITLE
feat: apply subtree replacement impact to persisted state

### DIFF
--- a/lib/dag/workflow/execution_store.rb
+++ b/lib/dag/workflow/execution_store.rb
@@ -107,17 +107,23 @@ module DAG
         end
 
         def mark_stale(workflow_id:, node_paths:, cause:)
-          run = ensure_run(workflow_id)
-          Array(node_paths).each do |node_path|
-            node = ensure_node(run, node_path)
-            node[:state] = :stale
-            node[:stale_cause] = deep_copy(cause)
-            Array(node[:outputs]).each do |output|
-              output[:superseded] = true if output[:reusable]
-            end
-          end
-          write_run(run)
-          nil
+          mark_nodes(
+            workflow_id: workflow_id,
+            node_paths: node_paths,
+            state: :stale,
+            cause_key: :stale_cause,
+            cause: cause
+          )
+        end
+
+        def mark_obsolete(workflow_id:, node_paths:, cause:)
+          mark_nodes(
+            workflow_id: workflow_id,
+            node_paths: node_paths,
+            state: :obsolete,
+            cause_key: :obsolete_cause,
+            cause: cause
+          )
         end
 
         def set_workflow_status(workflow_id:, status:, waiting_nodes: [])
@@ -142,6 +148,20 @@ module DAG
         end
 
         private
+
+        def mark_nodes(workflow_id:, node_paths:, state:, cause_key:, cause:)
+          run = ensure_run(workflow_id)
+          Array(node_paths).each do |node_path|
+            node = ensure_node(run, node_path)
+            node[:state] = state
+            node[cause_key] = deep_copy(cause)
+            Array(node[:outputs]).each do |output|
+              output[:superseded] = true if output[:reusable]
+            end
+          end
+          write_run(run)
+          nil
+        end
 
         def ensure_run(workflow_id)
           load_run(workflow_id) || raise(ArgumentError, "unknown workflow_id: #{workflow_id.inspect}")
@@ -277,15 +297,23 @@ module DAG
         end
 
         def mark_stale(workflow_id:, node_paths:, cause:)
-          Array(node_paths).each do |node_path|
-            node = ensure_node(workflow_id, node_path)
-            node[:state] = :stale
-            node[:stale_cause] = deep_copy(cause)
-            Array(node[:outputs]).each do |output|
-              output[:superseded] = true if output[:reusable]
-            end
-          end
-          nil
+          mark_nodes(
+            workflow_id: workflow_id,
+            node_paths: node_paths,
+            state: :stale,
+            cause_key: :stale_cause,
+            cause: cause
+          )
+        end
+
+        def mark_obsolete(workflow_id:, node_paths:, cause:)
+          mark_nodes(
+            workflow_id: workflow_id,
+            node_paths: node_paths,
+            state: :obsolete,
+            cause_key: :obsolete_cause,
+            cause: cause
+          )
         end
 
         def set_workflow_status(workflow_id:, status:, waiting_nodes: [])
@@ -306,6 +334,18 @@ module DAG
         end
 
         private
+
+        def mark_nodes(workflow_id:, node_paths:, state:, cause_key:, cause:)
+          Array(node_paths).each do |node_path|
+            node = ensure_node(workflow_id, node_path)
+            node[:state] = state
+            node[cause_key] = deep_copy(cause)
+            Array(node[:outputs]).each do |output|
+              output[:superseded] = true if output[:reusable]
+            end
+          end
+          nil
+        end
 
         def ensure_run(workflow_id)
           @runs.fetch(workflow_id) do

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -22,6 +22,35 @@ module DAG
         }
       end
 
+      def apply_subtree_replacement_impact(workflow_id:, definition:, root_node:, execution_store:, cause: nil)
+        impact = subtree_replacement_impact(
+          workflow_id: workflow_id,
+          definition: definition,
+          root_node: root_node,
+          execution_store: execution_store
+        )
+        root = mutation_node_path(root_node)
+        normalized_cause = subtree_replacement_cause(root, cause)
+
+        unless impact[:obsolete_nodes].empty?
+          execution_store.mark_obsolete(
+            workflow_id: workflow_id,
+            node_paths: impact[:obsolete_nodes],
+            cause: normalized_cause
+          )
+        end
+
+        unless impact[:stale_nodes].empty?
+          execution_store.mark_stale(
+            workflow_id: workflow_id,
+            node_paths: impact[:stale_nodes],
+            cause: normalized_cause
+          )
+        end
+
+        impact
+      end
+
       def replace_subtree(definition, root_node:, replacement:, reconnect: [])
         raise ArgumentError, "definition must be a DAG::Workflow::Definition" unless definition.is_a?(Definition)
         raise ArgumentError, "replacement must be a DAG::Workflow::Definition" unless replacement.is_a?(Definition)
@@ -90,6 +119,20 @@ module DAG
 
       def effective_input_key(from, metadata)
         (metadata[:as] || from).to_sym
+      end
+
+      def subtree_replacement_cause(root, custom_cause)
+        {code: :subtree_replaced}.merge(normalize_subtree_replacement_cause(custom_cause)).merge(replaced_from: root)
+      end
+
+      def normalize_subtree_replacement_cause(cause)
+        return {} if cause.nil?
+        raise ArgumentError, "cause must be a Hash" unless cause.is_a?(Hash)
+
+        normalized = cause.transform_keys(&:to_sym)
+        raise ArgumentError, "cause cannot override replaced_from" if normalized.key?(:replaced_from)
+
+        normalized
       end
 
       def node_completed?(run, node_path)

--- a/spec/execution_store_test.rb
+++ b/spec/execution_store_test.rb
@@ -151,6 +151,34 @@ class ExecutionStoreTest < Minitest::Test
     assert_equal [true], history.map { |entry| entry[:superseded] }
   end
 
+  def test_mark_obsolete_supersedes_reusable_outputs_and_records_obsolete_cause
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    store.begin_run(workflow_id: "wf-obsolete", definition_fingerprint: "fp-1", node_paths: [[:fetch]])
+    store.save_output(
+      workflow_id: "wf-obsolete",
+      node_path: [:fetch],
+      version: 1,
+      result: DAG::Success.new(value: "v1"),
+      reusable: true,
+      superseded: false
+    )
+
+    store.mark_obsolete(
+      workflow_id: "wf-obsolete",
+      node_paths: [[:fetch]],
+      cause: {code: :subtree_replaced, replaced_from: [:fetch]}
+    )
+
+    node = store.load_node(workflow_id: "wf-obsolete", node_path: [:fetch])
+    assert_equal :obsolete, node[:state]
+    assert_equal({code: :subtree_replaced, replaced_from: [:fetch]}, node[:obsolete_cause])
+    assert_nil store.load_output(workflow_id: "wf-obsolete", node_path: [:fetch])
+
+    history = store.load_output(workflow_id: "wf-obsolete", node_path: [:fetch], version: :all)
+    assert_equal [1], history.map { |entry| entry[:version] }
+    assert_equal [true], history.map { |entry| entry[:superseded] }
+  end
+
   def test_file_store_persists_runs_outputs_and_trace_across_instances
     Dir.mktmpdir("dag-file-store") do |dir|
       store = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)

--- a/spec/mutation_impact_test.rb
+++ b/spec/mutation_impact_test.rb
@@ -34,6 +34,81 @@ class MutationImpactTest < Minitest::Test
     assert_equal [[:report]], impact[:stale_nodes]
   end
 
+  def test_apply_subtree_replacement_impact_marks_obsolete_root_and_stale_completed_descendants
+    store = build_memory_store
+    definition = build_test_workflow(
+      source: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :source) }},
+      process: {type: :ruby, depends_on: [:source], callable: ->(_) { DAG::Success.new(value: :process) }},
+      report: {type: :ruby, depends_on: [:process], callable: ->(_) { DAG::Success.new(value: :report) }},
+      notify: {type: :ruby, depends_on: [:report], callable: ->(_) { DAG::Success.new(value: :notify) }}
+    )
+
+    store.begin_run(
+      workflow_id: "wf-apply-impact",
+      definition_fingerprint: "fp-1",
+      node_paths: [[:source], [:process], [:report], [:notify]]
+    )
+    save_completed_output(store, workflow_id: "wf-apply-impact", node_path: [:process], version: 1, value: :process_v1)
+    save_completed_output(store, workflow_id: "wf-apply-impact", node_path: [:report], version: 1, value: :report_v1)
+    store.set_node_state(workflow_id: "wf-apply-impact", node_path: [:notify], state: :waiting)
+
+    impact = DAG::Workflow.apply_subtree_replacement_impact(
+      workflow_id: "wf-apply-impact",
+      definition: definition,
+      root_node: :process,
+      execution_store: store,
+      cause: {source: :planner}
+    )
+
+    assert_equal [[:process]], impact[:obsolete_nodes]
+    assert_equal [[:report]], impact[:stale_nodes]
+
+    process = store.load_node(workflow_id: "wf-apply-impact", node_path: [:process])
+    report = store.load_node(workflow_id: "wf-apply-impact", node_path: [:report])
+    notify = store.load_node(workflow_id: "wf-apply-impact", node_path: [:notify])
+
+    assert_equal :obsolete, process[:state]
+    assert_equal :subtree_replaced, process[:obsolete_cause][:code]
+    assert_equal :planner, process[:obsolete_cause][:source]
+    assert_equal [:process], process[:obsolete_cause][:replaced_from]
+
+    assert_equal :stale, report[:state]
+    assert_equal :subtree_replaced, report[:stale_cause][:code]
+    assert_equal :planner, report[:stale_cause][:source]
+    assert_equal [:process], report[:stale_cause][:replaced_from]
+
+    assert_equal :waiting, notify[:state]
+    assert_nil store.load_output(workflow_id: "wf-apply-impact", node_path: [:process])
+    assert_nil store.load_output(workflow_id: "wf-apply-impact", node_path: [:report])
+    assert_equal [true], store.load_output(workflow_id: "wf-apply-impact", node_path: [:process], version: :all).map { |entry| entry[:superseded] }
+    assert_equal [true], store.load_output(workflow_id: "wf-apply-impact", node_path: [:report], version: :all).map { |entry| entry[:superseded] }
+  end
+
+  def test_apply_subtree_replacement_impact_rejects_replaced_from_override
+    definition = build_test_workflow(
+      process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :process) }}
+    )
+    store = build_memory_store
+    store.begin_run(
+      workflow_id: "wf-invalid-impact-cause",
+      definition_fingerprint: "fp-1",
+      node_paths: [[:process]]
+    )
+    store.set_node_state(workflow_id: "wf-invalid-impact-cause", node_path: [:process], state: :completed)
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.apply_subtree_replacement_impact(
+        workflow_id: "wf-invalid-impact-cause",
+        definition: definition,
+        root_node: :process,
+        execution_store: store,
+        cause: {replaced_from: [:other]}
+      )
+    end
+
+    assert_match(/replaced_from/, error.message)
+  end
+
   def test_subtree_replacement_impact_returns_empty_arrays_when_run_missing
     definition = build_test_workflow(
       process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :process) }}
@@ -48,5 +123,19 @@ class MutationImpactTest < Minitest::Test
 
     assert_equal [], impact[:obsolete_nodes]
     assert_equal [], impact[:stale_nodes]
+  end
+
+  private
+
+  def save_completed_output(store, workflow_id:, node_path:, version:, value:)
+    store.set_node_state(workflow_id: workflow_id, node_path: node_path, state: :completed)
+    store.save_output(
+      workflow_id: workflow_id,
+      node_path: node_path,
+      version: version,
+      result: DAG::Success.new(value: value),
+      reusable: true,
+      superseded: false
+    )
   end
 end


### PR DESCRIPTION
## Summary
- add `apply_subtree_replacement_impact` to mark persisted obsolete/stale nodes after immutable subtree replacement planning
- add `ExecutionStore#mark_obsolete` alongside shared state-marking logic in memory and file stores
- cover obsolete/stale persistence and cause validation with focused mutation/execution store tests

## Testing
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/mutation_impact_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/execution_store_test.rb
- TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake
