### PR TITLE
[codex] fix subtree run_if reconnect refs

### DIFF
--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -62,7 +62,8 @@ module DAG
 
         root = root_node.to_sym
         removed = [root]
-        validate_reconnect_aliases!(definition.graph, root, reconnect)
+        normalized_reconnect = normalize_reconnect_alias_entries(definition.graph, root, reconnect)
+        validate_reconnect_aliases!(definition.graph, root, normalized_reconnect)
 
         new_graph = definition.graph.with_subtree_replaced(
           root: root,
@@ -72,18 +73,21 @@ module DAG
         new_registry = definition.registry.dup
         removed.each { |name| new_registry.remove(name) }
         replacement.registry.steps.each { |step| new_registry.register(step) }
+        rewrite_reconnected_run_if_refs!(new_registry, definition.graph, root, normalized_reconnect)
 
         Definition.new(graph: new_graph, registry: new_registry, source_path: definition.source_path)
       end
 
       private
 
-      def validate_reconnect_aliases!(graph, root, reconnect)
-        aliases_by_target = Hash.new { |hash, key| hash[key] = Set.new }
-        normalized_reconnect = Array(reconnect).map do |descriptor|
+      def normalize_reconnect_alias_entries(graph, root, reconnect)
+        Array(reconnect).map do |descriptor|
           normalize_reconnect_alias_entry(descriptor, graph: graph, root: root)
         end
+      end
 
+      def validate_reconnect_aliases!(graph, root, normalized_reconnect)
+        aliases_by_target = Hash.new { |hash, key| hash[key] = Set.new }
         normalized_reconnect.each do |entry|
           target = entry.fetch(:to)
           aliases = aliases_by_target[target]
@@ -106,6 +110,38 @@ module DAG
 
           aliases_by_target[target] << alias_key
         end
+      end
+
+      def rewrite_reconnected_run_if_refs!(registry, graph, root, normalized_reconnect)
+        reconnects_by_target = normalized_reconnect.group_by { |entry| entry.fetch(:to) }
+
+        graph.each_successor(root) do |target|
+          next unless registry.key?(target)
+
+          step = registry[target]
+          run_if = step.config[:run_if]
+          next unless Condition.referenced_from_keys(run_if).include?(root)
+
+          reconnects = reconnects_by_target.fetch(target, [])
+          raise_stale_run_if_reconnect_error!(target, root) if reconnects.empty?
+          raise_ambiguous_run_if_reconnect_error!(target, root, reconnects) if reconnects.size > 1
+
+          rewritten = Condition.rename_from(run_if, root, reconnects.first.fetch(:from))
+          registry.replace(Step.new(name: step.name, type: step.type, **step.config.merge(run_if: rewritten)))
+        end
+      end
+
+      def raise_stale_run_if_reconnect_error!(target, root)
+        raise ArgumentError,
+          "subtree replacement would leave node #{target} run_if referencing removed node #{root}; " \
+          "reconnect #{root} to #{target} or update run_if before replacing the subtree"
+      end
+
+      def raise_ambiguous_run_if_reconnect_error!(target, root, reconnects)
+        leaves = reconnects.map { |entry| entry.fetch(:from) }.sort
+        raise ArgumentError,
+          "ambiguous run_if rewrite for node #{target}: removed node #{root} reconnects through " \
+          "multiple replacement leaves #{leaves.inspect}"
       end
 
       def normalize_reconnect_alias_entry(descriptor, graph:, root:)

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -126,7 +126,12 @@ module DAG
           raise_stale_run_if_reconnect_error!(target, root) if reconnects.empty?
           raise_ambiguous_run_if_reconnect_error!(target, root, reconnects) if reconnects.size > 1
 
-          rewritten = Condition.rename_from(run_if, root, reconnects.first.fetch(:from))
+          replacement_leaf = reconnects.first.fetch(:from)
+          if external_dependency_input_keys(step).include?(replacement_leaf)
+            raise_external_run_if_alias_collision_error!(target, root, replacement_leaf)
+          end
+
+          rewritten = Condition.rename_from(run_if, root, replacement_leaf)
           registry.replace(Step.new(name: step.name, type: step.type, **step.config.merge(run_if: rewritten)))
         end
       end
@@ -142,6 +147,20 @@ module DAG
         raise ArgumentError,
           "ambiguous run_if rewrite for node #{target}: removed node #{root} reconnects through " \
           "multiple replacement leaves #{leaves.inspect}"
+      end
+
+      def raise_external_run_if_alias_collision_error!(target, root, replacement_leaf)
+        raise ArgumentError,
+          "ambiguous run_if rewrite for node #{target}: removed node #{root} reconnects through " \
+          "replacement leaf #{replacement_leaf}, which collides with an external dependency alias on #{target}"
+      end
+
+      def external_dependency_input_keys(step)
+        Array(step.config[:external_dependencies]).filter_map do |dependency|
+          normalized = dependency.transform_keys(&:to_sym)
+          key = normalized[:as] || normalized[:node]
+          key&.to_sym
+        end
       end
 
       def normalize_reconnect_alias_entry(descriptor, graph:, root:)

--- a/spec/mutation_test.rb
+++ b/spec/mutation_test.rb
@@ -103,6 +103,187 @@ class MutationTest < Minitest::Test
     refute definition.graph.node?(:normalize)
   end
 
+  def test_workflow_replace_subtree_rewrites_downstream_declarative_run_if
+    definition = build_test_workflow(
+      source: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "payload") }
+      },
+      process: {
+        type: :ruby,
+        depends_on: [:source],
+        callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+      },
+      report: {
+        type: :ruby,
+        depends_on: [:process],
+        run_if: {from: :process, status: :success},
+        callable: ->(input) { DAG::Success.new(value: "report:#{input[:summarize]}") }
+      }
+    )
+
+    replacement = build_test_workflow(
+      summarize: {
+        type: :ruby,
+        callable: ->(input) { DAG::Success.new(value: input[:source].downcase) }
+      }
+    )
+
+    mutated = DAG::Workflow.replace_subtree(
+      definition,
+      root_node: :process,
+      replacement: replacement,
+      reconnect: [{from: :summarize, to: :report}]
+    )
+
+    assert_equal :summarize, mutated.step(:report).config[:run_if][:from]
+
+    result = DAG::Workflow::Runner.new(mutated, parallel: false).call
+
+    assert result.success?
+    assert_equal "report:payload", result.outputs[:report].value
+  end
+
+  def test_workflow_replace_subtree_rewrites_nested_downstream_declarative_run_if
+    definition = build_test_workflow(
+      source: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "payload") }
+      },
+      config: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "enabled") }
+      },
+      process: {
+        type: :ruby,
+        depends_on: [:source],
+        callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+      },
+      report: {
+        type: :ruby,
+        depends_on: [:process, :config],
+        run_if: {
+          all: [
+            {from: :process, status: :success},
+            {not: {from: :config, value: {equals: "disabled"}}}
+          ]
+        },
+        callable: ->(input) { DAG::Success.new(value: "#{input[:summary]}|#{input[:config]}") }
+      }
+    )
+
+    replacement = build_test_workflow(
+      summarize: {
+        type: :ruby,
+        callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+      }
+    )
+
+    mutated = DAG::Workflow.replace_subtree(
+      definition,
+      root_node: :process,
+      replacement: replacement,
+      reconnect: [{from: :summarize, to: :report, metadata: {as: :summary}}]
+    )
+
+    run_if = mutated.step(:report).config[:run_if]
+    assert_equal :summarize, run_if[:all][0][:from]
+    assert_equal :config, run_if[:all][1][:not][:from]
+
+    result = DAG::Workflow::Runner.new(mutated, parallel: false).call
+
+    assert result.success?
+    assert_equal "PAYLOAD|enabled", result.outputs[:report].value
+  end
+
+  def test_workflow_replace_subtree_rejects_ambiguous_downstream_run_if_rewrite
+    definition = build_test_workflow(
+      source: {type: :ruby, callable: ->(_) { DAG::Success.new(value: "payload") }},
+      process: {
+        type: :ruby,
+        depends_on: [:source],
+        callable: ->(input) { DAG::Success.new(value: input[:source]) }
+      },
+      report: {
+        type: :ruby,
+        depends_on: [:process],
+        run_if: {from: :process, status: :success},
+        callable: ->(_) { DAG::Success.new(value: "report") }
+      }
+    )
+
+    replacement = build_test_workflow(
+      normalize: {
+        type: :ruby,
+        callable: ->(input) { DAG::Success.new(value: input[:source]) }
+      },
+      left: {
+        type: :ruby,
+        depends_on: [:normalize],
+        callable: ->(input) { DAG::Success.new(value: input[:normalize]) }
+      },
+      right: {
+        type: :ruby,
+        depends_on: [:normalize],
+        callable: ->(input) { DAG::Success.new(value: input[:normalize]) }
+      }
+    )
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.replace_subtree(
+        definition,
+        root_node: :process,
+        replacement: replacement,
+        reconnect: [
+          {from: :left, to: :report},
+          {from: :right, to: :report}
+        ]
+      )
+    end
+
+    assert_includes error.message, "ambiguous run_if rewrite"
+    assert_includes error.message, "report"
+    assert_includes error.message, "process"
+    assert_includes error.message, "left"
+    assert_includes error.message, "right"
+  end
+
+  def test_workflow_replace_subtree_rejects_stale_downstream_run_if_without_reconnect
+    definition = build_test_workflow(
+      source: {type: :ruby, callable: ->(_) { DAG::Success.new(value: "payload") }},
+      process: {
+        type: :ruby,
+        depends_on: [:source],
+        callable: ->(input) { DAG::Success.new(value: input[:source]) }
+      },
+      report: {
+        type: :ruby,
+        depends_on: [:process],
+        run_if: {from: :process, status: :success},
+        callable: ->(_) { DAG::Success.new(value: "report") }
+      }
+    )
+
+    replacement = build_test_workflow(
+      summarize: {
+        type: :ruby,
+        callable: ->(input) { DAG::Success.new(value: input[:source]) }
+      }
+    )
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.replace_subtree(
+        definition,
+        root_node: :process,
+        replacement: replacement
+      )
+    end
+
+    assert_includes error.message, "run_if referencing removed node"
+    assert_includes error.message, "report"
+    assert_includes error.message, "process"
+  end
+
   def test_workflow_replace_subtree_preserves_unaffected_downstream_inputs
     definition = build_test_workflow(
       source: {

--- a/spec/mutation_test.rb
+++ b/spec/mutation_test.rb
@@ -196,6 +196,51 @@ class MutationTest < Minitest::Test
     assert_equal "PAYLOAD|enabled", result.outputs[:report].value
   end
 
+  def test_workflow_replace_subtree_rejects_run_if_rewrite_that_collides_with_external_dependency_alias
+    definition = build_test_workflow(
+      source: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "payload") }
+      },
+      process: {
+        type: :ruby,
+        depends_on: [:source],
+        callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+      },
+      report: {
+        type: :ruby,
+        depends_on: [
+          {from: :process, as: :summary},
+          {workflow: "pipeline-a", node: :validated_output, as: :summarize}
+        ],
+        run_if: {from: :process, value: {equals: "PAYLOAD"}},
+        callable: ->(input) { DAG::Success.new(value: "report:#{input[:summary]}") }
+      }
+    )
+
+    replacement = build_test_workflow(
+      summarize: {
+        type: :ruby,
+        callable: ->(input) { DAG::Success.new(value: input[:source].upcase) }
+      }
+    )
+
+    error = assert_raises(ArgumentError) do
+      DAG::Workflow.replace_subtree(
+        definition,
+        root_node: :process,
+        replacement: replacement,
+        reconnect: [{from: :summarize, to: :report}]
+      )
+    end
+
+    assert_includes error.message, "ambiguous run_if rewrite"
+    assert_includes error.message, "external dependency alias"
+    assert_includes error.message, "report"
+    assert_includes error.message, "process"
+    assert_includes error.message, "summarize"
+  end
+
   def test_workflow_replace_subtree_rejects_ambiguous_downstream_run_if_rewrite
     definition = build_test_workflow(
       source: {type: :ruby, callable: ->(_) { DAG::Success.new(value: "payload") }},


### PR DESCRIPTION
## Summary

Fixes declarative `run_if` handling during `DAG::Workflow.replace_subtree`.

When a downstream node is reconnected from a replacement leaf, any declarative
`run_if` condition that referenced the removed root is now rewritten to the
replacement leaf when the mapping is unambiguous.

## Root Cause

`replace_subtree` updated graph topology and registry entries, but left
downstream declarative `run_if.from` references pointing at the removed root
node. The resulting definition could be structurally reconnected but fail
workflow validation when a runner was constructed.

## Changes

- Normalize reconnect descriptors once and reuse them for validation and
  `run_if` rewrite decisions.
- Rewrite downstream declarative `run_if` references from the removed root to
  the unique replacement leaf.
- Reject missing or ambiguous reconnect mappings with `ArgumentError` instead
  of returning an invalid definition.
- Add regression coverage for the issue repro, nested conditions, ambiguous
  reconnects, and missing reconnects.

Closes #61.

## Validation

- `bundle exec ruby -Ilib:spec spec/mutation_test.rb`
- `bundle exec ruby -Ilib:spec spec/condition_test.rb`
- `bundle exec ruby -Ilib:spec spec/validator_test.rb`
- `bundle exec rake`
