### PR TITLE
[codex] fix FileStore concurrent run updates

### DIFF
--- a/lib/dag/workflow/execution_store.rb
+++ b/lib/dag/workflow/execution_store.rb
@@ -9,100 +9,111 @@ module DAG
       class FileStore
         def initialize(dir:)
           @dir = File.expand_path(dir)
+          @runs = {}
+          @mutex = Mutex.new
           FileUtils.mkdir_p(@dir)
         end
 
         def begin_run(workflow_id:, definition_fingerprint:, node_paths:)
-          run = load_run(workflow_id)
-          if run
-            run[:node_paths] |= normalized_node_paths(node_paths)
-          else
-            run = {
-              workflow_id: workflow_id,
-              definition_fingerprint: definition_fingerprint,
-              node_paths: normalized_node_paths(node_paths),
-              workflow_status: nil,
-              waiting_nodes: [],
-              paused: false,
-              trace: [],
-              nodes: {}
-            }
+          @mutex.synchronize do
+            run = cached_run(workflow_id)
+            if run
+              run[:node_paths] |= normalized_node_paths(node_paths)
+            else
+              run = {
+                workflow_id: workflow_id,
+                definition_fingerprint: definition_fingerprint,
+                node_paths: normalized_node_paths(node_paths),
+                workflow_status: nil,
+                waiting_nodes: [],
+                paused: false,
+                trace: [],
+                nodes: {}
+              }
+              @runs[cache_key(workflow_id)] = run
+            end
+            write_run(run)
+            deep_copy(run)
           end
-          write_run(run)
-          deep_copy(run)
         end
 
         def load_run(workflow_id)
-          path = run_path(workflow_id)
-          return nil unless File.exist?(path)
-
-          Marshal.load(File.binread(path))
+          @mutex.synchronize do
+            run = cached_run(workflow_id)
+            run ? deep_copy(run) : nil
+          end
         end
 
         def paused?(workflow_id)
-          load_run(workflow_id)&.fetch(:paused, false) || false
+          @mutex.synchronize do
+            cached_run(workflow_id)&.fetch(:paused, false) || false
+          end
         end
 
         def next_output_version(workflow_id:, node_path:)
-          node = fetch_node(load_run(workflow_id), node_path)
-          outputs = node ? Array(node[:outputs]) : []
-          (outputs.map { |entry| entry[:version] }.max || 0) + 1
+          @mutex.synchronize do
+            node = fetch_node(cached_run(workflow_id), node_path)
+            outputs = node ? Array(node[:outputs]) : []
+            (outputs.map { |entry| entry[:version] }.max || 0) + 1
+          end
         end
 
         def load_node(workflow_id:, node_path:)
-          node = fetch_node(load_run(workflow_id), node_path)
-          node ? deep_copy(node) : nil
+          @mutex.synchronize do
+            node = fetch_node(cached_run(workflow_id), node_path)
+            node ? deep_copy(node) : nil
+          end
         end
 
         def set_node_state(workflow_id:, node_path:, state:, reason: nil, metadata: {})
-          run = ensure_run(workflow_id)
-          node = ensure_node(run, node_path)
-          node[:state] = state
-          node[:reason] = reason
-          node[:metadata] = deep_copy(metadata)
-          write_run(run)
+          mutate_run(workflow_id) do |run|
+            node = ensure_node(run, node_path)
+            node[:state] = state
+            node[:reason] = reason
+            node[:metadata] = deep_copy(metadata)
+          end
           nil
         end
 
         def append_trace(workflow_id:, entry:)
-          run = ensure_run(workflow_id)
-          run[:trace] << entry
-          write_run(run)
+          mutate_run(workflow_id) { |run| run[:trace] << deep_copy(entry) }
           nil
         end
 
         def save_output(workflow_id:, node_path:, version:, result:, reusable:, superseded:, saved_at: Time.now.utc)
-          run = ensure_run(workflow_id)
-          node = ensure_node(run, node_path)
-          node[:outputs] ||= []
-          node[:outputs] << {
-            version: version,
-            result: result,
-            reusable: reusable,
-            superseded: superseded,
-            saved_at: saved_at
-          }
-          write_run(run)
+          mutate_run(workflow_id) do |run|
+            node = ensure_node(run, node_path)
+            node[:outputs] ||= []
+            node[:outputs] << {
+              version: version,
+              result: deep_copy(result),
+              reusable: reusable,
+              superseded: superseded,
+              saved_at: saved_at
+            }
+          end
           nil
         end
 
         def load_output(workflow_id:, node_path:, version: :latest)
-          node = fetch_node(ensure_run(workflow_id), node_path)
-          return nil unless node
+          @mutex.synchronize do
+            node = fetch_node(ensure_run(workflow_id), node_path)
+            return nil unless node
 
-          outputs = Array(node[:outputs])
-          active_outputs = outputs.reject { |entry| entry[:superseded] }
-          case version
-          when :latest
-            # standard:disable Style/ReverseFind -- Array#rfind is unavailable on Ruby 3.2, which this gem still tests against.
-            output = active_outputs.reverse_each.find { |entry| entry[:reusable] }
-            # standard:enable Style/ReverseFind
-            output ? deep_copy(output) : nil
-          when :all
-            deep_copy(outputs.sort_by { |entry| entry[:version] })
-          else
-            output = outputs.find { |entry| entry[:version] == version }
-            output ? deep_copy(output) : nil
+            outputs = Array(node[:outputs])
+            active_outputs = outputs.reject { |entry| entry[:superseded] }
+            case version
+            when :latest
+              # standard:disable Style/ReverseFind -- Array#rfind is unavailable on Ruby 3.2, which this gem still tests against.
+              output = active_outputs.reverse_each.find { |entry| entry[:reusable] }
+              # standard:enable Style/ReverseFind
+              output ? deep_copy(output) : nil
+            when :all
+              deep_copy(outputs.sort_by { |entry| entry[:version] })
+            else
+              output = outputs.find { |entry| entry[:version] == version }
+              output ? deep_copy(output) : nil
+            end
           end
         end
 
@@ -127,52 +138,75 @@ module DAG
         end
 
         def set_workflow_status(workflow_id:, status:, waiting_nodes: [])
-          run = ensure_run(workflow_id)
-          run[:workflow_status] = status
-          run[:waiting_nodes] = normalized_node_paths(waiting_nodes)
-          write_run(run)
+          mutate_run(workflow_id) do |run|
+            run[:workflow_status] = status
+            run[:waiting_nodes] = normalized_node_paths(waiting_nodes)
+          end
           nil
         end
 
         def update_definition(workflow_id:, definition_fingerprint:, node_paths:)
-          run = ensure_run(workflow_id)
-          run[:definition_fingerprint] = definition_fingerprint
-          run[:node_paths] |= normalized_node_paths(node_paths)
-          write_run(run)
+          mutate_run(workflow_id) do |run|
+            run[:definition_fingerprint] = definition_fingerprint
+            run[:node_paths] |= normalized_node_paths(node_paths)
+          end
           nil
         end
 
         def set_pause_flag(workflow_id:, paused:)
-          run = ensure_run(workflow_id)
-          run[:paused] = paused
-          write_run(run)
+          mutate_run(workflow_id) { |run| run[:paused] = paused }
           nil
         end
 
         def clear_run(workflow_id:)
-          path = run_path(workflow_id)
-          File.delete(path) if File.exist?(path)
+          @mutex.synchronize do
+            @runs.delete(cache_key(workflow_id))
+            path = run_path(workflow_id)
+            File.delete(path) if File.exist?(path)
+          end
           nil
         end
 
         private
 
         def mark_nodes(workflow_id:, node_paths:, state:, cause_key:, cause:)
-          run = ensure_run(workflow_id)
-          Array(node_paths).each do |node_path|
-            node = ensure_node(run, node_path)
-            node[:state] = state
-            node[cause_key] = deep_copy(cause)
-            Array(node[:outputs]).each do |output|
-              output[:superseded] = true if output[:reusable]
+          mutate_run(workflow_id) do |run|
+            Array(node_paths).each do |node_path|
+              node = ensure_node(run, node_path)
+              node[:state] = state
+              node[cause_key] = deep_copy(cause)
+              Array(node[:outputs]).each do |output|
+                output[:superseded] = true if output[:reusable]
+              end
             end
           end
-          write_run(run)
           nil
         end
 
+        def mutate_run(workflow_id)
+          @mutex.synchronize do
+            run = ensure_run(workflow_id)
+            yield run
+            write_run(run)
+          end
+        end
+
         def ensure_run(workflow_id)
-          load_run(workflow_id) || raise(ArgumentError, "unknown workflow_id: #{workflow_id.inspect}")
+          cached_run(workflow_id) || raise(ArgumentError, "unknown workflow_id: #{workflow_id.inspect}")
+        end
+
+        def cached_run(workflow_id)
+          key = cache_key(workflow_id)
+          return @runs[key] if @runs.key?(key)
+
+          path = run_path(workflow_id)
+          return nil unless File.exist?(path)
+
+          @runs[key] = Marshal.load(File.binread(path))
+        end
+
+        def cache_key(workflow_id)
+          workflow_id.to_s
         end
 
         def ensure_node(run, node_path)

--- a/spec/execution_store_test.rb
+++ b/spec/execution_store_test.rb
@@ -263,4 +263,74 @@ class ExecutionStoreTest < Minitest::Test
       assert_equal({payload: ["a"]}, reopened.load_output(workflow_id: "wf-file", node_path: [:fetch])[:result].value)
     end
   end
+
+  def test_file_store_concurrent_append_trace_does_not_drop_entries
+    Dir.mktmpdir("dag-file-store-concurrent-trace") do |dir|
+      store = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)
+      store.begin_run(workflow_id: "wf-file-concurrent", definition_fingerprint: "fp-1", node_paths: [[:fetch]])
+
+      threads = 8.times.map do |thread_index|
+        Thread.new do
+          50.times do |entry_index|
+            store.append_trace(
+              workflow_id: "wf-file-concurrent",
+              entry: build_trace_entry(:"fetch_#{thread_index}_#{entry_index}")
+            )
+          end
+        end
+      end
+      threads.each(&:join)
+
+      run = store.load_run("wf-file-concurrent")
+      reopened = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)
+
+      assert_equal 400, run[:trace].size
+      assert_equal 400, run[:trace].map(&:name).uniq.size
+      assert_equal 400, reopened.load_run("wf-file-concurrent")[:trace].size
+    end
+  end
+
+  def test_file_store_clear_run_clears_cached_run
+    Dir.mktmpdir("dag-file-store-clear-cache") do |dir|
+      store = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)
+      store.begin_run(workflow_id: "wf-file-clear", definition_fingerprint: "fp-1", node_paths: [[:fetch]])
+      store.load_run("wf-file-clear")
+
+      store.clear_run(workflow_id: "wf-file-clear")
+
+      assert_nil store.load_run("wf-file-clear")
+      assert_nil DAG::Workflow::ExecutionStore::FileStore.new(dir: dir).load_run("wf-file-clear")
+    end
+  end
+
+  def test_file_store_cached_trace_entries_are_isolated_from_caller_mutation
+    Dir.mktmpdir("dag-file-store-trace-isolation") do |dir|
+      store = DAG::Workflow::ExecutionStore::FileStore.new(dir: dir)
+      store.begin_run(workflow_id: "wf-file-trace-isolation", definition_fingerprint: "fp-1", node_paths: [[:fetch]])
+      entry = build_trace_entry(:fetch, input_keys: [:source])
+
+      store.append_trace(workflow_id: "wf-file-trace-isolation", entry: entry)
+      entry.input_keys << :mutated
+
+      run = store.load_run("wf-file-trace-isolation")
+
+      assert_equal [:source], run[:trace].first.input_keys
+    end
+  end
+
+  private
+
+  def build_trace_entry(name, input_keys: [])
+    DAG::Workflow::TraceEntry.new(
+      name: name,
+      layer: 0,
+      started_at: 1.0,
+      finished_at: 2.0,
+      duration_ms: 1000.0,
+      status: :success,
+      input_keys: input_keys,
+      attempt: 1,
+      retried: false
+    )
+  end
 end


### PR DESCRIPTION
## Summary
- Add an in-memory per-workflow run cache to `ExecutionStore::FileStore`.
- Serialize FileStore run mutations with a mutex to prevent lost updates under threaded execution.
- Keep write-through atomic persistence on every mutation and clear cached state in `clear_run`.
- Preserve caller isolation by copying saved trace entries/results before storing them in the cache.

## Validation
- `bundle exec ruby -Ilib -Ispec spec/execution_store_test.rb`
- `bundle exec standardrb lib/dag/workflow/execution_store.rb spec/execution_store_test.rb`
- `git diff --check`
- `bundle exec rake`

Closes #81