### PR TITLE
feat: support reruns after subtree replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,8 @@ DAG::Workflow.apply_subtree_replacement_impact(
   definition: workflow,
   root_node: :process,
   execution_store: store,
-  cause: {source: :planner}
+  cause: {source: :planner},
+  new_definition: mutated_workflow
 )
 ```
 
@@ -405,6 +406,7 @@ Notes:
 - the replaced root is included in `obsolete_nodes` only when it is currently `:completed`
 - completed downstream descendants reachable from the replaced root are included in `stale_nodes`
 - `apply_subtree_replacement_impact` marks obsolete roots with `obsolete_cause` and stale descendants with `stale_cause`
+- pass `new_definition:` when you want the persisted run fingerprint and known node paths updated for the next runner invocation against the mutated workflow
 - both helpers preserve audit history by superseding reusable outputs instead of deleting historical versions
 - the replaced root cannot currently be `:running`; mutation is only legal between runner invocations
 - `cause:` accepts any Hash merged into the stored transition cause, but `replaced_from` is reserved and always set from `root_node`

--- a/examples/subtree_replacement_impact.rb
+++ b/examples/subtree_replacement_impact.rb
@@ -11,23 +11,48 @@ store = DAG::Workflow::ExecutionStore::MemoryStore.new
 workflow = DAG::Workflow::Loader.from_hash(
   source: {
     type: :ruby,
+    resume_key: "source-v1",
     callable: ->(_input) { DAG::Success.new(value: "payload") }
   },
   process: {
     type: :ruby,
     depends_on: [:source],
+    resume_key: "process-v1",
     callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
   },
   report: {
     type: :ruby,
     depends_on: [:process],
+    resume_key: "report-v1",
     callable: ->(input) { DAG::Success.new(value: "report:#{input[:process]}") }
   },
   notify: {
     type: :ruby,
     depends_on: [:report],
+    resume_key: "notify-v1",
     callable: ->(input) { DAG::Success.new(value: "notify:#{input[:report]}") }
   }
+)
+
+replacement = DAG::Workflow::Loader.from_hash(
+  normalize: {
+    type: :ruby,
+    resume_key: "normalize-v1",
+    callable: ->(input) { DAG::Success.new(value: "#{input[:source]}-normalized") }
+  },
+  summarize: {
+    type: :ruby,
+    depends_on: [:normalize],
+    resume_key: "summarize-v1",
+    callable: ->(input) { DAG::Success.new(value: input[:normalize].upcase) }
+  }
+)
+
+mutated = DAG::Workflow.replace_subtree(
+  workflow,
+  root_node: :process,
+  replacement: replacement,
+  reconnect: [{from: :summarize, to: :report, metadata: {as: :process}}]
 )
 
 store.begin_run(
@@ -68,11 +93,14 @@ DAG::Workflow.apply_subtree_replacement_impact(
   definition: workflow,
   root_node: :process,
   execution_store: store,
-  cause: {source: :planner}
+  cause: {source: :planner},
+  new_definition: mutated
 )
 
 process_node = store.load_node(workflow_id: "example-subtree-impact", node_path: [:process])
 report_node = store.load_node(workflow_id: "example-subtree-impact", node_path: [:report])
+run = store.load_run("example-subtree-impact")
+mutated_fingerprint = DAG::Workflow::DefinitionFingerprint.for(mutated)
 
 running_store = DAG::Workflow::ExecutionStore::MemoryStore.new
 running_store.begin_run(
@@ -102,4 +130,6 @@ puts "Process state: #{process_node[:state]}"
 puts "Report state: #{report_node[:state]}"
 puts "Report stale cause code: #{report_node[:stale_cause][:code]}"
 puts "Report stale cause source: #{report_node[:stale_cause][:source]}"
+puts "Stored fingerprint updated: #{run[:definition_fingerprint] == mutated_fingerprint}"
+puts "Known node paths include summarize: #{run[:node_paths].include?([:summarize])}"
 puts "Running-root guard: #{running_root_error}"

--- a/lib/dag/workflow/execution_store.rb
+++ b/lib/dag/workflow/execution_store.rb
@@ -134,6 +134,14 @@ module DAG
           nil
         end
 
+        def update_definition(workflow_id:, definition_fingerprint:, node_paths:)
+          run = ensure_run(workflow_id)
+          run[:definition_fingerprint] = definition_fingerprint
+          run[:node_paths] |= normalized_node_paths(node_paths)
+          write_run(run)
+          nil
+        end
+
         def set_pause_flag(workflow_id:, paused:)
           run = ensure_run(workflow_id)
           run[:paused] = paused
@@ -320,6 +328,13 @@ module DAG
           run = ensure_run(workflow_id)
           run[:workflow_status] = status
           run[:waiting_nodes] = normalized_node_paths(waiting_nodes)
+          nil
+        end
+
+        def update_definition(workflow_id:, definition_fingerprint:, node_paths:)
+          run = ensure_run(workflow_id)
+          run[:definition_fingerprint] = definition_fingerprint
+          run[:node_paths] |= normalized_node_paths(node_paths)
           nil
         end
 

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -24,7 +24,7 @@ module DAG
         }
       end
 
-      def apply_subtree_replacement_impact(workflow_id:, definition:, root_node:, execution_store:, cause: nil)
+      def apply_subtree_replacement_impact(workflow_id:, definition:, root_node:, execution_store:, cause: nil, new_definition: nil)
         impact = subtree_replacement_impact(
           workflow_id: workflow_id,
           definition: definition,
@@ -49,6 +49,8 @@ module DAG
             cause: normalized_cause
           )
         end
+
+        update_mutated_definition!(execution_store, workflow_id, new_definition)
 
         impact
       end
@@ -145,6 +147,18 @@ module DAG
         return unless run.dig(:nodes, root, :state) == :running
 
         raise ArgumentError, "replaced subtree root cannot currently be :running"
+      end
+
+      def update_mutated_definition!(execution_store, workflow_id, new_definition)
+        return if new_definition.nil?
+        raise ArgumentError, "new_definition must be a DAG::Workflow::Definition" unless new_definition.is_a?(Definition)
+        return unless execution_store.respond_to?(:update_definition)
+
+        execution_store.update_definition(
+          workflow_id: workflow_id,
+          definition_fingerprint: DefinitionFingerprint.for(new_definition),
+          node_paths: new_definition.graph.topological_sort.map { |name| mutation_node_path(name) }
+        )
       end
 
       def mutation_node_path(node_path)

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -210,6 +210,8 @@ class ExamplesTest < Minitest::Test
     assert_includes stdout, "Process state: obsolete"
     assert_includes stdout, "Report state: stale"
     assert_includes stdout, "Report stale cause code: subtree_replaced"
+    assert_includes stdout, "Stored fingerprint updated: true"
+    assert_includes stdout, "Known node paths include summarize: true"
     assert_includes stdout, "Running-root guard: replaced subtree root cannot currently be :running"
   end
 

--- a/spec/execution_store_test.rb
+++ b/spec/execution_store_test.rb
@@ -179,6 +179,26 @@ class ExecutionStoreTest < Minitest::Test
     assert_equal [true], history.map { |entry| entry[:superseded] }
   end
 
+  def test_update_definition_replaces_fingerprint_and_unions_node_paths
+    store = DAG::Workflow::ExecutionStore::MemoryStore.new
+    store.begin_run(
+      workflow_id: "wf-definition-update",
+      definition_fingerprint: "fp-1",
+      node_paths: [[:source], [:process], [:report]]
+    )
+
+    store.update_definition(
+      workflow_id: "wf-definition-update",
+      definition_fingerprint: "fp-2",
+      node_paths: [[:source], [:normalize], [:summarize], [:report]]
+    )
+
+    run = store.load_run("wf-definition-update")
+
+    assert_equal "fp-2", run[:definition_fingerprint]
+    assert_equal [[:normalize], [:process], [:report], [:source], [:summarize]], run[:node_paths].sort_by { |path| path.map(&:to_s) }
+  end
+
   def test_file_store_persists_runs_outputs_and_trace_across_instances
     Dir.mktmpdir("dag-file-store") do |dir|
       store = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)

--- a/spec/mutation_impact_test.rb
+++ b/spec/mutation_impact_test.rb
@@ -159,6 +159,110 @@ class MutationImpactTest < Minitest::Test
     assert_match(/currently be :running/, error.message)
   end
 
+  def test_subtree_replacement_impact_preserves_upstream_outputs_when_mutated_workflow_reruns
+    source_calls = 0
+    process_calls = 0
+    normalize_calls = 0
+    summarize_calls = 0
+    report_calls = 0
+    store = build_memory_store
+
+    original = build_test_workflow(
+      source: {
+        type: :ruby,
+        resume_key: "source-v1",
+        callable: ->(_input) do
+          source_calls += 1
+          DAG::Success.new(value: "payload")
+        end
+      },
+      process: {
+        type: :ruby,
+        depends_on: [:source],
+        resume_key: "process-v1",
+        callable: ->(input) do
+          process_calls += 1
+          DAG::Success.new(value: input[:source].upcase)
+        end
+      },
+      report: {
+        type: :ruby,
+        depends_on: [:process],
+        resume_key: "report-v1",
+        callable: ->(input) do
+          report_calls += 1
+          DAG::Success.new(value: "report:#{input[:process]}:v#{report_calls}")
+        end
+      }
+    )
+
+    initial = DAG::Workflow::Runner.new(original,
+      parallel: false,
+      workflow_id: "wf-rerun-impact",
+      execution_store: store).call
+
+    replacement = build_test_workflow(
+      normalize: {
+        type: :ruby,
+        resume_key: "normalize-v1",
+        callable: ->(input) do
+          normalize_calls += 1
+          DAG::Success.new(value: "#{input[:source]}-normalized")
+        end
+      },
+      summarize: {
+        type: :ruby,
+        depends_on: [:normalize],
+        resume_key: "summarize-v1",
+        callable: ->(input) do
+          summarize_calls += 1
+          DAG::Success.new(value: input[:normalize].upcase)
+        end
+      }
+    )
+
+    mutated = DAG::Workflow.replace_subtree(
+      original,
+      root_node: :process,
+      replacement: replacement,
+      reconnect: [{from: :summarize, to: :report, metadata: {as: :process}}]
+    )
+
+    impact = DAG::Workflow.apply_subtree_replacement_impact(
+      workflow_id: "wf-rerun-impact",
+      definition: original,
+      root_node: :process,
+      execution_store: store,
+      cause: {source: :planner},
+      new_definition: mutated
+    )
+
+    rerun = DAG::Workflow::Runner.new(mutated,
+      parallel: false,
+      workflow_id: "wf-rerun-impact",
+      execution_store: store).call
+
+    assert initial.success?
+    assert rerun.success?
+    assert_equal [[:process]], impact[:obsolete_nodes]
+    assert_equal [[:report]], impact[:stale_nodes]
+    assert_equal 1, source_calls
+    assert_equal 1, process_calls
+    assert_equal 1, normalize_calls
+    assert_equal 1, summarize_calls
+    assert_equal 2, report_calls
+    assert_equal "payload", rerun.outputs[:source].value
+    assert_equal "PAYLOAD-NORMALIZED", rerun.outputs[:summarize].value
+    assert_equal "report:PAYLOAD-NORMALIZED:v2", rerun.outputs[:report].value
+
+    source_history = store.load_output(workflow_id: "wf-rerun-impact", node_path: [:source], version: :all)
+    report_history = store.load_output(workflow_id: "wf-rerun-impact", node_path: [:report], version: :all)
+
+    assert_equal [1], source_history.map { |entry| entry[:version] }
+    assert_equal [1, 2], report_history.map { |entry| entry[:version] }
+    assert_equal [true, false], report_history.map { |entry| entry[:superseded] }
+  end
+
   def test_subtree_replacement_impact_returns_empty_arrays_when_run_missing
     definition = build_test_workflow(
       process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :process) }}


### PR DESCRIPTION
## Summary
- allow `apply_subtree_replacement_impact(..., new_definition:)` to update the persisted run fingerprint and known node paths for the mutated workflow
- add execution-store support for updating stored definition metadata without losing audit history
- add an integration test proving upstream reusable outputs survive while the replaced branch reruns on the mutated definition
- update the runnable subtree-replacement-impact example and README docs

## Test Plan
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`

## Notes
- this closes the real gap exposed by an integration test: after applying mutation impact, rerunning the mutated workflow previously failed with a stored fingerprint mismatch
