### PR TITLE
docs: close Feature 5 (scheduling constraints) as implemented

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -687,12 +687,15 @@ runner = Runner.new(definition, clock: my_clock)
 - `cron` metadata round-trips through Loader/Dumper for YAML-safe step types.
 - Scheduling tests can run against a fake clock without real sleeping.
 
-**Status:** `partial` | **Priority:** medium
+**Status:** `implemented` | **Priority:** medium
 
-Current repo reality: `not_before`, `not_after`, `ttl`, waiting state, and cron
-metadata round-trip all exist. This remains `partial` because scheduling is
-implemented as runner-time eligibility plus stored metadata, but still needs a
-more explicit closeout pass in the roadmap/docs.
+All acceptance criteria are satisfied and exercised in the test suite:
+`not_before` via `spec/scheduling_test.rb`, `not_after` and deadline-exceeded
+failure via the same, `ttl` expiry via the same, cron round-trip via
+`spec/dumper_test.rb:test_round_trip_schedule_metadata_with_yaml_safe_values`,
+and scheduling examples via `spec/examples_test.rb`. Fake-clock testing is
+verified without real sleeping in `spec/schedule_policy_test.rb` and
+`spec/scheduling_test.rb` via the `MutableClock` test helper.
 
 ---
 
@@ -1126,7 +1129,7 @@ one isolated milestone PR.
 | 2 | Checkpointing and resume | high | `implemented` | medium |
 | 3 | Sub-workflow composition | high | `partial` | medium |
 | 4 | Runner context injection | high | `implemented` | small |
-| 5 | Node scheduling constraints | medium | `partial` | medium |
+| 5 | Node scheduling constraints | medium | `implemented` | medium |
 | 6 | Versioned step outputs | medium | `implemented` | medium |
 | 7 | Invalidation cascade | medium | `implemented` | small |
 | 8 | Dynamic graph mutation | medium | `partial` | large |
@@ -1182,10 +1185,7 @@ From here, the goal is to close the partials in a deliberate order.
    - enforce and document any remaining nesting/depth limits
    - re-check deadline inheritance and edge-case validation coverage
    - make the supported contract explicit instead of implied by tests
-2. Feature 5: scheduling constraints
-   - decide whether this is effectively done after docs cleanup
-   - or land the small remaining gaps and promote it to `implemented`
-3. Feature 10: cross-workflow dependencies
+2. Feature 10: cross-workflow dependencies
    - either bless the simpler resolver contract that shipped
    - or add a thin normalization layer if the original structured contract is still preferred
 4. Feature 8: dynamic graph mutation


### PR DESCRIPTION
## Summary

Promotes Feature 5 (Node Scheduling Constraints) from `partial` to `implemented` in ROADMAP.md.

## What changed

- `ROADMAP.md`: Feature 5 status changed from `partial` to `implemented`
- `ROADMAP.md`: replaced the "Current repo reality" note with concrete test coverage evidence
- `ROADMAP.md`: removed Feature 5 from the Phase B "remaining work" list (no longer outstanding)
- Feature summary table updated accordingly

## Audit basis

Full code inspection of `lib/dag/workflow/schedule_policy.rb`, `layer_admitter.rb`, `execution_persistence.rb`, `runner.rb`, `loader.rb`, `dumper.rb`, and the full scheduling test suite confirmed:

| Acceptance criterion | Evidence |
|---|---|
| `not_before` future nodes do not emit `Success(nil)` | `spec/scheduling_test.rb:test_not_before_returns_waiting_status_and_waiting_nodes` — `refute result.outputs.key?(:scheduled)` |
| `not_after` fails deterministically before executing late work | `spec/scheduling_test.rb:test_not_after_fails_before_executing_late_work` — `assert_equal 0, calls` |
| `ttl` expiry causes re-execution instead of reuse | `spec/scheduling_test.rb:test_ttl_expiry_reexecutes_instead_of_reusing_output` — stale cause is `:ttl_expired` |
| `cron` metadata round-trips through Loader/Dumper | `spec/dumper_test.rb:test_round_trip_schedule_metadata_with_yaml_safe_values` |
| Scheduling tests use fake clock without real sleeping | `spec/schedule_policy_test.rb`, `spec/scheduling_test.rb` via `MutableClock` test helper |

## No code changes

This is a documentation-only closeout. All scheduling semantics were already implemented and tested. No implementation changes were necessary.

## Test plan

- `bundle exec rake` — 766 runs, 40908 assertions, 0 failures ✅