### PR TITLE
fix(durable): include root_input in definition fingerprint (closes #59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Notes:
 - durable execution currently requires `workflow_id:`
 - `:ruby` steps must declare a deterministic `resume_key:` when durable execution is enabled
 - changing the workflow fingerprint for an existing `workflow_id` raises `DAG::ValidationError` before any step runs
+- non-empty `root_input:` participates in the durable fingerprint; clear existing durable runs before reusing a `workflow_id` created by an older build that did not include root input in fingerprints
 - see `examples/checkpoint_resume.rb` for a runnable end-to-end example that is exercised in the test suite
 
 ### Versioned dependency inputs
@@ -407,6 +408,7 @@ Notes:
 - completed downstream descendants reachable from the replaced root are included in `stale_nodes`
 - `apply_subtree_replacement_impact` marks obsolete roots with `obsolete_cause` and stale descendants with `stale_cause`
 - pass `new_definition:` when you want the persisted run fingerprint and known node paths updated for the next runner invocation against the mutated workflow
+- when updating a durable run that used `root_input:`, pass the same `root_input:` to `apply_subtree_replacement_impact`
 - both helpers preserve audit history by superseding reusable outputs instead of deleting historical versions
 - the replaced root cannot currently be `:running`; mutation is only legal between runner invocations
 - `cause:` accepts any Hash merged into the stored transition cause, but `replaced_from` is reserved and always set from `root_node`

--- a/lib/dag/workflow/definition_fingerprint.rb
+++ b/lib/dag/workflow/definition_fingerprint.rb
@@ -7,7 +7,7 @@ module DAG
   module Workflow
     class DefinitionFingerprint
       class << self
-        def for(definition)
+        def for(definition, root_input: {})
           data = {
             graph: definition.graph.to_h,
             steps: definition.graph.topological_sort.map do |name|
@@ -17,10 +17,15 @@ module DAG
                 type: step.type,
                 fingerprint: fingerprint_step(step, source_path: definition.source_path)
               }
-            end
+            end,
+            root_input: root_input.empty? ? nil : normalize_root_input(root_input)
           }
 
           Digest::SHA256.hexdigest(YAML.dump(data))
+        end
+
+        def normalize_root_input(root_input)
+          root_input.transform_values { |v| normalize(v) }.sort_by { |k, _| k.to_s }.to_h
         end
 
         private

--- a/lib/dag/workflow/definition_fingerprint.rb
+++ b/lib/dag/workflow/definition_fingerprint.rb
@@ -17,18 +17,37 @@ module DAG
                 type: step.type,
                 fingerprint: fingerprint_step(step, source_path: definition.source_path)
               }
-            end,
-            root_input: root_input.empty? ? nil : normalize_root_input(root_input)
+            end
           }
+          data[:root_input] = normalize_root_input(root_input) unless root_input.empty?
 
           Digest::SHA256.hexdigest(YAML.dump(data))
         end
 
+        private
+
         def normalize_root_input(root_input)
-          root_input.transform_values { |v| normalize(v) }.sort_by { |k, _| k.to_s }.to_h
+          root_input.each_with_object({}) do |(key, nested), hash|
+            hash[key.to_sym] = normalize_root_input_value(nested)
+          end.sort_by { |key, _| key.to_s }.to_h
         end
 
-        private
+        def normalize_root_input_value(value)
+          case value
+          when Hash
+            value.each_with_object({}) do |(key, nested), hash|
+              hash[key] = normalize_root_input_value(nested)
+            end.sort_by { |key, _| root_input_key_sort_token(key) }.to_h
+          when Array
+            value.map { |nested| normalize_root_input_value(nested) }
+          else
+            value
+          end
+        end
+
+        def root_input_key_sort_token(key)
+          [key.class.name, key.inspect]
+        end
 
         def fingerprint_step(step, source_path: nil)
           if step.type == :sub_workflow

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -24,7 +24,8 @@ module DAG
         }
       end
 
-      def apply_subtree_replacement_impact(workflow_id:, definition:, root_node:, execution_store:, cause: nil, new_definition: nil)
+      def apply_subtree_replacement_impact(workflow_id:, definition:, root_node:, execution_store:,
+        cause: nil, new_definition: nil, root_input: {})
         impact = subtree_replacement_impact(
           workflow_id: workflow_id,
           definition: definition,
@@ -50,7 +51,7 @@ module DAG
           )
         end
 
-        update_mutated_definition!(execution_store, workflow_id, new_definition)
+        update_mutated_definition!(execution_store, workflow_id, new_definition, root_input: root_input)
 
         impact
       end
@@ -149,14 +150,14 @@ module DAG
         raise ArgumentError, "replaced subtree root cannot currently be :running"
       end
 
-      def update_mutated_definition!(execution_store, workflow_id, new_definition)
+      def update_mutated_definition!(execution_store, workflow_id, new_definition, root_input:)
         return if new_definition.nil?
         raise ArgumentError, "new_definition must be a DAG::Workflow::Definition" unless new_definition.is_a?(Definition)
         return unless execution_store.respond_to?(:update_definition)
 
         execution_store.update_definition(
           workflow_id: workflow_id,
-          definition_fingerprint: DefinitionFingerprint.for(new_definition),
+          definition_fingerprint: DefinitionFingerprint.for(new_definition, root_input: root_input),
           node_paths: new_definition.graph.topological_sort.map { |name| mutation_node_path(name) }
         )
       end

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -100,7 +100,7 @@ module DAG
         validate_coverage!(graph, registry)
         validate_workflow!(graph, registry)
         validate_durable_execution!
-        @definition_fingerprint = @execution_store ? DefinitionFingerprint.for(Definition.new(graph: @graph, registry: @registry, source_path: @definition_source_path)) : nil
+        @definition_fingerprint = @execution_store ? DefinitionFingerprint.for(Definition.new(graph: @graph, registry: @registry, source_path: @definition_source_path), root_input: @root_input) : nil
       end
 
       def call

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -100,7 +100,12 @@ module DAG
         validate_coverage!(graph, registry)
         validate_workflow!(graph, registry)
         validate_durable_execution!
-        @definition_fingerprint = @execution_store ? DefinitionFingerprint.for(Definition.new(graph: @graph, registry: @registry, source_path: @definition_source_path), root_input: @root_input) : nil
+        @definition_fingerprint = if @execution_store
+          DefinitionFingerprint.for(
+            Definition.new(graph: @graph, registry: @registry, source_path: @definition_source_path),
+            root_input: @root_input
+          )
+        end
       end
 
       def call

--- a/spec/mutation_impact_test.rb
+++ b/spec/mutation_impact_test.rb
@@ -264,6 +264,99 @@ class MutationImpactTest < Minitest::Test
     assert_equal [true, false], report_history.map { |entry| entry[:superseded] }
   end
 
+  def test_apply_subtree_replacement_impact_threads_root_input_into_mutated_fingerprint
+    source_calls = 0
+    normalize_calls = 0
+    summarize_calls = 0
+    report_calls = 0
+    store = build_memory_store
+    root_input = {seed: 1}
+
+    original = build_test_workflow(
+      source: {
+        type: :ruby,
+        resume_key: "source-v1",
+        callable: ->(input) do
+          source_calls += 1
+          DAG::Success.new(value: "seed-#{input[:seed]}")
+        end
+      },
+      process: {
+        type: :ruby,
+        depends_on: [:source],
+        resume_key: "process-v1",
+        callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+      },
+      report: {
+        type: :ruby,
+        depends_on: [:process],
+        resume_key: "report-v1",
+        callable: ->(input) do
+          report_calls += 1
+          DAG::Success.new(value: "#{input[:process]}:report-#{report_calls}")
+        end
+      }
+    )
+
+    initial = DAG::Workflow::Runner.new(original,
+      parallel: false,
+      workflow_id: "wf-rerun-impact-root-input",
+      execution_store: store,
+      root_input: root_input).call
+
+    replacement = build_test_workflow(
+      normalize: {
+        type: :ruby,
+        resume_key: "normalize-v1",
+        callable: ->(input) do
+          normalize_calls += 1
+          DAG::Success.new(value: "#{input[:source]}-normalized")
+        end
+      },
+      summarize: {
+        type: :ruby,
+        depends_on: [:normalize],
+        resume_key: "summarize-v1",
+        callable: ->(input) do
+          summarize_calls += 1
+          DAG::Success.new(value: input[:normalize].upcase)
+        end
+      }
+    )
+
+    mutated = DAG::Workflow.replace_subtree(
+      original,
+      root_node: :process,
+      replacement: replacement,
+      reconnect: [{from: :summarize, to: :report, metadata: {as: :process}}]
+    )
+
+    impact = DAG::Workflow.apply_subtree_replacement_impact(
+      workflow_id: "wf-rerun-impact-root-input",
+      definition: original,
+      root_node: :process,
+      execution_store: store,
+      new_definition: mutated,
+      root_input: root_input
+    )
+
+    rerun = DAG::Workflow::Runner.new(mutated,
+      parallel: false,
+      workflow_id: "wf-rerun-impact-root-input",
+      execution_store: store,
+      root_input: root_input).call
+
+    assert initial.success?
+    assert rerun.success?
+    assert_equal [[:process]], impact[:obsolete_nodes]
+    assert_equal [[:report]], impact[:stale_nodes]
+    assert_equal 1, source_calls
+    assert_equal 1, normalize_calls
+    assert_equal 1, summarize_calls
+    assert_equal 2, report_calls
+    assert_equal "SEED-1-NORMALIZED:report-2", rerun.outputs[:report].value
+  end
+
   def test_apply_subtree_replacement_impact_rejects_non_definition_new_definition
     definition = build_test_workflow(
       process: {type: :ruby, callable: ->(_) { DAG::Success.new(value: :process) }}

--- a/spec/runner_test.rb
+++ b/spec/runner_test.rb
@@ -157,6 +157,46 @@ class RunnerTest < Minitest::Test
     assert_equal :completed, store.load_node(workflow_id: "wf-stale-rerun", node_path: [:transform])[:state]
   end
 
+  def test_runner_does_not_silently_reuse_stale_output_when_root_input_changes
+    store = build_memory_store
+    step_calls = 0
+
+    definition = build_test_workflow(
+      read_seed: {
+        type: :ruby,
+        resume_key: "read-seed-v1",
+        callable: ->(input) do
+          step_calls += 1
+          DAG::Success.new(value: "value=#{input[:seed]}")
+        end
+      }
+    )
+
+    # First run with seed=1
+    first_run = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      execution_store: store,
+      workflow_id: "wf-root-input",
+      root_input: {seed: 1}).call
+
+    assert_equal 1, step_calls
+    assert_equal "value=1", first_run.outputs[:read_seed].value
+
+    # Second run with same workflow_id but different root_input must not silently
+    # reuse the persisted output — the fingerprint check in prepare_execution_store!
+    # detects the changed root_input and raises rather than returning stale data.
+    error = assert_raises(DAG::ValidationError) do
+      DAG::Workflow::Runner.new(definition,
+        parallel: false,
+        execution_store: store,
+        workflow_id: "wf-root-input",
+        root_input: {seed: 2}).call
+    end
+
+    assert_match(/fingerprint.*does not match/, error.message)
+    assert_equal 1, step_calls # step ran only once — no silent stale reuse
+  end
+
   def test_runner_reexecutes_nested_subworkflow_branch_after_nested_invalidation
     store = build_memory_store
     transform_calls = 0

--- a/spec/runner_test.rb
+++ b/spec/runner_test.rb
@@ -183,7 +183,7 @@ class RunnerTest < Minitest::Test
     assert_equal "value=1", first_run.outputs[:read_seed].value
 
     # Second run with same workflow_id but different root_input must not silently
-    # reuse the persisted output — the fingerprint check in prepare_execution_store!
+    # reuse the persisted output; the fingerprint check in prepare_execution_store!
     # detects the changed root_input and raises rather than returning stale data.
     error = assert_raises(DAG::ValidationError) do
       DAG::Workflow::Runner.new(definition,
@@ -193,8 +193,112 @@ class RunnerTest < Minitest::Test
         root_input: {seed: 2}).call
     end
 
-    assert_match(/fingerprint.*does not match/, error.message)
-    assert_equal 1, step_calls # step ran only once — no silent stale reuse
+    assert_includes error.message, "does not match"
+    assert_equal 1, step_calls # step ran only once; no silent stale reuse
+  end
+
+  def test_runner_resumes_when_root_input_is_unchanged
+    store = build_memory_store
+    step_calls = 0
+
+    definition = build_test_workflow(
+      read_seed: {
+        type: :ruby,
+        resume_key: "read-seed-v1",
+        callable: ->(input) do
+          step_calls += 1
+          DAG::Success.new(value: "value=#{input[:seed]}")
+        end
+      }
+    )
+
+    first_run = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      execution_store: store,
+      workflow_id: "wf-root-input-same",
+      root_input: {seed: 1}).call
+
+    second_run = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      execution_store: store,
+      workflow_id: "wf-root-input-same",
+      root_input: {seed: 1}).call
+
+    assert first_run.success?
+    assert second_run.success?
+    assert_equal 1, step_calls
+    assert_equal "value=1", second_run.outputs[:read_seed].value
+  end
+
+  def test_empty_root_input_matches_omitted_root_input_fingerprint
+    definition = build_test_workflow(
+      read: {
+        type: :ruby,
+        resume_key: "read-v1",
+        callable: ->(_input) { DAG::Success.new(value: "ok") }
+      }
+    )
+    omitted_store = build_memory_store
+    empty_store = build_memory_store
+
+    DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      execution_store: omitted_store,
+      workflow_id: "wf-root-input-omitted").call
+
+    DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      execution_store: empty_store,
+      workflow_id: "wf-root-input-empty",
+      root_input: {}).call
+
+    omitted_fingerprint = omitted_store.load_run("wf-root-input-omitted")[:definition_fingerprint]
+    empty_fingerprint = empty_store.load_run("wf-root-input-empty")[:definition_fingerprint]
+
+    assert_equal omitted_fingerprint, empty_fingerprint
+  end
+
+  def test_nested_root_input_string_and_symbol_keys_fingerprint_differently
+    definition = build_test_workflow(
+      read: {
+        type: :ruby,
+        resume_key: "read-v1",
+        callable: ->(_input) { DAG::Success.new(value: "ok") }
+      }
+    )
+
+    string_key_fingerprint = DAG::Workflow::DefinitionFingerprint.for(
+      definition,
+      root_input: {payload: {"x" => 1}}
+    )
+    symbol_key_fingerprint = DAG::Workflow::DefinitionFingerprint.for(
+      definition,
+      root_input: {payload: {x: 1}}
+    )
+
+    refute_equal string_key_fingerprint, symbol_key_fingerprint
+  end
+
+  def test_nested_root_input_non_symbol_keys_do_not_break_durable_runner
+    nested_key = 1
+    store = build_memory_store
+
+    definition = build_test_workflow(
+      read: {
+        type: :ruby,
+        resume_key: "read-v1",
+        callable: ->(input) { DAG::Success.new(value: input[:payload][nested_key]) }
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(definition,
+      parallel: false,
+      execution_store: store,
+      workflow_id: "wf-root-input-nested-non-symbol-key",
+      root_input: {payload: {nested_key => "ok"}}).call
+
+    assert result.success?
+    assert_equal "ok", result.outputs[:read].value
   end
 
   def test_runner_reexecutes_nested_subworkflow_branch_after_nested_invalidation


### PR DESCRIPTION
## Summary

Make durable execution reject stale outputs when runtime inputs change.

### The bug

`DefinitionFingerprint` covered only graph + step config. When the same
`workflow_id` was reused with different `root_input`, the fingerprint
matched the stored one, so `ExecutionPersistence#load_reusable_result`
silently returned the old persisted output instead of recomputing with the
new inputs.

### The fix

Include a normalized form of `root_input` in the fingerprint data hash.
Any runtime input change now produces a different fingerprint, causing
`prepare_execution_store!` to raise a `ValidationError` before stale data
can be returned.

### Files changed

- `lib/dag/workflow/definition_fingerprint.rb` -- add `root_input` to
  fingerprint data; expose `normalize_root_input` as a public class method
  so callers can predict the fingerprint value
- `lib/dag/workflow/runner.rb` -- pass `root_input:` when computing the
  fingerprint
- `spec/runner_test.rb` -- regression test covering the repro case

### Acceptance criteria

- rerunning the same `workflow_id` with different `root_input` raises
  `ValidationError` (no silent stale reuse)
- behavior is explicit and covered by regression tests
- full test suite passes
- PR is small, focused, closes #59

### Tradeoffs

The fingerprint is now sensitive to runtime input values, which means
the same workflow code + different inputs cannot share persisted outputs.
This is the correct safety property: outputs are tightly coupled to the
inputs that produced them. There is no intermediate heuristic (e.g.
skipping only steps that read `root_input`) -- the fix is coarse because
the guarantee requires it.

Closes #59