### PR TITLE
docs: add file store subtree replacement example

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Notes:
 - both helpers preserve audit history by superseding reusable outputs instead of deleting historical versions
 - the replaced root cannot currently be `:running`; mutation is only legal between runner invocations
 - `cause:` accepts any Hash merged into the stored transition cause, but `replaced_from` is reserved and always set from `root_node`
-- see `examples/immutable_subtree_replacement.rb` for definition mutation and `examples/subtree_replacement_impact.rb` for runnable persisted-state impact planning/application
+- see `examples/immutable_subtree_replacement.rb` for definition mutation, `examples/subtree_replacement_impact.rb` for persisted-state impact planning/application, and `examples/subtree_replacement_file_store.rb` for the same rerun flow across fresh `FileStore` instances
 
 ### Waiting and not_before scheduling
 

--- a/examples/subtree_replacement_file_store.rb
+++ b/examples/subtree_replacement_file_store.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+# Dynamic graph mutation with a file-backed execution store across fresh store
+# instances.
+#
+# Run: ruby -Ilib examples/subtree_replacement_file_store.rb
+
+require "dag"
+require "tmpdir"
+
+source_calls = 0
+process_calls = 0
+normalize_calls = 0
+summarize_calls = 0
+report_calls = 0
+
+original = DAG::Workflow::Loader.from_hash(
+  source: {
+    type: :ruby,
+    resume_key: "source-v1",
+    callable: ->(_input) do
+      source_calls += 1
+      DAG::Success.new(value: "payload")
+    end
+  },
+  process: {
+    type: :ruby,
+    depends_on: [:source],
+    resume_key: "process-v1",
+    callable: ->(input) do
+      process_calls += 1
+      DAG::Success.new(value: input[:source].upcase)
+    end
+  },
+  report: {
+    type: :ruby,
+    depends_on: [:process],
+    resume_key: "report-v1",
+    callable: ->(input) do
+      report_calls += 1
+      DAG::Success.new(value: "report:#{input[:process]}:v#{report_calls}")
+    end
+  }
+)
+
+replacement = DAG::Workflow::Loader.from_hash(
+  normalize: {
+    type: :ruby,
+    resume_key: "normalize-v1",
+    callable: ->(input) do
+      normalize_calls += 1
+      DAG::Success.new(value: "#{input[:source]}-normalized")
+    end
+  },
+  summarize: {
+    type: :ruby,
+    depends_on: [:normalize],
+    resume_key: "summarize-v1",
+    callable: ->(input) do
+      summarize_calls += 1
+      DAG::Success.new(value: input[:normalize].upcase)
+    end
+  }
+)
+
+mutated = DAG::Workflow.replace_subtree(
+  original,
+  root_node: :process,
+  replacement: replacement,
+  reconnect: [{from: :summarize, to: :report, metadata: {as: :process}}]
+)
+
+Dir.mktmpdir("dag-subtree-replacement-file-store") do |dir|
+  first_store = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)
+  second_store = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)
+  third_store = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)
+
+  first = DAG::Workflow::Runner.new(original,
+    parallel: false,
+    workflow_id: "example-subtree-file-store",
+    execution_store: first_store).call
+
+  impact = DAG::Workflow.apply_subtree_replacement_impact(
+    workflow_id: "example-subtree-file-store",
+    definition: original,
+    root_node: :process,
+    execution_store: second_store,
+    cause: {source: :planner},
+    new_definition: mutated
+  )
+
+  second = DAG::Workflow::Runner.new(mutated,
+    parallel: false,
+    workflow_id: "example-subtree-file-store",
+    execution_store: third_store).call
+
+  puts "=== First Run (file store) ==="
+  puts "Initial source: #{first.outputs[:source].value}"
+  puts "Initial report: #{first.outputs[:report].value}"
+  puts
+  puts "=== Mutation Impact Applied ==="
+  puts "Obsolete nodes: #{impact[:obsolete_nodes].inspect}"
+  puts "Stale nodes: #{impact[:stale_nodes].inspect}"
+  puts
+  puts "=== Second Run (mutated definition, fresh store instance) ==="
+  puts "Final source: #{second.outputs[:source].value}"
+  puts "Final summarize: #{second.outputs[:summarize].value}"
+  puts "Final report: #{second.outputs[:report].value}"
+  puts "Source reused calls: #{source_calls}"
+  puts "Process calls: #{process_calls}"
+  puts "Normalize calls: #{normalize_calls}"
+  puts "Summarize calls: #{summarize_calls}"
+  puts "Report calls: #{report_calls}"
+end

--- a/spec/examples_test.rb
+++ b/spec/examples_test.rb
@@ -215,6 +215,30 @@ class ExamplesTest < Minitest::Test
     assert_includes stdout, "Running-root guard: replaced subtree root cannot currently be :running"
   end
 
+  def test_subtree_replacement_file_store_example_executes_successfully
+    stdout, stderr, status = run_example("examples/subtree_replacement_file_store.rb")
+
+    assert status.success?, <<~MSG
+      expected subtree_replacement_file_store example to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "=== First Run (file store) ==="
+    assert_includes stdout, "Initial report: report:PAYLOAD:v1"
+    assert_includes stdout, "=== Mutation Impact Applied ==="
+    assert_includes stdout, "Obsolete nodes: [[:process]]"
+    assert_includes stdout, "Stale nodes: [[:report]]"
+    assert_includes stdout, "=== Second Run (mutated definition, fresh store instance) ==="
+    assert_includes stdout, "Source reused calls: 1"
+    assert_includes stdout, "Normalize calls: 1"
+    assert_includes stdout, "Summarize calls: 1"
+    assert_includes stdout, "Report calls: 2"
+    assert_includes stdout, "Final report: report:PAYLOAD-NORMALIZED:v2"
+  end
+
   def test_missing_requested_version_waiting_example_executes_successfully
     stdout, stderr, status = run_example("examples/missing_requested_version_waiting.rb")
 


### PR DESCRIPTION
## Summary
- add a runnable `examples/subtree_replacement_file_store.rb` example for the between-invocations subtree replacement rerun flow on fresh `FileStore` instances
- wire the example into `spec/examples_test.rb`
- update the README mutation section to point at the new file-store example

## Test Plan
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`
