### PR TITLE
fix(workflow): unify local-dep run_if key contract on input_key (closes #79)

### DIFF
--- a/lib/dag/workflow/dependency_input_resolver.rb
+++ b/lib/dag/workflow/dependency_input_resolver.rb
@@ -203,7 +203,7 @@ module DAG
       def local_condition_context(name, outputs, statuses)
         local_dependencies_for(name).to_h do |dependency|
           status = (dependency.version == :latest) ? statuses.fetch(dependency.name) : :success
-          [dependency.name, {
+          [dependency.input_key, {
             value: resolve_local_dependency_value(dependency, outputs),
             status: status
           }]

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -120,8 +120,11 @@ module DAG
 
           step = registry[target]
           run_if = step.config[:run_if]
+          referenced = Condition.referenced_from_keys(run_if)
+          next if referenced.empty?
+
           old_input_key = effective_input_key(root, graph.edge_metadata(root, target))
-          next unless Condition.referenced_from_keys(run_if).include?(old_input_key)
+          next unless referenced.include?(old_input_key)
 
           reconnects = reconnects_by_target.fetch(target, [])
           raise_stale_run_if_reconnect_error!(target, root) if reconnects.empty?

--- a/lib/dag/workflow/mutation.rb
+++ b/lib/dag/workflow/mutation.rb
@@ -120,18 +120,19 @@ module DAG
 
           step = registry[target]
           run_if = step.config[:run_if]
-          next unless Condition.referenced_from_keys(run_if).include?(root)
+          old_input_key = effective_input_key(root, graph.edge_metadata(root, target))
+          next unless Condition.referenced_from_keys(run_if).include?(old_input_key)
 
           reconnects = reconnects_by_target.fetch(target, [])
           raise_stale_run_if_reconnect_error!(target, root) if reconnects.empty?
           raise_ambiguous_run_if_reconnect_error!(target, root, reconnects) if reconnects.size > 1
 
-          replacement_leaf = reconnects.first.fetch(:from)
-          if external_dependency_input_keys(step).include?(replacement_leaf)
-            raise_external_run_if_alias_collision_error!(target, root, replacement_leaf)
+          new_input_key = effective_input_key(reconnects.first.fetch(:from), reconnects.first.fetch(:metadata))
+          if external_dependency_input_keys(step).include?(new_input_key)
+            raise_external_run_if_alias_collision_error!(target, root, new_input_key)
           end
 
-          rewritten = Condition.rename_from(run_if, root, replacement_leaf)
+          rewritten = Condition.rename_from(run_if, old_input_key, new_input_key)
           registry.replace(Step.new(name: step.name, type: step.type, **step.config.merge(run_if: rewritten)))
         end
       end

--- a/lib/dag/workflow/validator.rb
+++ b/lib/dag/workflow/validator.rb
@@ -131,25 +131,21 @@ module DAG
 
       def self.allowed_condition_inputs(graph, step, node_name:)
         local_keys = graph.each_predecessor(node_name).map do |dependency_name|
-          metadata = graph.edge_metadata(dependency_name, node_name)
-          (metadata[:as] || dependency_name).to_sym
+          local_effective_input_key(graph, dependency_name, node_name)
         end
         external_keys = Array(step.config[:external_dependencies]).map do |dependency|
-          (dependency[:as] || dependency[:node]).to_sym
+          external_effective_input_key(dependency)
         end
         local_keys + external_keys
       end
 
       def self.duplicate_effective_input_key_errors(graph, step, node_name:)
         keys = graph.each_predecessor(node_name).each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |dependency_name, memo|
-          metadata = graph.edge_metadata(dependency_name, node_name)
-          key = (metadata[:as] || dependency_name).to_sym
-          memo[key] << dependency_name
+          memo[local_effective_input_key(graph, dependency_name, node_name)] << dependency_name
         end
 
         Array(step.config[:external_dependencies]).each do |dependency|
-          key = (dependency[:as] || dependency[:node]).to_sym
-          keys[key] << "#{dependency[:workflow_id]}.#{dependency[:node]}"
+          keys[external_effective_input_key(dependency)] << "#{dependency[:workflow_id]}.#{dependency[:node]}"
         end
 
         keys.filter_map do |key, dependencies|
@@ -157,6 +153,15 @@ module DAG
 
           "Node #{node_name} has duplicate effective input key #{key.inspect} from dependencies #{dependencies.sort_by(&:to_s).inspect}"
         end
+      end
+
+      def self.local_effective_input_key(graph, dependency_name, node_name)
+        metadata = graph.edge_metadata(dependency_name, node_name)
+        (metadata[:as] || dependency_name).to_sym
+      end
+
+      def self.external_effective_input_key(dependency)
+        (dependency[:as] || dependency[:node]).to_sym
       end
 
       def self.validate_retry_max_attempts(value, node_name:, errors:)

--- a/lib/dag/workflow/validator.rb
+++ b/lib/dag/workflow/validator.rb
@@ -130,9 +130,14 @@ module DAG
       end
 
       def self.allowed_condition_inputs(graph, step, node_name:)
-        graph.predecessors(node_name) + Array(step.config[:external_dependencies]).map do |dependency|
+        local_keys = graph.each_predecessor(node_name).map do |dependency_name|
+          metadata = graph.edge_metadata(dependency_name, node_name)
+          (metadata[:as] || dependency_name).to_sym
+        end
+        external_keys = Array(step.config[:external_dependencies]).map do |dependency|
           (dependency[:as] || dependency[:node]).to_sym
         end
+        local_keys + external_keys
       end
 
       def self.duplicate_effective_input_key_errors(graph, step, node_name:)

--- a/spec/dependency_input_resolver_test.rb
+++ b/spec/dependency_input_resolver_test.rb
@@ -372,4 +372,53 @@ class DependencyInputResolverTest < Minitest::Test
     assert_equal "value-of-x", context[:x][:value]
     refute context.key?(:y)
   end
+
+  def test_callable_input_for_keys_local_aliased_dep_by_input_key
+    definition = build_test_workflow(
+      source: {type: :ruby, callable: ->(_input) { DAG::Success.new(value: "scan") }},
+      consumer: {
+        type: :ruby,
+        depends_on: [{from: :source, as: :first}],
+        callable: ->(input) { DAG::Success.new(value: input[:first]) }
+      }
+    )
+    resolver = DAG::Workflow::DependencyInputResolver.new(
+      graph: definition.graph, execution_store: nil, workflow_id: nil
+    )
+
+    lazy = resolver.callable_input_for(
+      name: :consumer,
+      step: definition.registry[:consumer],
+      outputs: {source: DAG::Success.new(value: "scan-1")},
+      statuses: {source: :success}
+    )
+
+    assert_equal "scan-1", lazy[:first]
+    assert lazy.key?(:first)
+    refute lazy.key?(:source)
+  end
+
+  def test_condition_context_for_keys_local_aliased_dep_by_input_key
+    definition = build_test_workflow(
+      source: {type: :ruby, callable: ->(_input) { DAG::Success.new(value: "scan") }},
+      consumer: {
+        type: :ruby,
+        depends_on: [{from: :source, as: :first}],
+        callable: ->(input) { DAG::Success.new(value: input[:first]) }
+      }
+    )
+    resolver = DAG::Workflow::DependencyInputResolver.new(
+      graph: definition.graph, execution_store: nil, workflow_id: nil
+    )
+
+    context = resolver.condition_context_for(
+      name: :consumer,
+      step: definition.registry[:consumer],
+      outputs: {source: DAG::Success.new(value: "scan-1")},
+      statuses: {source: :success}
+    )
+
+    assert_equal({value: "scan-1", status: :success}, context[:first])
+    refute context.key?(:source)
+  end
 end

--- a/spec/layer_admitter_test.rb
+++ b/spec/layer_admitter_test.rb
@@ -358,7 +358,7 @@ class LayerAdmitterTest < Minitest::Test
         resume_key: "consumer-v1",
         schedule: {ttl: 1},
         depends_on: [{from: :source, version: 1, as: :historical}],
-        run_if: {from: :source, value: {equals: "scan-1"}},
+        run_if: {from: :historical, value: {equals: "scan-1"}},
         callable: ->(input) { DAG::Success.new(value: input[:historical]) }
       }
     )
@@ -408,7 +408,7 @@ class LayerAdmitterTest < Minitest::Test
         resume_key: "consumer-v1",
         schedule: {ttl: 1},
         depends_on: [{from: :source, version: 1, as: :historical}],
-        run_if: ->(input) { input[:source] == "scan-1" },
+        run_if: ->(input) { input[:historical] == "scan-1" },
         callable: ->(input) do
           consumer_calls += 1
           DAG::Success.new(value: input[:historical])

--- a/spec/mutation_test.rb
+++ b/spec/mutation_test.rb
@@ -187,7 +187,7 @@ class MutationTest < Minitest::Test
     )
 
     run_if = mutated.step(:report).config[:run_if]
-    assert_equal :summarize, run_if[:all][0][:from]
+    assert_equal :summary, run_if[:all][0][:from]
     assert_equal :config, run_if[:all][1][:not][:from]
 
     result = DAG::Workflow::Runner.new(mutated, parallel: false).call
@@ -210,11 +210,11 @@ class MutationTest < Minitest::Test
       report: {
         type: :ruby,
         depends_on: [
-          {from: :process, as: :summary},
+          :process,
           {workflow: "pipeline-a", node: :validated_output, as: :summarize}
         ],
         run_if: {from: :process, value: {equals: "PAYLOAD"}},
-        callable: ->(input) { DAG::Success.new(value: "report:#{input[:summary]}") }
+        callable: ->(input) { DAG::Success.new(value: "report:#{input[:process]}") }
       }
     )
 

--- a/spec/runner_test.rb
+++ b/spec/runner_test.rb
@@ -1055,6 +1055,42 @@ class RunnerTest < Minitest::Test
     assert result.trace.any? { |e| e.status == :skipped }
   end
 
+  def test_callable_run_if_uses_input_key_for_local_aliased_dep
+    graph = DAG::Graph.new.add_node(:source).add_node(:consumer)
+    graph.add_edge(:source, :consumer, as: :first)
+    registry = DAG::Workflow::Registry.new
+    registry.register(DAG::Workflow::Step.new(name: :source, type: :ruby,
+      callable: ->(_) { DAG::Success.new(value: 1) }))
+    registry.register(DAG::Workflow::Step.new(name: :consumer, type: :ruby,
+      callable: ->(input) { DAG::Success.new(value: input[:first]) },
+      run_if: ->(input) { input[:first] == 1 }))
+
+    result = DAG::Workflow::Runner.new(graph, registry, parallel: false).call
+
+    assert result.success?
+    assert_equal 1, result.outputs[:consumer].value
+    consumer_entry = result.trace.find { |entry| entry.name == :consumer }
+    assert_equal :success, consumer_entry.status
+  end
+
+  def test_declarative_run_if_uses_input_key_for_local_aliased_dep
+    graph = DAG::Graph.new.add_node(:source).add_node(:consumer)
+    graph.add_edge(:source, :consumer, as: :first)
+    registry = DAG::Workflow::Registry.new
+    registry.register(DAG::Workflow::Step.new(name: :source, type: :ruby,
+      callable: ->(_) { DAG::Success.new(value: 1) }))
+    registry.register(DAG::Workflow::Step.new(name: :consumer, type: :ruby,
+      callable: ->(input) { DAG::Success.new(value: input[:first]) },
+      run_if: {from: :first, value: {equals: 1}}))
+
+    result = DAG::Workflow::Runner.new(graph, registry, parallel: false).call
+
+    assert result.success?
+    assert_equal 1, result.outputs[:consumer].value
+    consumer_entry = result.trace.find { |entry| entry.name == :consumer }
+    assert_equal :success, consumer_entry.status
+  end
+
   def test_declarative_run_if_selects_branch_by_value
     graph = DAG::Graph.new.add_node(:decide).add_node(:prod).add_node(:noop)
     graph.add_edge(:decide, :prod)

--- a/spec/validator_test.rb
+++ b/spec/validator_test.rb
@@ -172,4 +172,40 @@ class ValidatorTest < Minitest::Test
     report = ValidationReport.new(errors: ["err"])
     assert report.errors.frozen?
   end
+
+  def test_allows_declarative_run_if_to_reference_local_dependency_alias
+    defn = build_test_workflow(
+      source: {},
+      consumer: {
+        type: :ruby,
+        depends_on: [{from: :source, as: :first}],
+        run_if: {from: :first, value: {equals: "ready"}},
+        callable: ->(input) { DAG::Success.new(value: input[:first]) }
+      }
+    )
+
+    report = Validator.validate(defn.graph, defn.registry)
+
+    assert report.valid?
+    assert_empty report.errors
+  end
+
+  def test_rejects_declarative_run_if_referencing_local_dependency_raw_name_when_aliased
+    defn = build_test_workflow(
+      source: {},
+      consumer: {
+        type: :ruby,
+        depends_on: [{from: :source, as: :first}],
+        run_if: {from: :source, value: {equals: "ready"}},
+        callable: ->(input) { DAG::Success.new(value: input[:first]) }
+      }
+    )
+
+    report = Validator.validate(defn.graph, defn.registry)
+
+    refute report.valid?
+    assert_equal 1, report.errors.size
+    assert_match(/\bsource\b/, report.errors.first)
+    assert_match(/\bfirst\b/, report.errors.first)
+  end
 end


### PR DESCRIPTION
## Summary

Closes #79.

Local dependencies were keyed inconsistently across the `run_if` surface: step body used `input_key` (alias-aware), while `local_condition_context` / `local_callable_values` keyed by the raw predecessor name. With `depends_on: [{from: :source, as: :first}]`, a callable `run_if: ->(input) { input[:first] }` read nil and silently skipped the step. External deps already keyed by `input_key` everywhere.

This change unifies on `input_key` so step body, callable `run_if`, and declarative `from:` all use the same key — the public contract becomes "`input_key` is the only public key for any dependency, anywhere."

## Changes

- `DependencyInputResolver#local_condition_context` keys by `dependency.input_key` (was `dependency.name`).
- `Validator.allowed_condition_inputs` resolves local declarative `from:` references against `(metadata[:as] || dependency_name)`, mirroring the existing external branch and `duplicate_effective_input_key_errors`.
- `Mutation#rewrite_reconnected_run_if_refs!` matches and rewrites references by edge input_key (alias-aware) instead of node name, so subtree replacement keeps `run_if` pointing at the correct downstream alias.

Behavior change: declarative `run_if: {from: :source}` is now invalid when the edge `source -> consumer` carries `as: :first`. Use `from: :first`. Step-body callers were already correct (no change required).

## Tests

- 6 new regression tests covering "local alias x run_if":
  - `dependency_input_resolver_test`: callable input + condition context unit tests.
  - `runner_test`: end-to-end for callable and declarative `run_if`.
  - `validator_test`: accepts the alias, rejects the raw name when aliased.
- 2 `layer_admitter_test` cases that codified the buggy behavior updated to the alias key.
- 2 `mutation_test` cases adjusted to match the new contract:
  - assertion now expects the rewritten `from:` to be the input_key (`:summary`) rather than the new node name (`:summarize`).
  - the external-alias collision setup restructured so the new input_key actually collides.

804 runs, 41090 assertions, 0 failures. `bundle exec rake` (test + standard) clean.

## Test plan

- [x] `bundle exec rake test`
- [x] `bundle exec rake standard`
- [ ] Smoke check on a workflow with `as:` alias + callable `run_if` reading the alias key (was previously skipped silently, should now run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)