### PR TITLE
fix(workflow): record :blocked_upstream for descendants of paused/waiting nodes (closes #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@
 
 ### Fixed
 
+- **Sub_workflow paused/waiting silently dropped downstream nodes**
+  (issue #75). When a sub_workflow returned `:paused` or `:waiting`,
+  `TaskCompletionHandler` skipped writing both `results[name]` and
+  `statuses[name]`. The next layer's `LayerAdmitter#dependency_outputs_ready?`
+  then quietly `next`'d any descendant whose dependency was missing — no
+  trace entry, no error. Fixed by:
+  - `TaskCompletionHandler` now writes `statuses[name]` (`:waiting` /
+    `:paused`) and persists the node state on lifecycle outcomes.
+  - `LayerAdmitter` uses a tri-state `predecessor_admission_status`
+    predicate. Predecessors in `:waiting`, `:paused`, or `:blocked_upstream`
+    block downstream admission and emit a `BlockedResult` that the
+    `TraceRecorder` materializes as a `:blocked_upstream` `TraceEntry`.
+  - `:blocked_upstream` propagates transitively through `statuses`, so
+    chains and diamond joins are recorded explicitly without
+    interrupting independent parallel branches.
+  - The same status-aware admission also closes the analogous
+    silent-drop for `SchedulePolicy.waiting?` and
+    `DependencyInputResolver::WaitingForDependencyError`.
+  - New `ExecutionPersistence#persist_paused_node` mirrors
+    `persist_waiting_node` for paused lifecycle outcomes.
 - **EINTR in `Steps::Exec#drain_pipes`**: `read_nonblock(exception: false)`
   does not suppress `Errno::EINTR`. Under the `Threads` strategy with
   concurrent `:exec` steps, SIGCHLD from a sibling child could crash a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,15 @@ Adding a duplicate edge is **not** an error — `add_edge` is idempotent and ret
 ## Dumper round-trip property
 
 `Loader.from_yaml(Dumper.to_yaml(definition))` produces an equivalent Definition for all serializable step types. This includes edge metadata via expanded `depends_on` format. Tested against every example YAML.
+
+## Roadmap board hygiene
+
+Issues for this repo are tracked on GitHub Project #2 (`ruby-dag Roadmap v3.4`, project_id `PVT_kwHOAAsSz84BVsbw`). The board has a `Roadmap Status` field with options `Backlog | Ready | In Progress | Blocked | Done` (field_id `PVTSSF_lAHOAAsSz84BVsbwzhRGfOs`). **Keep this field current at every transition** — it is the source of truth for "what is in progress, what is ready to pick up, what is blocked, what is done".
+
+- New issues triaged but not scheduled → `Backlog` (`92bab679`).
+- Issue reviewed and a plan written → `Ready` (`cbe5fa16`).
+- PR opened or work actively in progress → `In Progress` (`17602557`).
+- Work paused on an external dependency or another issue → `Blocked` (`77d114c8`); also fill the `Blocked By` field.
+- PR merged → `Done` (`0372fd32`) (also set `Status = Done`).
+
+Update via `gh project item-edit --id <ITEM_ID> --field-id PVTSSF_lAHOAAsSz84BVsbwzhRGfOs --project-id PVT_kwHOAAsSz84BVsbw --single-select-option-id <OPT_ID>`. Look up `ITEM_ID` with `gh project item-list 2 --owner duncanita --format json | jq '.items[] | select(.content.number == <N>) | .id'`.

--- a/lib/dag/workflow/execution_persistence.rb
+++ b/lib/dag/workflow/execution_persistence.rb
@@ -53,6 +53,17 @@ module DAG
         )
       end
 
+      def persist_paused_node(name)
+        return unless enabled?
+
+        @execution_store.set_node_state(
+          workflow_id: @workflow_id,
+          node_path: node_path_for(name),
+          state: :paused,
+          metadata: {}
+        )
+      end
+
       def persist_expired_schedule_node(name, error)
         persist_failed_schedule_node(name, error)
       end

--- a/lib/dag/workflow/layer_admitter.rb
+++ b/lib/dag/workflow/layer_admitter.rb
@@ -3,6 +3,8 @@
 module DAG
   module Workflow
     class LayerAdmitter
+      PREDECESSOR_BLOCKING_STATUSES = %i[waiting paused blocked_upstream].freeze
+
       def initialize(graph:, registry:, clock:, execution_persistence:, dependency_input_resolver:, root_input:, task_builder:)
         @graph = graph
         @registry = registry
@@ -17,9 +19,21 @@ module DAG
         runnable = []
         immediate_results = []
         waiting_nodes = []
+        blocked_results = []
 
         layer.each do |name|
-          next unless dependency_outputs_ready?(name, previous_outputs)
+          admission, blocked_by = predecessor_admission_status(name, previous_outputs, statuses)
+          if admission == :blocked_upstream
+            blocked_results << BlockedResult.new(
+              name: name,
+              predecessor: blocked_by[0],
+              predecessor_status: blocked_by[1],
+              input_keys: @dependency_input_resolver.input_keys_for(name: name, step: @registry[name])
+            )
+            statuses[name] = :blocked_upstream
+            next
+          end
+          next unless admission == :ready
 
           step = @registry[name]
           schedule_policy = SchedulePolicy.new(step, clock: @clock)
@@ -34,6 +48,7 @@ module DAG
             elsif schedule_policy.waiting?
               waiting_nodes << @execution_persistence.node_path_for(name)
               @execution_persistence.persist_waiting_node(name)
+              statuses[name] = :waiting
             elsif schedule_policy.expired?
               result = schedule_policy.deadline_exceeded_result(name)
               @execution_persistence.persist_expired_schedule_node(name, result.error)
@@ -60,6 +75,7 @@ module DAG
           rescue DependencyInputResolver::WaitingForDependencyError
             waiting_nodes << @execution_persistence.node_path_for(name)
             @execution_persistence.persist_waiting_node(name)
+            statuses[name] = :waiting
           rescue DependencyInputResolver::ResolverError => e
             immediate_results << failure_result(name, :cross_workflow_resolution_failed, e.message,
               workflow_id: e.workflow_id, node_name: e.node_name, version: e.version)
@@ -74,7 +90,12 @@ module DAG
           end
         end
 
-        LayerPartition.new(runnable: runnable, immediate_results: immediate_results, waiting_nodes: waiting_nodes)
+        LayerPartition.new(
+          runnable: runnable,
+          immediate_results: immediate_results,
+          waiting_nodes: waiting_nodes,
+          blocked_results: blocked_results
+        )
       end
 
       private
@@ -97,8 +118,23 @@ module DAG
 
       def record_skip_result = Success.new(value: nil)
 
-      def dependency_outputs_ready?(name, outputs)
-        @graph.each_predecessor(name).all? { |dep| outputs.key?(dep) }
+      def predecessor_admission_status(name, outputs, statuses)
+        blocked_by = nil
+        not_ready = false
+        @graph.each_predecessor(name) do |dep|
+          next if outputs.key?(dep)
+
+          dep_status = statuses[dep]
+          if PREDECESSOR_BLOCKING_STATUSES.include?(dep_status)
+            blocked_by ||= [dep, dep_status]
+          else
+            not_ready = true
+          end
+        end
+        return [:blocked_upstream, blocked_by] if blocked_by
+        return [:not_ready_yet, nil] if not_ready
+
+        [:ready, nil]
       end
 
       def build_condition_context(name, step, outputs, statuses)

--- a/lib/dag/workflow/layer_partition.rb
+++ b/lib/dag/workflow/layer_partition.rb
@@ -3,6 +3,7 @@
 module DAG
   module Workflow
     ImmediateResult = Data.define(:name, :result, :input_keys, :status)
-    LayerPartition = Data.define(:runnable, :immediate_results, :waiting_nodes)
+    BlockedResult = Data.define(:name, :predecessor, :predecessor_status, :input_keys)
+    LayerPartition = Data.define(:runnable, :immediate_results, :waiting_nodes, :blocked_results)
   end
 end

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -293,6 +293,12 @@ module DAG
           trace: trace,
           node_path_for: method(:node_path_for)
         )
+        @trace_recorder.record_blocked_results(
+          entries: partition.blocked_results,
+          layer_index: layer_index,
+          trace: trace,
+          node_path_for: method(:node_path_for)
+        )
         task_waiting_nodes, paused = run_tasks(partition.runnable, layer_index, trace, results, statuses)
         waiting_nodes = partition.waiting_nodes + task_waiting_nodes
 

--- a/lib/dag/workflow/task_completion_handler.rb
+++ b/lib/dag/workflow/task_completion_handler.rb
@@ -26,6 +26,8 @@ module DAG
         @execution_persistence.persist_step_result(task, result, entries, skip_result: !lifecycle_payload.nil?)
 
         if lifecycle_payload
+          statuses[task.name] = lifecycle_payload[:status]
+          persist_lifecycle_node(task.name, lifecycle_payload[:status])
           @callbacks.finish(task.name, @lifecycle_callback_result.call(lifecycle_payload))
           return TaskCompletionOutcome.new(
             waiting_nodes: (lifecycle_payload[:status] == :waiting) ? lifecycle_payload[:waiting_nodes] : [],
@@ -38,6 +40,15 @@ module DAG
         results[task.name] = result
 
         TaskCompletionOutcome.new(waiting_nodes: [], paused: false)
+      end
+
+      private
+
+      def persist_lifecycle_node(name, status)
+        case status
+        when :waiting then @execution_persistence.persist_waiting_node(name)
+        when :paused then @execution_persistence.persist_paused_node(name)
+        end
       end
     end
   end

--- a/lib/dag/workflow/trace_recorder.rb
+++ b/lib/dag/workflow/trace_recorder.rb
@@ -26,6 +26,22 @@ module DAG
         end
       end
 
+      def record_blocked_results(entries:, layer_index:, trace:, node_path_for:)
+        entries.each do |entry|
+          trace << TraceEntry.new(
+            name: trace_name_for(node_path_for.call(entry.name)),
+            layer: layer_index,
+            started_at: nil,
+            finished_at: nil,
+            duration_ms: 0,
+            status: :blocked_upstream,
+            input_keys: entry.input_keys,
+            attempt: 1,
+            retried: false
+          )
+        end
+      end
+
       def build_trace_entries_for_task(task:, layer_index:, result:, started_at:, finished_at:, duration_ms:, lifecycle_payload:)
         if task.attempt_log.empty?
           return [] if lifecycle_payload

--- a/spec/sub_workflow_test.rb
+++ b/spec/sub_workflow_test.rb
@@ -564,4 +564,179 @@ class SubWorkflowTest < Minitest::Test
     assert_equal :process, result.error[:failed_node]
     assert_equal :sub_workflow_input_missing, result.error[:step_error][:code]
   end
+
+  def test_sub_workflow_waiting_records_blocked_upstream_for_single_downstream
+    clock = build_clock(wall_time: Time.utc(2026, 4, 15, 9, 0, 0))
+
+    parent = parent_with_waiting_child_and(downstream: {
+      finalize: {
+        type: :ruby,
+        depends_on: [:process],
+        callable: ->(input) { DAG::Success.new(value: "finalized:#{input[:process]}") }
+      }
+    })
+
+    result = DAG::Workflow::Runner.new(parent, parallel: false, clock: clock).call
+
+    assert_equal :waiting, result.status
+    refute result.outputs.key?(:process)
+    refute result.outputs.key?(:finalize)
+
+    finalize_entry = result.trace.find { |e| e.name == :finalize }
+    refute_nil finalize_entry, "expected blocked_upstream trace entry for :finalize"
+    assert_equal :blocked_upstream, finalize_entry.status
+  end
+
+  def test_sub_workflow_waiting_propagates_blocked_upstream_transitively
+    clock = build_clock(wall_time: Time.utc(2026, 4, 15, 9, 0, 0))
+
+    parent = parent_with_waiting_child_and(downstream: {
+      middle: {
+        type: :ruby,
+        depends_on: [:process],
+        callable: ->(input) { DAG::Success.new(value: input[:process]) }
+      },
+      tail: {
+        type: :ruby,
+        depends_on: [:middle],
+        callable: ->(input) { DAG::Success.new(value: input[:middle]) }
+      }
+    })
+
+    result = DAG::Workflow::Runner.new(parent, parallel: false, clock: clock).call
+
+    assert_equal :waiting, result.status
+    refute result.outputs.key?(:middle)
+    refute result.outputs.key?(:tail)
+
+    statuses = result.trace.to_h { |e| [e.name, e.status] }
+    assert_equal :blocked_upstream, statuses[:middle]
+    assert_equal :blocked_upstream, statuses[:tail]
+  end
+
+  def test_sub_workflow_waiting_blocks_only_dependent_branch
+    clock = build_clock(wall_time: Time.utc(2026, 4, 15, 9, 0, 0))
+
+    parent = parent_with_waiting_child_and(downstream: {
+      blocked_branch: {
+        type: :ruby,
+        depends_on: [:process],
+        callable: ->(input) { DAG::Success.new(value: input[:process]) }
+      },
+      independent_root: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "indep") }
+      },
+      independent_leaf: {
+        type: :ruby,
+        depends_on: [:independent_root],
+        callable: ->(input) { DAG::Success.new(value: "leaf:#{input[:independent_root]}") }
+      }
+    })
+
+    result = DAG::Workflow::Runner.new(parent, parallel: false, clock: clock).call
+
+    assert_equal :waiting, result.status
+    assert_equal "indep", result.outputs[:independent_root].value
+    assert_equal "leaf:indep", result.outputs[:independent_leaf].value
+    refute result.outputs.key?(:blocked_branch)
+
+    blocked_entry = result.trace.find { |e| e.name == :blocked_branch }
+    refute_nil blocked_entry
+    assert_equal :blocked_upstream, blocked_entry.status
+  end
+
+  def test_sub_workflow_waiting_blocks_diamond_join_when_one_branch_waits
+    clock = build_clock(wall_time: Time.utc(2026, 4, 15, 9, 0, 0))
+    future_time = Time.utc(2026, 4, 15, 10, 0, 0)
+
+    child = DAG::Workflow::Loader.from_hash(
+      gated: {
+        type: :ruby,
+        schedule: {not_before: future_time},
+        callable: ->(_input) { DAG::Success.new(value: "later") }
+      }
+    )
+
+    parent = DAG::Workflow::Loader.from_hash(
+      seed: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: "seed") }
+      },
+      process: {
+        type: :sub_workflow,
+        definition: child,
+        depends_on: [:seed]
+      },
+      sibling: {
+        type: :ruby,
+        depends_on: [:seed],
+        callable: ->(input) { DAG::Success.new(value: "sibling:#{input[:seed]}") }
+      },
+      join: {
+        type: :ruby,
+        depends_on: [:process, :sibling],
+        callable: ->(input) { DAG::Success.new(value: "joined") }
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(parent, parallel: false, clock: clock).call
+
+    assert_equal :waiting, result.status
+    assert_equal "seed", result.outputs[:seed].value
+    assert_equal "sibling:seed", result.outputs[:sibling].value
+    refute result.outputs.key?(:join)
+
+    join_entry = result.trace.find { |e| e.name == :join }
+    refute_nil join_entry
+    assert_equal :blocked_upstream, join_entry.status
+  end
+
+  def test_lifecycle_paused_blocks_downstream_when_pause_flag_not_set_externally
+    fake_paused = ->(_input) do
+      DAG::Success.new(value: {
+        __sub_workflow_status__: :paused,
+        __sub_workflow_trace__: []
+      })
+    end
+
+    parent = DAG::Workflow::Loader.from_hash(
+      process: {
+        type: :ruby,
+        callable: fake_paused
+      },
+      finalize: {
+        type: :ruby,
+        depends_on: [:process],
+        callable: ->(input) { DAG::Success.new(value: "finalized:#{input[:process]}") }
+      }
+    )
+
+    result = DAG::Workflow::Runner.new(parent, parallel: false).call
+
+    assert_equal :paused, result.status
+    refute result.outputs.key?(:process)
+    refute result.outputs.key?(:finalize)
+
+    finalize_entry = result.trace.find { |e| e.name == :finalize }
+    refute_nil finalize_entry, "expected blocked_upstream trace entry for :finalize"
+    assert_equal :blocked_upstream, finalize_entry.status
+  end
+
+  private
+
+  def parent_with_waiting_child_and(downstream:)
+    future_time = Time.utc(2026, 4, 15, 10, 0, 0)
+
+    child = DAG::Workflow::Loader.from_hash(
+      gated: {
+        type: :ruby,
+        schedule: {not_before: future_time},
+        callable: ->(_input) { DAG::Success.new(value: "later") }
+      }
+    )
+
+    nodes = {process: {type: :sub_workflow, definition: child}}.merge(downstream)
+    DAG::Workflow::Loader.from_hash(**nodes)
+  end
 end

--- a/spec/task_completion_handler_test.rb
+++ b/spec/task_completion_handler_test.rb
@@ -50,7 +50,7 @@ class TaskCompletionHandlerTest < Minitest::Test
     assert_equal [[task, result, trace, false]], persistence.calls
   end
 
-  def test_handle_lifecycle_result_returns_waiting_without_mutating_results_or_statuses
+  def test_handle_lifecycle_waiting_marks_status_without_writing_result
     callback_events = []
     callbacks = DAG::Workflow::RunCallbacks.new(
       on_step_finish: ->(name, result) { callback_events << [name, result] }
@@ -87,13 +87,54 @@ class TaskCompletionHandlerTest < Minitest::Test
     assert_equal [[:process, :child]], outcome.waiting_nodes
     refute outcome.paused
     assert_equal child_trace, trace
-    assert_equal({}, statuses)
+    assert_equal({process: :waiting}, statuses)
     assert_equal({}, results)
     assert_equal 1, callback_events.size
     assert_equal :process, callback_events.first[0]
     assert_kind_of DAG::Success, callback_events.first[1]
     assert_nil callback_events.first[1].value
     assert_equal [[task, result, child_trace, true]], persistence.calls
+    assert_equal [:process], persistence.waiting_nodes
+    assert_empty persistence.paused_nodes
+  end
+
+  def test_handle_lifecycle_paused_marks_status_without_writing_result
+    callbacks = DAG::Workflow::RunCallbacks.new
+    child_trace = [build_trace_entry(name: :"process.inner", status: :success)]
+    trace_recorder = build_trace_recorder(entries: child_trace, observed_status: :success)
+    persistence = build_persistence_spy
+    handler = DAG::Workflow::TaskCompletionHandler.new(
+      trace_recorder: trace_recorder,
+      execution_persistence: persistence,
+      callbacks: callbacks,
+      lifecycle_callback_result: ->(_lifecycle) { DAG::Success.new(value: nil) }
+    )
+    task = build_task(name: :process, node_path: [:process])
+    result = DAG::Success.new(value: {__sub_workflow_status__: :paused})
+    trace = []
+    results = {}
+    statuses = {}
+    lifecycle = {status: :paused, waiting_nodes: []}
+
+    outcome = handler.handle(
+      task: task,
+      result: result,
+      layer_index: 1,
+      started_at: 3.0,
+      finished_at: 4.0,
+      duration_ms: 1000.0,
+      trace: trace,
+      results: results,
+      statuses: statuses,
+      lifecycle_payload: lifecycle
+    )
+
+    assert_equal [], outcome.waiting_nodes
+    assert outcome.paused
+    assert_equal({process: :paused}, statuses)
+    assert_equal({}, results)
+    assert_equal [:process], persistence.paused_nodes
+    assert_empty persistence.waiting_nodes
   end
 
   private
@@ -146,14 +187,24 @@ class TaskCompletionHandlerTest < Minitest::Test
 
   def build_persistence_spy
     Class.new do
-      attr_reader :calls
+      attr_reader :calls, :waiting_nodes, :paused_nodes
 
       def initialize
         @calls = []
+        @waiting_nodes = []
+        @paused_nodes = []
       end
 
       def persist_step_result(task, result, entries, skip_result: false)
         @calls << [task, result, entries, skip_result]
+      end
+
+      def persist_waiting_node(name)
+        @waiting_nodes << name
+      end
+
+      def persist_paused_node(name)
+        @paused_nodes << name
       end
     end.new
   end


### PR DESCRIPTION
## Summary

Closes #75 (P0 / CRITICAL).

A sub_workflow returning `:paused` / `:waiting` (and the analogous `SchedulePolicy.waiting?` / `WaitingForDependencyError` paths) silently dropped any descendant whose dependency was missing — no trace entry, no error.

The fix propagates non-completion via `statuses` and adds a tri-state admission predicate in `LayerAdmitter`. Descendants of a paused/waiting predecessor get an explicit `:blocked_upstream` `TraceEntry`. Independent parallel branches keep running (no break of the layer loop).

- `TaskCompletionHandler` writes `statuses[name]` and persists the node state on lifecycle outcomes.
- `LayerAdmitter#predecessor_admission_status` returns `:ready | :not_ready_yet | :blocked_upstream`. Blocked nodes emit a `BlockedResult` that `TraceRecorder` materializes as a `:blocked_upstream` `TraceEntry` (no callbacks, no result).
- `:blocked_upstream` propagates transitively via `statuses`, covering chains and diamond joins.
- New `ExecutionPersistence#persist_paused_node` mirrors `persist_waiting_node`.
- CHANGELOG entry under 0.4.0 / Fixed.
- CLAUDE.md gains a "Roadmap board hygiene" section so future agents keep the project board's `Roadmap Status` field current.

## Test plan

- [x] `bundle exec rake` (test + lint): 792 runs, 41 049 assertions, 0 failures (was 787 before).
- [x] 5 new sub_workflow scenarios: single downstream, transitive chain (3-deep), parallel mixed branches, diamond join, lifecycle-paused without external flag.
- [x] 2 new unit tests on `TaskCompletionHandler` for `:waiting` and `:paused` lifecycle persistence + status propagation.
- [x] Manual regression: existing sub_workflow paused/waiting tests (no downstream) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)