### PR TITLE
[codex] fix condition regex normalization

### DIFF
--- a/lib/dag/workflow/condition.rb
+++ b/lib/dag/workflow/condition.rb
@@ -174,13 +174,7 @@ module DAG
           when :matches
             raise ValidationError, "#{context}.matches must be a non-empty string" unless expected.is_a?(String) && !expected.empty?
 
-            begin
-              verbose, $VERBOSE = $VERBOSE, nil
-              Regexp.new(expected)
-            ensure
-              $VERBOSE = verbose
-            end
-            {matches: expected}
+            {matches: Regexp.new(expected)}
             # :nocov: unreachable — key is pre-validated against VALUE_KEYS
           else raise "unexpected value predicate: #{key}"
             # :nocov:
@@ -242,11 +236,17 @@ module DAG
           when :nil
             actual.nil?
           when :matches
-            actual.is_a?(String) && Regexp.new(expected).match?(actual)
+            actual.is_a?(String) && regexp_for(expected).match?(actual)
             # :nocov: unreachable — predicate comes from normalized condition
           else raise "unexpected value predicate: #{predicate}"
             # :nocov:
           end
+        end
+
+        def regexp_for(value)
+          return value if value.is_a?(Regexp)
+
+          Regexp.new(value)
         end
 
         # Callables receive the same value-only input hash that Runner
@@ -268,9 +268,15 @@ module DAG
           node["status"] = condition[:status].to_s if condition.key?(:status)
           if condition.key?(:value)
             predicate, expected = condition[:value].first
-            node["value"] = {predicate.to_s => expected}
+            node["value"] = {predicate.to_s => dump_value(predicate, expected)}
           end
           node
+        end
+
+        def dump_value(predicate, expected)
+          return expected.source if predicate == :matches && expected.is_a?(Regexp)
+
+          expected
         end
 
         def map_tree(condition, all_key: :all, any_key: :any, not_key: :not, &block)

--- a/spec/condition_test.rb
+++ b/spec/condition_test.rb
@@ -43,7 +43,20 @@ class ConditionTest < Minitest::Test
 
   def test_normalize_leaf_with_value_matches
     result = Condition.normalize({from: :a, value: {matches: "^prod"}})
-    assert_equal({from: :a, value: {matches: "^prod"}}, result)
+    assert_equal :a, result[:from]
+    assert_instance_of Regexp, result[:value][:matches]
+    assert_equal "^prod", result[:value][:matches].source
+  end
+
+  def test_normalize_leaf_with_value_matches_preserves_verbose
+    original = $VERBOSE
+    $VERBOSE = true
+
+    Condition.normalize({from: :a, value: {matches: "^prod"}})
+
+    assert_equal true, $VERBOSE
+  ensure
+    $VERBOSE = original
   end
 
   def test_normalize_leaf_with_status_and_value
@@ -270,7 +283,7 @@ class ConditionTest < Minitest::Test
 
   def test_normalize_rejects_invalid_regex
     error = assert_raises(DAG::ValidationError) do
-      Condition.normalize({from: :a, value: {matches: "[invalid"}})
+      Condition.normalize({from: :a, value: {matches: "("}})
     end
     assert_match(/valid regular expression/, error.message)
   end
@@ -360,13 +373,19 @@ class ConditionTest < Minitest::Test
   end
 
   def test_evaluate_value_matches
+    cond = Condition.normalize({from: :a, value: {matches: "^prod"}})
+    assert Condition.evaluate(cond, {a: {value: "production", status: :success}})
+    refute Condition.evaluate(cond, {a: {value: "staging", status: :success}})
+  end
+
+  def test_evaluate_value_matches_accepts_legacy_string_pattern
     cond = {from: :a, value: {matches: "^prod"}}
     assert Condition.evaluate(cond, {a: {value: "production", status: :success}})
     refute Condition.evaluate(cond, {a: {value: "staging", status: :success}})
   end
 
   def test_evaluate_value_matches_non_string
-    cond = {from: :a, value: {matches: "^prod"}}
+    cond = Condition.normalize({from: :a, value: {matches: "^prod"}})
     refute Condition.evaluate(cond, {a: {value: 42, status: :success}})
   end
 
@@ -512,7 +531,9 @@ class ConditionTest < Minitest::Test
     reloaded = Condition.normalize(dumped)
     assert_equal :a, reloaded[:all][0][:from]
     assert_equal :b, reloaded[:all][1][:from]
-    assert_equal "^ok", reloaded[:all][1][:value][:matches]
+    assert_equal "^ok", dumped["all"][1]["value"]["matches"]
+    assert_instance_of Regexp, reloaded[:all][1][:value][:matches]
+    assert_equal "^ok", reloaded[:all][1][:value][:matches].source
   end
 
   # --- rename_from ---


### PR DESCRIPTION
## Summary
- Remove global `$VERBOSE` mutation from `Condition.normalize` for `:matches` predicates.
- Compile regex patterns once during normalization and reuse normalized `Regexp` instances during evaluation.
- Keep YAML dump output as the original regex source string and preserve compatibility with legacy string patterns.

## Validation
- `bundle exec ruby -Ilib -Ispec spec/condition_test.rb`
- `bundle exec ruby -Ilib -Ispec spec/loader_test.rb`
- runner tests for declarative `run_if`
- `bundle exec rake`
- `bundle exec standardrb`
- `git diff --check`

Closes #77
Closes #85