### PR TITLE
fix(events): skip emission for sub_workflow lifecycle payloads (closes #78)

### DIFF
--- a/lib/dag/workflow/event_middleware.rb
+++ b/lib/dag/workflow/event_middleware.rb
@@ -58,9 +58,8 @@ module DAG
         metadata_builder.call(result)
       end
 
-      # Sub_workflow paused/waiting results carry magic-key payloads that
-      # are Runner's internal protocol, not user-facing values. Mirrors
-      # AttemptTraceMiddleware#lifecycle_payload?.
+      # Sub_workflow paused/waiting payloads are Runner's internal
+      # protocol, not user-facing values — never publish them as events.
       def lifecycle_payload?(result)
         return false unless result.success? && result.value.is_a?(Hash)
 

--- a/lib/dag/workflow/event_middleware.rb
+++ b/lib/dag/workflow/event_middleware.rb
@@ -18,6 +18,7 @@ module DAG
 
       def emit_events(step, execution, result)
         return unless result.success?
+        return if lifecycle_payload?(result)
 
         event_bus = @event_bus || execution.event_bus
         return unless event_bus&.respond_to?(:publish)
@@ -55,6 +56,15 @@ module DAG
         return {} if metadata_builder.nil?
 
         metadata_builder.call(result)
+      end
+
+      # Sub_workflow paused/waiting results carry magic-key payloads that
+      # are Runner's internal protocol, not user-facing values. Mirrors
+      # AttemptTraceMiddleware#lifecycle_payload?.
+      def lifecycle_payload?(result)
+        return false unless result.success? && result.value.is_a?(Hash)
+
+        %i[waiting paused].include?(result.value[:__sub_workflow_status__])
       end
     end
   end

--- a/spec/event_middleware_test.rb
+++ b/spec/event_middleware_test.rb
@@ -211,6 +211,20 @@ class EventMiddlewareTest < Minitest::Test
     assert_empty bus.events
   end
 
+  def test_skips_emission_for_sub_workflow_paused_payload
+    bus = MemoryEventBus.new
+    middleware = DAG::Workflow::EventMiddleware.new(event_bus: bus, clock: build_clock)
+
+    result = middleware.call(build_step(emit_events: [
+      {name: :sub_workflow_done}
+    ]), {}, context: nil, execution: build_execution, next_step: lambda do |_step, _input, context:, execution:|
+      DAG::Success.new(value: {__sub_workflow_status__: :paused, __sub_workflow_trace__: []})
+    end)
+
+    assert result.success?
+    assert_empty bus.events
+  end
+
   def test_emits_for_unrecognized_sub_workflow_status
     bus = MemoryEventBus.new
     middleware = DAG::Workflow::EventMiddleware.new(event_bus: bus, clock: build_clock)

--- a/spec/event_middleware_test.rb
+++ b/spec/event_middleware_test.rb
@@ -211,20 +211,6 @@ class EventMiddlewareTest < Minitest::Test
     assert_empty bus.events
   end
 
-  def test_skips_emission_for_sub_workflow_paused_payload
-    bus = MemoryEventBus.new
-    middleware = DAG::Workflow::EventMiddleware.new(event_bus: bus, clock: build_clock)
-
-    result = middleware.call(build_step(emit_events: [
-      {name: :sub_workflow_done}
-    ]), {}, context: nil, execution: build_execution, next_step: lambda do |_step, _input, context:, execution:|
-      DAG::Success.new(value: {__sub_workflow_status__: :paused, __sub_workflow_trace__: []})
-    end)
-
-    assert result.success?
-    assert_empty bus.events
-  end
-
   def test_emits_for_unrecognized_sub_workflow_status
     bus = MemoryEventBus.new
     middleware = DAG::Workflow::EventMiddleware.new(event_bus: bus, clock: build_clock)

--- a/spec/event_middleware_test.rb
+++ b/spec/event_middleware_test.rb
@@ -197,6 +197,48 @@ class EventMiddlewareTest < Minitest::Test
     assert_empty bus.events
   end
 
+  def test_skips_emission_for_sub_workflow_waiting_payload
+    bus = MemoryEventBus.new
+    middleware = DAG::Workflow::EventMiddleware.new(event_bus: bus, clock: build_clock)
+
+    result = middleware.call(build_step(emit_events: [
+      {name: :sub_workflow_done}
+    ]), {}, context: nil, execution: build_execution, next_step: lambda do |_step, _input, context:, execution:|
+      DAG::Success.new(value: {__sub_workflow_status__: :waiting, __sub_workflow_trace__: []})
+    end)
+
+    assert result.success?
+    assert_empty bus.events
+  end
+
+  def test_skips_emission_for_sub_workflow_paused_payload
+    bus = MemoryEventBus.new
+    middleware = DAG::Workflow::EventMiddleware.new(event_bus: bus, clock: build_clock)
+
+    result = middleware.call(build_step(emit_events: [
+      {name: :sub_workflow_done}
+    ]), {}, context: nil, execution: build_execution, next_step: lambda do |_step, _input, context:, execution:|
+      DAG::Success.new(value: {__sub_workflow_status__: :paused, __sub_workflow_trace__: []})
+    end)
+
+    assert result.success?
+    assert_empty bus.events
+  end
+
+  def test_emits_for_unrecognized_sub_workflow_status
+    bus = MemoryEventBus.new
+    middleware = DAG::Workflow::EventMiddleware.new(event_bus: bus, clock: build_clock)
+
+    result = middleware.call(build_step(emit_events: [
+      {name: :sub_workflow_done}
+    ]), {}, context: nil, execution: build_execution, next_step: lambda do |_step, _input, context:, execution:|
+      DAG::Success.new(value: {__sub_workflow_status__: :something_else})
+    end)
+
+    assert result.success?
+    assert_equal [:sub_workflow_done], bus.events.map(&:name)
+  end
+
   def test_runner_uses_runner_event_bus_for_event_middleware
     bus = MemoryEventBus.new
     definition = build_test_workflow(


### PR DESCRIPTION
## Summary

- `EventMiddleware` was emitting user events with a `payload` of `{__sub_workflow_status__: :waiting/:paused, __sub_workflow_trace__: ...}` whenever a `:sub_workflow` step paused or waited.
- Add a private `lifecycle_payload?` predicate mirroring `AttemptTraceMiddleware#lifecycle_payload?` and short-circuit `emit_events` for those results.
- Completed sub_workflow runs are unaffected: `unwrap_sub_workflow_result` replaces their `__sub_workflow_output__` with the real value inside `core_step_invoker` before the middleware chain sees the result, so the existing nested-emit test (`test_runner_emits_namespaced_events_from_nested_sub_workflow_steps`) keeps passing.

## Why

`EventMiddleware` lives in the user-supplied middleware chain that wraps `core_step_invoker`. The runner deliberately leaves the magic-key payload intact for paused/waiting branches because they are part of the internal protocol used by `unwrap_sub_workflow_result`. Without a guard, those internal-protocol hashes leak straight to user event callbacks.

`AttemptTraceMiddleware` already had the right guard (`attempt_trace_middleware.rb:35-39`); this PR ports the same shape to `EventMiddleware`.

A future DRY pass should hoist the predicate (now duplicated in `AttemptTraceMiddleware`, `EventMiddleware`, and `Runner#sub_workflow_lifecycle_payload`) into a shared helper. Out of scope here to keep the bug fix focused; fits the family of issues #87-#105.

## Test plan

- [x] New unit tests in `spec/event_middleware_test.rb`:
  - `test_skips_emission_for_sub_workflow_waiting_payload` — `:waiting` payload, bus stays empty.
  - `test_skips_emission_for_sub_workflow_paused_payload` — `:paused` payload, bus stays empty.
  - `test_emits_for_unrecognized_sub_workflow_status` — sanity check that the predicate does not over-match (any other `__sub_workflow_status__` value still emits).
- [x] `bundle exec rake` (test + standard) green: 809 runs, 41105 assertions, 0 failures, 0 errors, lint clean.
- [x] Existing happy-path test `test_runner_emits_namespaced_events_from_nested_sub_workflow_steps` still passes — confirms completed sub_workflows still emit unwrapped payloads.

Closes #78.