### PR TITLE
test: harden subtree mutation store coverage

### DIFF
--- a/spec/execution_store_test.rb
+++ b/spec/execution_store_test.rb
@@ -199,6 +199,29 @@ class ExecutionStoreTest < Minitest::Test
     assert_equal [[:normalize], [:process], [:report], [:source], [:summarize]], run[:node_paths].sort_by { |path| path.map(&:to_s) }
   end
 
+  def test_file_store_update_definition_persists_fingerprint_and_node_paths_across_instances
+    Dir.mktmpdir("dag-file-store-definition-update") do |dir|
+      store = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)
+      store.begin_run(
+        workflow_id: "wf-file-definition-update",
+        definition_fingerprint: "fp-1",
+        node_paths: [[:source], [:process], [:report]]
+      )
+
+      store.update_definition(
+        workflow_id: "wf-file-definition-update",
+        definition_fingerprint: "fp-2",
+        node_paths: [[:source], [:normalize], [:summarize], [:report]]
+      )
+
+      reopened = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)
+      run = reopened.load_run("wf-file-definition-update")
+
+      assert_equal "fp-2", run[:definition_fingerprint]
+      assert_equal [[:normalize], [:process], [:report], [:source], [:summarize]], run[:node_paths].sort_by { |path| path.map(&:to_s) }
+    end
+  end
+
   def test_file_store_persists_runs_outputs_and_trace_across_instances
     Dir.mktmpdir("dag-file-store") do |dir|
       store = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)

--- a/spec/mutation_impact_test.rb
+++ b/spec/mutation_impact_test.rb
@@ -263,6 +263,31 @@ class MutationImpactTest < Minitest::Test
     assert_equal [true, false], report_history.map { |entry| entry[:superseded] }
   end
 
+  def test_apply_subtree_replacement_impact_rejects_non_definition_new_definition
+    definition = build_test_workflow(
+      process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :process) }}
+    )
+    store = build_memory_store
+    store.begin_run(
+      workflow_id: "wf-invalid-new-definition",
+      definition_fingerprint: "fp-1",
+      node_paths: [[:process]]
+    )
+    store.set_node_state(workflow_id: "wf-invalid-new-definition", node_path: [:process], state: :completed)
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.apply_subtree_replacement_impact(
+        workflow_id: "wf-invalid-new-definition",
+        definition: definition,
+        root_node: :process,
+        execution_store: store,
+        new_definition: Object.new
+      )
+    end
+
+    assert_match(/new_definition must be a DAG::Workflow::Definition/, error.message)
+  end
+
   def test_subtree_replacement_impact_returns_empty_arrays_when_run_missing
     definition = build_test_workflow(
       process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :process) }}


### PR DESCRIPTION
## Summary
- add file-store coverage for `update_definition` so subtree-mutation metadata updates are verified across fresh store instances
- add a mutation-impact regression test for invalid `new_definition:` values
- keep the subtree-replacement rerun path better locked down without changing production behavior

## Test Plan
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`
