### PR TITLE
docs: close Feature 10 (cross-workflow dependencies) as implemented

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -995,14 +995,20 @@ runner = Runner.new(definition,
 - Duplicate input aliases are validation errors.
 - External resolution failure is surfaced as explicit workflow error, not silent skip.
 
-**Status:** `partial` | **Priority:** low
+**Status:** `implemented` | **Priority:** low
 
-Current repo reality: cross-workflow dependency descriptors, resolver-driven
-waiting/failure behavior, loader/dumper round-trip, and runnable examples/tests
-exist today. It remains `partial` because the concrete resolver contract that
-landed in code is simpler and more Ruby-native than the original structured
-`CrossWorkflowResolution` sketch in this document.
+All acceptance criteria are satisfied:
+- `spec/dependency_input_resolver_test.rb` exercises local+cross-workflow coexistence,
+  positional/keyword resolver auto-detection, `nil` → `WaitingForDependencyError`,
+  resolver exception → `ResolverError`, and missing resolver → `MissingCrossWorkflowResolverError`
+- `spec/loader_test.rb:test_from_hash_treats_cross_workflow_dependency` verifies loading
+- `spec/dumper_test.rb:test_round_trips_cross_workflow_dependency` verifies round-trip
+- `examples/missing_requested_version_waiting.rb` is exercised in `spec/examples_test.rb`
+- duplicate alias validation via `Validator.duplicate_effective_input_key_errors`
 
+The resolver contract is intentionally Ruby-native (positional or keyword, auto-detected
+via callable parameters inspection — no `CrossWorkflowResolution` wrapper). This is the
+blessed simpler contract per the Phase B roadmap guidance.
 ---
 
 ## Feature 11: Pause and Resume
@@ -1134,7 +1140,7 @@ one isolated milestone PR.
 | 7 | Invalidation cascade | medium | `implemented` | small |
 | 8 | Dynamic graph mutation | medium | `partial` | large |
 | 9 | Event emission from steps | low | `implemented` | small |
-| 10 | Cross-workflow dependencies | low | `partial` | medium |
+| 10 | Cross-workflow dependencies | low | `implemented` | medium |
 | 11 | Pause and resume | medium | `implemented` | medium |
 | 12 | Step middleware | medium | `implemented` | small |
 
@@ -1185,10 +1191,7 @@ From here, the goal is to close the partials in a deliberate order.
    - enforce and document any remaining nesting/depth limits
    - re-check deadline inheritance and edge-case validation coverage
    - make the supported contract explicit instead of implied by tests
-2. Feature 10: cross-workflow dependencies
-   - either bless the simpler resolver contract that shipped
-   - or add a thin normalization layer if the original structured contract is still preferred
-4. Feature 8: dynamic graph mutation
+2. Feature 8: dynamic graph mutation
    - document that the implemented slice is subtree replacement between invocations
    - decide whether the roadmap should stop there for v1 or grow beyond it in a later phase
 


### PR DESCRIPTION
## Summary

Promotes Feature 10 (Cross-Workflow Dependencies) from `partial` to `implemented` in ROADMAP.md.

## What changed

- `ROADMAP.md`: Feature 10 status changed from `partial` to `implemented`
- `ROADMAP.md`: replaced "Current repo reality" note with concrete test coverage evidence
- `ROADMAP.md`: removed Feature 10 from Phase B "remaining work" list
- `ROADMAP.md`: Feature 8 renumbered from position 4 to 2 in Phase B list
- Feature summary table updated to `implemented`

## Audit basis

Full code inspection of `lib/dag/workflow/dependency_input_resolver.rb`, `loader.rb`, `dumper.rb`, `validator.rb`, `layer_admitter.rb`, and the test suite confirmed all acceptance criteria are satisfied:

| Acceptance criterion | Evidence |
|---|---|
| Local + cross-workflow dependencies coexist on the same node | `spec/dependency_input_resolver_test.rb:test_input_keys_for_sorts_and_dedups` |
| Resolver `nil` → `RunResult(:waiting)` | `spec/dependency_input_resolver_test.rb:test_resolve_external_dependency_nil_raises_waiting_with_descriptor` |
| Resolver exception → explicit failure | `spec/dependency_input_resolver_test.rb:test_resolve_external_resolver_exception_is_wrapped_in_resolver_error` |
| Duplicate input aliases = validation error | `Validator.duplicate_effective_input_key_errors` (also exercised via scenario) |
| External resolution failure = explicit error | `spec/dependency_input_resolver_test.rb:test_resolve_external_without_resolver_raises_missing_cross_workflow_resolver` |
| Positional + keyword resolver support | `spec/dependency_input_resolver_test.rb:test_invokes_positional_and_keyword_resolver_callables` |
| Loader/dumper round-trip | `spec/loader_test.rb`, `spec/dumper_test.rb:test_round_trips_cross_workflow_dependency` |
| Runnable examples | `examples/missing_requested_version_waiting.rb` exercised in `spec/examples_test.rb` |

## Decision: Bless the simpler contract

The roadmap posed a binary choice:

1. **bless the simpler resolver contract that shipped** — ✅ chosen
2. add a thin normalization layer if the original structured contract is still preferred

The resolver contract that shipped is intentionally Ruby-native:
- positional (`→(workflow_id, node_name, version)`) or keyword (`→(workflow_id:, node_name:, version:)`), auto-detected via callable `parameters` inspection
- returns raw value, `DAG::Success`, `{result: DAG::Success(...)}` hash (store-entry shape), or `nil` for "not yet available"
- exceptions are wrapped in `ResolverError` for explicit failure

No `CrossWorkflowResolution` wrapper is needed. This is the right call for a generic gem — it keeps the contract minimal, Ruby-idiomatic, and composable.

## No implementation changes

This is a documentation-only closeout. All cross-workflow semantics were already implemented and tested. No code changes were necessary.

## Test plan

- `bundle exec rake` — 766 runs, 40908 assertions, 0 failures ✅