### PR TITLE
fix(workflow): surface missing sub_workflow leaf as :sub_workflow_leaf_missing (#94)

### DIFF
--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -531,9 +531,11 @@ module DAG
           return outputs.key?(output_key) ? outputs[output_key].value : leaf_missing_failure(step, output_key, outputs)
         end
 
-        return leaf_missing_failure(step, leaves.find { |l| !outputs.key?(l) }, outputs) unless leaves.all? { |l| outputs.key?(l) }
+        leaves.each_with_object({}) do |leaf, acc|
+          return leaf_missing_failure(step, leaf, outputs) unless outputs.key?(leaf)
 
-        leaves.to_h { |leaf| [leaf, outputs[leaf].value] }
+          acc[leaf] = outputs[leaf].value
+        end
       rescue ValidationError => e
         Failure.new(error: {
           code: :sub_workflow_invalid_output_key,

--- a/lib/dag/workflow/runner.rb
+++ b/lib/dag/workflow/runner.rb
@@ -528,14 +528,25 @@ module DAG
               "sub_workflow step #{step.name} output_key #{output_key.inspect} must reference a leaf node (leaves: #{leaves.inspect})"
           end
 
-          return outputs.fetch(output_key).value
+          return outputs.key?(output_key) ? outputs[output_key].value : leaf_missing_failure(step, output_key, outputs)
         end
 
-        leaves.to_h { |leaf| [leaf, outputs.fetch(leaf).value] }
+        return leaf_missing_failure(step, leaves.find { |l| !outputs.key?(l) }, outputs) unless leaves.all? { |l| outputs.key?(l) }
+
+        leaves.to_h { |leaf| [leaf, outputs[leaf].value] }
       rescue ValidationError => e
         Failure.new(error: {
           code: :sub_workflow_invalid_output_key,
           message: e.message
+        })
+      end
+
+      def leaf_missing_failure(step, leaf, outputs)
+        Failure.new(error: {
+          code: :sub_workflow_leaf_missing,
+          message: "sub_workflow step #{step.name} expected output for leaf #{leaf.inspect} but it was not produced",
+          missing_leaf: leaf,
+          available_outputs: outputs.keys
         })
       end
 

--- a/spec/sub_workflow_test.rb
+++ b/spec/sub_workflow_test.rb
@@ -205,6 +205,70 @@ class SubWorkflowTest < Minitest::Test
     assert_equal :sub_workflow_invalid_output_key, result.error[:step_error][:code]
   end
 
+  def test_select_sub_workflow_output_returns_leaf_missing_failure_when_named_leaf_absent
+    child = DAG::Workflow::Loader.from_hash(
+      analyze: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: 1) }
+      },
+      summarize: {
+        type: :ruby,
+        depends_on: [:analyze],
+        callable: ->(input) { DAG::Success.new(value: input[:analyze]) }
+      }
+    )
+
+    parent = DAG::Workflow::Loader.from_hash(
+      process: {
+        type: :sub_workflow,
+        definition: child,
+        output_key: :summarize
+      }
+    )
+
+    runner = DAG::Workflow::Runner.new(parent, parallel: false)
+    step = parent.registry[:process]
+    outputs = {}
+
+    failure = runner.send(:select_sub_workflow_output, step, child, outputs)
+
+    assert_kind_of DAG::Failure, failure
+    assert_equal :sub_workflow_leaf_missing, failure.error[:code]
+    assert_equal :summarize, failure.error[:missing_leaf]
+    assert_equal [], failure.error[:available_outputs]
+  end
+
+  def test_select_sub_workflow_output_returns_leaf_missing_failure_when_implicit_leaf_absent
+    child = DAG::Workflow::Loader.from_hash(
+      a: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: 1) }
+      },
+      b: {
+        type: :ruby,
+        callable: ->(_input) { DAG::Success.new(value: 2) }
+      }
+    )
+
+    parent = DAG::Workflow::Loader.from_hash(
+      process: {
+        type: :sub_workflow,
+        definition: child
+      }
+    )
+
+    runner = DAG::Workflow::Runner.new(parent, parallel: false)
+    step = parent.registry[:process]
+    outputs = {a: DAG::Success.new(value: 1)}
+
+    failure = runner.send(:select_sub_workflow_output, step, child, outputs)
+
+    assert_kind_of DAG::Failure, failure
+    assert_equal :sub_workflow_leaf_missing, failure.error[:code]
+    assert_equal :b, failure.error[:missing_leaf]
+    assert_equal [:a], failure.error[:available_outputs]
+  end
+
   def test_sub_workflow_propagates_waiting_status_and_namespaced_waiting_nodes
     clock = build_clock(wall_time: Time.utc(2026, 4, 15, 9, 0, 0))
     future_time = Time.utc(2026, 4, 15, 10, 0, 0)


### PR DESCRIPTION
## Summary

- `Runner#select_sub_workflow_output` used `outputs.fetch(leaf).value`, which raises `KeyError` when a leaf is absent from the child run's outputs. Only `ValidationError` was rescued, so the `KeyError` escaped through `core_step_invoker` and surfaced as `:step_raised` — mislabeling an internal sub_workflow contract violation as a user-step crash.
- Replace the raising fetches with explicit `outputs.key?` checks. Missing leaves now return `Failure(code: :sub_workflow_leaf_missing)` with `missing_leaf:` and `available_outputs:` (keys only — values may be large/non-printable).
- Healthy paths and the existing `:sub_workflow_invalid_output_key` branch (leaf not in graph) are unchanged.

Closes #94.

## Why this is defensive

In current `main`, the lifecycle branches (`failure?` / `waiting?` / `paused?`) short-circuit before `select_sub_workflow_output` runs, and skipped leaves still record `Success(nil)` in `outputs`. So a "leaf truly missing" state is hard to reach today. But the wrong error code is the actual bug — and this is the kind of regression vector that produced #75 / #76.

## Test plan

- [x] Two new unit tests in `spec/sub_workflow_test.rb` driving `select_sub_workflow_output` directly with a hand-crafted `outputs` hash (named-leaf branch and implicit-leaves branch).
- [x] `bundle exec rake` — 827 runs, 41137 assertions, 0 failures.
- [x] `bundle exec standardrb` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)