### PR TITLE
feat: guard subtree mutation impact on running roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,39 @@ Notes:
 - `max_cascade_depth:` limits how far descendants are traversed from the invalidated root
 - see `examples/invalidation_cascade.rb`, `examples/nested_invalidation_cascade.rb`, and `examples/yaml_nested_invalidation_cascade.rb` for runnable end-to-end examples exercised in the test suite
 
+### Dynamic graph mutation impact
+
+Subtree replacement is a between-invocations operation: first derive a new
+workflow definition with `replace_subtree`, then inspect/apply the persisted
+state impact for the branch being replaced.
+
+```ruby
+impact = DAG::Workflow.subtree_replacement_impact(
+  workflow_id: "demo-mutation",
+  definition: workflow,
+  root_node: :process,
+  execution_store: store
+)
+
+DAG::Workflow.apply_subtree_replacement_impact(
+  workflow_id: "demo-mutation",
+  definition: workflow,
+  root_node: :process,
+  execution_store: store,
+  cause: {source: :planner}
+)
+```
+
+Notes:
+- `subtree_replacement_impact` is read-only and returns `{obsolete_nodes:, stale_nodes:}`
+- the replaced root is included in `obsolete_nodes` only when it is currently `:completed`
+- completed downstream descendants reachable from the replaced root are included in `stale_nodes`
+- `apply_subtree_replacement_impact` marks obsolete roots with `obsolete_cause` and stale descendants with `stale_cause`
+- both helpers preserve audit history by superseding reusable outputs instead of deleting historical versions
+- the replaced root cannot currently be `:running`; mutation is only legal between runner invocations
+- `cause:` accepts any Hash merged into the stored transition cause, but `replaced_from` is reserved and always set from `root_node`
+- see `examples/immutable_subtree_replacement.rb` for definition mutation and `examples/subtree_replacement_impact.rb` for runnable persisted-state impact planning/application
+
 ### Waiting and not_before scheduling
 
 Scheduling is eligibility-based. The runner does not sleep: if a node has a

--- a/examples/subtree_replacement_impact.rb
+++ b/examples/subtree_replacement_impact.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# Dynamic graph mutation impact: inspect which persisted nodes become obsolete or
+# stale before applying a subtree replacement transition.
+#
+# Run: ruby -Ilib examples/subtree_replacement_impact.rb
+
+require "dag"
+
+store = DAG::Workflow::ExecutionStore::MemoryStore.new
+workflow = DAG::Workflow::Loader.from_hash(
+  source: {
+    type: :ruby,
+    callable: ->(_input) { DAG::Success.new(value: "payload") }
+  },
+  process: {
+    type: :ruby,
+    depends_on: [:source],
+    callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+  },
+  report: {
+    type: :ruby,
+    depends_on: [:process],
+    callable: ->(input) { DAG::Success.new(value: "report:#{input[:process]}") }
+  },
+  notify: {
+    type: :ruby,
+    depends_on: [:report],
+    callable: ->(input) { DAG::Success.new(value: "notify:#{input[:report]}") }
+  }
+)
+
+store.begin_run(
+  workflow_id: "example-subtree-impact",
+  definition_fingerprint: "fp-1",
+  node_paths: [[:source], [:process], [:report], [:notify]]
+)
+store.set_node_state(workflow_id: "example-subtree-impact", node_path: [:source], state: :completed)
+store.set_node_state(workflow_id: "example-subtree-impact", node_path: [:process], state: :completed)
+store.set_node_state(workflow_id: "example-subtree-impact", node_path: [:report], state: :completed)
+store.set_node_state(workflow_id: "example-subtree-impact", node_path: [:notify], state: :waiting)
+store.save_output(
+  workflow_id: "example-subtree-impact",
+  node_path: [:process],
+  version: 1,
+  result: DAG::Success.new(value: "PAYLOAD"),
+  reusable: true,
+  superseded: false
+)
+store.save_output(
+  workflow_id: "example-subtree-impact",
+  node_path: [:report],
+  version: 1,
+  result: DAG::Success.new(value: "report:PAYLOAD"),
+  reusable: true,
+  superseded: false
+)
+
+impact = DAG::Workflow.subtree_replacement_impact(
+  workflow_id: "example-subtree-impact",
+  definition: workflow,
+  root_node: :process,
+  execution_store: store
+)
+
+DAG::Workflow.apply_subtree_replacement_impact(
+  workflow_id: "example-subtree-impact",
+  definition: workflow,
+  root_node: :process,
+  execution_store: store,
+  cause: {source: :planner}
+)
+
+process_node = store.load_node(workflow_id: "example-subtree-impact", node_path: [:process])
+report_node = store.load_node(workflow_id: "example-subtree-impact", node_path: [:report])
+
+running_store = DAG::Workflow::ExecutionStore::MemoryStore.new
+running_store.begin_run(
+  workflow_id: "example-subtree-impact-running",
+  definition_fingerprint: "fp-1",
+  node_paths: [[:process], [:report]]
+)
+running_store.set_node_state(workflow_id: "example-subtree-impact-running", node_path: [:process], state: :running)
+
+running_root_error = begin
+  DAG::Workflow.subtree_replacement_impact(
+    workflow_id: "example-subtree-impact-running",
+    definition: workflow,
+    root_node: :process,
+    execution_store: running_store
+  )
+  "no error"
+rescue ArgumentError => e
+  e.message
+end
+
+puts "=== Planned Impact ==="
+puts "Obsolete nodes: #{impact[:obsolete_nodes].inspect}"
+puts "Stale nodes: #{impact[:stale_nodes].inspect}"
+puts "=== Applied Impact ==="
+puts "Process state: #{process_node[:state]}"
+puts "Report state: #{report_node[:state]}"
+puts "Report stale cause code: #{report_node[:stale_cause][:code]}"
+puts "Report stale cause source: #{report_node[:stale_cause][:source]}"
+puts "Running-root guard: #{running_root_error}"

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -10,6 +10,8 @@ module DAG
         return {obsolete_nodes: [], stale_nodes: []} unless run
 
         root = mutation_node_path(root_node)
+        raise_if_running_mutation_root!(run, root)
+
         obsolete_nodes = node_completed?(run, root) ? [root] : []
         stale_nodes = definition.graph.descendants(root.last).sort.each_with_object([]) do |name, nodes|
           node_path = mutation_node_path(name)
@@ -137,6 +139,12 @@ module DAG
 
       def node_completed?(run, node_path)
         run.dig(:nodes, node_path, :state) == :completed
+      end
+
+      def raise_if_running_mutation_root!(run, root)
+        return unless run.dig(:nodes, root, :state) == :running
+
+        raise ArgumentError, "replaced subtree root cannot currently be :running"
       end
 
       def mutation_node_path(node_path)

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -192,6 +192,27 @@ class ExamplesTest < Minitest::Test
     assert_includes stdout, "Stored versions: [1, 2]"
   end
 
+  def test_subtree_replacement_impact_example_executes_successfully
+    stdout, stderr, status = run_example("examples/subtree_replacement_impact.rb")
+
+    assert status.success?, <<~MSG
+      expected subtree_replacement_impact example to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "=== Planned Impact ==="
+    assert_includes stdout, "Obsolete nodes: [[:process]]"
+    assert_includes stdout, "Stale nodes: [[:report]]"
+    assert_includes stdout, "=== Applied Impact ==="
+    assert_includes stdout, "Process state: obsolete"
+    assert_includes stdout, "Report state: stale"
+    assert_includes stdout, "Report stale cause code: subtree_replaced"
+    assert_includes stdout, "Running-root guard: replaced subtree root cannot currently be :running"
+  end
+
   def test_missing_requested_version_waiting_example_executes_successfully
     stdout, stderr, status = run_example("examples/missing_requested_version_waiting.rb")
 

--- a/spec/mutation_impact_test.rb
+++ b/spec/mutation_impact_test.rb
@@ -109,6 +109,56 @@ class MutationImpactTest < Minitest::Test
     assert_match(/replaced_from/, error.message)
   end
 
+  def test_subtree_replacement_impact_rejects_running_root
+    definition = build_test_workflow(
+      process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :process) }},
+      report: {type: :ruby, depends_on: [:process], callable: ->(_) { DAG::Success.new(value: :report) }}
+    )
+    store = build_memory_store
+    store.begin_run(
+      workflow_id: "wf-running-root",
+      definition_fingerprint: "fp-1",
+      node_paths: [[:process], [:report]]
+    )
+    store.set_node_state(workflow_id: "wf-running-root", node_path: [:process], state: :running)
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.subtree_replacement_impact(
+        workflow_id: "wf-running-root",
+        definition: definition,
+        root_node: :process,
+        execution_store: store
+      )
+    end
+
+    assert_match(/currently be :running/, error.message)
+  end
+
+  def test_apply_subtree_replacement_impact_rejects_running_root
+    definition = build_test_workflow(
+      process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :process) }},
+      report: {type: :ruby, depends_on: [:process], callable: ->(_) { DAG::Success.new(value: :report) }}
+    )
+    store = build_memory_store
+    store.begin_run(
+      workflow_id: "wf-running-root-apply",
+      definition_fingerprint: "fp-1",
+      node_paths: [[:process], [:report]]
+    )
+    store.set_node_state(workflow_id: "wf-running-root-apply", node_path: [:process], state: :running)
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.apply_subtree_replacement_impact(
+        workflow_id: "wf-running-root-apply",
+        definition: definition,
+        root_node: :process,
+        execution_store: store
+      )
+    end
+
+    assert_match(/currently be :running/, error.message)
+  end
+
   def test_subtree_replacement_impact_returns_empty_arrays_when_run_missing
     definition = build_test_workflow(
       process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :process) }}


### PR DESCRIPTION
## Summary
- reject subtree mutation impact planning/application when the replaced root is currently `:running`
- add a runnable `subtree_replacement_impact` example and wire it into `spec/examples_test.rb`
- document the persisted-state mutation impact helpers in the README

## Test Plan
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`

## Notes
- keeps Feature 8 aligned with the roadmap rule that subtree mutation is legal only between runner invocations
- preserves the existing local untracked planning files untouched
