### PR TITLE
fix(CLI): use current RunResult shape (closes #58)

### DIFF
--- a/bin/dag
+++ b/bin/dag
@@ -64,11 +64,10 @@ result = DAG::Workflow::Runner.new(definition.graph, definition.registry,
   parallel: parallel, on_step_start: on_start, on_step_finish: on_finish).call
 
 if result.success?
-  trace = result.value[:trace]
-  puts "\n✓ Workflow completed (#{definition.size} nodes, #{trace.size} steps traced)"
+  puts "\n✓ Workflow completed (#{definition.size} nodes, #{result.trace.size} steps traced)"
   exit 0
 else
-  failure = result.error[:error]
+  failure = result.error
   warn "\n✗ Failed at '#{failure[:failed_node]}': #{humanize_error(failure[:step_error])}"
   exit 1
 end

--- a/spec/cli_test.rb
+++ b/spec/cli_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "open3"
+
+class CLIWorkflowTest < Minitest::Test
+  include TestHelpers
+
+  def test_bin_dag_runs_deploy_yml_success
+    stdout, stderr, status = run_bin_dag("examples/deploy.yml")
+
+    assert status.success?, <<~MSG
+      expected deploy.yml to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "✓ Workflow completed"
+    assert_includes stdout, "5 nodes"
+  end
+
+  def test_bin_dag_exits_nonzero_on_failure
+    yaml = build_failure_yaml
+    with_tempfile(yaml) do |path|
+      stdout, stderr, status = run_bin_dag(path)
+
+      refute status.success?, <<~MSG
+        expected failure workflow to exit non-zero
+        stdout:
+        #{stdout}
+        stderr:
+        #{stderr}
+      MSG
+
+      assert_includes stderr, "✗ Failed at"
+      assert_includes stderr, "exit"
+    end
+  end
+
+  def test_bin_dag_dry_run_shows_plan
+    stdout, stderr, status = run_bin_dag("examples/deploy.yml", extra_args: ["--dry-run"])
+
+    assert status.success?, <<~MSG
+      expected dry-run to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "Workflow:"
+    assert_includes stdout, "Nodes:"
+    assert_includes stdout, "Execution order:"
+    assert_includes stdout, "Layer"
+  end
+
+  def test_bin_dag_no_parallel_sequential
+    stdout, stderr, status = run_bin_dag("examples/deploy.yml", extra_args: ["--no-parallel"])
+
+    assert status.success?, <<~MSG
+      expected --no-parallel run to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "✓ Workflow completed"
+  end
+
+  def test_bin_dag_load_error_exits_code_2
+    stdout, stderr, status = run_bin_dag("nonexistent.yml")
+
+    refute status.success?, <<~MSG
+      expected nonexistent file to fail
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_equal 2, status.exitstatus
+    assert_includes stderr, "failed to load"
+  end
+
+  def test_bin_dag_help_exits_code_0
+    stdout, stderr, status = run_bin_dag("--help")
+
+    assert status.success?, <<~MSG
+      expected --help to succeed
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MSG
+
+    assert_includes stdout, "Usage:"
+    assert_includes stdout, "Options:"
+  end
+
+  private
+
+  def run_bin_dag(file_or_arg, extra_args: [])
+    args = (file_or_arg == "--help") ? ["--help"] : [file_or_arg, *extra_args]
+    Open3.capture3(example_env,
+      Gem.ruby, "-Ilib", "bin/dag", *args,
+      chdir: File.expand_path("..", __dir__))
+  end
+
+  def build_failure_yaml
+    <<~YAML
+      name: cli-fail-test
+      description: "Failure test for CLI"
+      nodes:
+        fail_step:
+          type: exec
+          command: "exit 1"
+    YAML
+  end
+end


### PR DESCRIPTION
## Repro

```bash
$ bundle exec ruby bin/dag examples/deploy.yml
✓ lint
✓ test
✓ build
✓ push
✓ notify
bin/dag:67:in '<main>': undefined method 'value' for an instance of DAG::Workflow::RunResult (NoMethodError)
```

## Root cause

bin/dag accessed RunResult via the deprecated Result wrapper interface:
- `result.value[:trace]` — RunResult has no `.value` method
- `result.error[:error]` — RunResult already contains the raw error hash

## Fix applied

bin/dag now uses the current RunResult contract directly:

| Before | After |
|--------|-------|
| `result.value[:trace]` | `result.trace` |
| `result.error[:error]` | `result.error` |

## Tests added

`spec/cli_test.rb` — 6 end-to-end CLI tests:
- ✅ deploy.yml success (exit 0)
- ✅ failure path (exit 1)
- ✅ --dry-run (exit 0)
- ✅ --no-parallel (exit 0)
- ✅ nonexistent file (exit 2)
- ✅ --help (exit 0)

Full suite: **772 runs, 40939 assertions, 0 failures**

## Verification

```
$ bundle exec ruby bin/dag examples/deploy.yml
✓ lint
✓ test
✓ build
✓ push
✓ notify

✓ Workflow completed (5 nodes, 5 steps traced)

$ bundle exec ruby bin/dag /home/openclaw/.openclaw/workspace/fail-test.yml
✗ Failed at 'fail_step': exec command exited with status 1
EXIT: 1
``"

## Scope

Single-purpose fix: only bin/dag result accessors updated. No refactors to runner, store, middleware, or other components.

---
Closes #58