### PR TITLE
fix: reject impossible schedule windows instead of forever-waiting (#60)

### DIFF
--- a/lib/dag/workflow/execution_persistence.rb
+++ b/lib/dag/workflow/execution_persistence.rb
@@ -65,6 +65,18 @@ module DAG
         )
       end
 
+      def persist_impossible_schedule_window(name, error)
+        return unless enabled?
+
+        @execution_store.set_node_state(
+          workflow_id: @workflow_id,
+          node_path: node_path_for(name),
+          state: :failed,
+          reason: error,
+          metadata: {}
+        )
+      end
+
       def load_reusable_result(name, schedule_policy: nil)
         return nil unless enabled?
 

--- a/lib/dag/workflow/execution_persistence.rb
+++ b/lib/dag/workflow/execution_persistence.rb
@@ -54,18 +54,14 @@ module DAG
       end
 
       def persist_expired_schedule_node(name, error)
-        return unless enabled?
-
-        @execution_store.set_node_state(
-          workflow_id: @workflow_id,
-          node_path: node_path_for(name),
-          state: :failed,
-          reason: error,
-          metadata: {}
-        )
+        persist_failed_schedule_node(name, error)
       end
 
       def persist_impossible_schedule_window(name, error)
+        persist_failed_schedule_node(name, error)
+      end
+
+      def persist_failed_schedule_node(name, error)
         return unless enabled?
 
         @execution_store.set_node_state(
@@ -76,6 +72,7 @@ module DAG
           metadata: {}
         )
       end
+      private :persist_failed_schedule_node
 
       def load_reusable_result(name, schedule_policy: nil)
         return nil unless enabled?

--- a/lib/dag/workflow/layer_admitter.rb
+++ b/lib/dag/workflow/layer_admitter.rb
@@ -27,7 +27,11 @@ module DAG
           begin
             input_keys = @dependency_input_resolver.input_keys_for(name: name, step: step)
 
-            if schedule_policy.waiting?
+            if schedule_policy.impossible_window?
+              result = schedule_policy.impossible_window_result(name)
+              @execution_persistence.persist_impossible_schedule_window(name, result.error)
+              immediate_results << ImmediateResult.new(name: name, result: result, input_keys: input_keys, status: :failure)
+            elsif schedule_policy.waiting?
               waiting_nodes << @execution_persistence.node_path_for(name)
               @execution_persistence.persist_waiting_node(name)
             elsif schedule_policy.expired?

--- a/lib/dag/workflow/schedule_policy.rb
+++ b/lib/dag/workflow/schedule_policy.rb
@@ -34,6 +34,7 @@ module DAG
       end
 
       def expired?
+        return false if impossible_window?
         not_after && @clock.wall_now > not_after
       end
 

--- a/lib/dag/workflow/schedule_policy.rb
+++ b/lib/dag/workflow/schedule_policy.rb
@@ -29,6 +29,7 @@ module DAG
       end
 
       def waiting?
+        return false if impossible_window?
         not_before && @clock.wall_now < not_before
       end
 
@@ -36,10 +37,23 @@ module DAG
         not_after && @clock.wall_now > not_after
       end
 
+      def impossible_window?
+        not_before && not_after && not_before > not_after
+      end
+
       def deadline_exceeded_result(name)
         Failure.new(error: {
           code: :deadline_exceeded,
           message: "step #{name} missed schedule.not_after #{not_after.utc.iso8601}",
+          not_after: not_after.utc.iso8601
+        })
+      end
+
+      def impossible_window_result(name)
+        Failure.new(error: {
+          code: :invalid_schedule_window,
+          message: "step #{name} has schedule.not_before #{not_before.utc.iso8601} after schedule.not_after #{not_after.utc.iso8601}: impossible window",
+          not_before: not_before.utc.iso8601,
           not_after: not_after.utc.iso8601
         })
       end

--- a/spec/layer_admitter_test.rb
+++ b/spec/layer_admitter_test.rb
@@ -86,6 +86,67 @@ class LayerAdmitterTest < Minitest::Test
     assert_equal :failed, store.load_run("wf-layer-admitter")[:nodes][[:expired]][:state]
   end
 
+  def test_call_rejects_impossible_schedule_window_as_failure_not_waiting
+    # Regression: not_before > not_after must not park in :waiting state.
+    # It should immediately fail with :invalid_schedule_window.
+    clock = build_clock(wall_time: Time.utc(2026, 4, 15, 9, 0, 0))
+    store = build_memory_store
+    definition = build_test_workflow(
+      impossible: {
+        type: :ruby,
+        schedule: {
+          not_before: Time.utc(2026, 4, 15, 10, 0, 0), # > not_after
+          not_after: Time.utc(2026, 4, 15, 8, 0, 0)   # < not_before
+        },
+        callable: ->(_input) { DAG::Success.new(value: "never") }
+      }
+    )
+
+    store.begin_run(
+      workflow_id: "wf-impossible-window",
+      definition_fingerprint: "fp-impossible-window",
+      node_paths: [[:impossible]]
+    )
+
+    persistence = DAG::Workflow::ExecutionPersistence.new(
+      execution_store: store,
+      workflow_id: "wf-impossible-window",
+      registry: definition.registry,
+      clock: clock
+    )
+    resolver = DAG::Workflow::DependencyInputResolver.new(
+      graph: definition.graph,
+      execution_store: store,
+      workflow_id: "wf-impossible-window"
+    )
+
+    admitter = DAG::Workflow::LayerAdmitter.new(
+      graph: definition.graph,
+      registry: definition.registry,
+      clock: clock,
+      execution_persistence: persistence,
+      dependency_input_resolver: resolver,
+      root_input: {},
+      task_builder: ->(**_kwargs) { flunk "task_builder should not be called for impossible window" }
+    )
+
+    partition = admitter.call(layer: [:impossible], previous_outputs: {}, statuses: {}, deadline: nil)
+
+    # The step must not be put in waiting_nodes.
+    assert_empty partition.waiting_nodes, "impossible window must not enter :waiting state"
+    # Must appear in immediate_results as a failure.
+    assert_equal [:impossible], partition.immediate_results.map(&:name)
+    assert_equal [:failure], partition.immediate_results.map(&:status)
+    # The stored error must have the correct code.
+    error = partition.immediate_results.first.result.error
+    assert_equal :invalid_schedule_window, error[:code]
+    assert_match(/not_before.*after.*not_after/, error[:message])
+    # The execution store must have recorded :failed state, not :waiting.
+    run_record = store.load_run("wf-impossible-window")
+    assert_equal :failed, run_record[:nodes][[:impossible]][:state]
+    assert_equal :invalid_schedule_window, run_record[:nodes][[:impossible]][:reason][:code]
+  end
+
   def test_call_translates_missing_execution_store_into_immediate_failure
     definition = build_test_workflow(
       source: {

--- a/spec/schedule_policy_test.rb
+++ b/spec/schedule_policy_test.rb
@@ -16,6 +16,24 @@ class SchedulePolicyTest < Minitest::Test
     assert_equal Time.utc(2026, 4, 15, 10, 0, 0), policy.not_before
   end
 
+  def test_contradictory_not_before_greater_than_not_after_is_never_waiting
+    # When not_before > not_after the window is impossible.
+    # The step must NOT enter a long-lived :waiting state —
+    # it should fail immediately with :invalid_schedule_window.
+    clock = build_clock(wall_time: Time.utc(2026, 4, 15, 9, 0, 0))
+    step = build_step(schedule: {
+      not_before: Time.utc(2026, 4, 15, 10, 0, 0), # > not_after
+      not_after: Time.utc(2026, 4, 15, 8, 0, 0)   # < not_before
+    })
+
+    policy = DAG::Workflow::SchedulePolicy.new(step, clock: clock)
+
+    # The policy must expose the contradiction so LayerAdmitter can reject it.
+    # This is the contract: impossible windows are never waiting.
+    refute policy.waiting?, "not_before > not_after must not return waiting? = true"
+    assert policy.impossible_window?, "impossible_window? must be true when not_before > not_after"
+  end
+
   def test_expired_when_wall_clock_is_after_not_after
     clock = build_clock(wall_time: Time.utc(2026, 4, 15, 10, 0, 1))
     step = build_step(schedule: {not_after: Time.utc(2026, 4, 15, 10, 0, 0)})


### PR DESCRIPTION
## Root cause

`SchedulePolicy#waiting?` was evaluated before any impossible-window check.
When `clock.wall_now` is before `not_before`, the policy returned `true`,
parking the step in a long-lived `:waiting` state — even though
`not_before > not_after` makes the window logically impossible to ever satisfy.

## Chosen contract

**Reject contradictory schedule windows early as invalid, not as waiting.**

An impossible window is a definition-time mistake, not a timing condition.
Treating it as a failure is deterministic, makes the bug visible immediately,
and avoids workflows that stall indefinitely waiting for a moment that cannot
arrive.

```
Contract: not_before > not_after → :invalid_schedule_window failure
          never enters :waiting state
```

## Files changed

| File | Change |
|------|--------|
| `lib/dag/workflow/schedule_policy.rb` | `impossible_window?`, `impossible_window_result`, `waiting?` guards against impossible |
| `lib/dag/workflow/layer_admitter.rb` | Check `impossible_window?` before `waiting?` |
| `lib/dag/workflow/execution_persistence.rb` | `persist_impossible_schedule_window` |
| `spec/schedule_policy_test.rb` | Regression test for `impossible_window?` |
| `spec/layer_admitter_test.rb` | Regression test for end-to-end rejection |

## Tests run

```
bundle exec ruby -Itest spec/schedule_policy_test.rb
bundle exec ruby -Itest spec/layer_admitter_test.rb
# Full suite: 781 runs, 40976 assertions, 0 failures
```

Closes #60