### PR TITLE
[codex] Enforce immutable DAG runtime contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor/bundle
 /coverage/
 /.ruby-lsp/
+/.rubocop_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### Added — Roadmap v3.4 R2/R3: resume and structural mutation
+
+- `DAG::Runner#resume` resumes workflows in `:running`, `:waiting`, or
+  `:paused`, aborting in-flight attempts before recomputing eligibility.
+- `DAG::Adapters::Memory::CrashableStorage` supports deterministic crash
+  injection and `#snapshot_to_healthy` for resume tests.
+- `DAG::DefinitionEditor` and `DAG::MutationService` implement R3
+  `:invalidate` and `:replace_subtree` planning/application with revision CAS
+  and durable `mutation_applied` events.
+- Storage attempt numbering is now supplied by the Runner via
+  `begin_attempt(..., attempt_number:)`; storage persists the supplied number
+  and rejects duplicate `commit_attempt` calls.
+- Tagged types validate through `initialize`, so `.new`, `[]`, and `#with`
+  share the same JSON-safety and closed-enum checks.
+
+### Changed
+
+- `DAG::Runner#call` now only accepts workflows in `:pending`. Use
+  `DAG::Runner#resume` to recover workflows in `:waiting` or `:paused`.
+- `DAG::RunResult` now validates `outcome:` and `metadata:` as JSON-safe
+  on construction; passing `Time`, non-finite floats, or other non-JSON
+  values raises `ArgumentError`.
+
 ### Added — Roadmap v3.4 R1: deterministic core runner and default adapters
 
 - `DAG::Runner` — frozen kernel runner with seven injected ports

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -116,6 +116,23 @@ together. If a process crashes before that boundary, the step may be invoked
 again on resume. If it crashes after the boundary, resume starts from the next
 eligible node.
 
+The Runner owns attempt numbering. It computes:
+
+```ruby
+storage.count_attempts(workflow_id:, revision:, node_id:) + 1
+```
+
+and passes that value to:
+
+```ruby
+storage.begin_attempt(workflow_id:, revision:, node_id:,
+                      expected_node_state:, attempt_number:)
+```
+
+Storage must persist the supplied `attempt_number`; it must not recalculate it.
+`commit_attempt` is one-shot: adapters must reject a second commit for the same
+attempt after it has left `:running`.
+
 ## Proposed Mutations
 
 Consumers may propose mutations with:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ dependencies; Ruby 3.4+.
 > The legacy v0.x runtime (`Workflow::Runner`, YAML loader, parallel
 > strategies, `:exec` / `:ruby_script` / `:sub_workflow` step types) was
 > removed during R1. The current state of the kernel is the deterministic
-> in-memory runtime described below. SQLite storage, durable resume,
-> and adaptive structural mutation arrive in later phases (R2 / R3 / S0).
+> in-memory runtime described below. Durable in-memory resume and adaptive
+> structural mutation are present; SQLite storage arrives in S0.
 
 ## Quick start
 
@@ -65,8 +65,8 @@ result.state
   `DAG::StepTypeRegistry` with a deterministic
   `fingerprint_payload`.
 - **Runner** (`DAG::Runner`) — frozen, dependency-injected. `#call(id)`
-  runs the layered algorithm; `#retry_workflow(id)` enforces the
-  workflow-retry budget.
+  starts pending workflows, `#resume(id)` recovers running/waiting/paused
+  workflows, and `#retry_workflow(id)` enforces the workflow-retry budget.
 - **Adapters** (`DAG::Adapters::*`) — `Memory::Storage`,
   `Memory::EventBus`, `Null::EventBus`, plus `Stdlib::{Clock,
   IdGenerator, Fingerprint, Serializer}`.
@@ -77,8 +77,8 @@ for the R1 implementation notes.
 
 ## Status
 
-R1 has landed. Next: R2 resume + crash recovery (#72), R3 adaptive
-structural mutation (#73), Release v1.0 readiness gate (#74).
+R0-R3 have landed. Next: S0 SQLite storage and the Release v1.0 readiness
+gate (#74).
 
 Roadmap board: <https://github.com/users/duncanita/projects/2>.
 

--- a/README.md
+++ b/README.md
@@ -89,4 +89,15 @@ bundle install
 bundle exec rake          # test + standardrb
 ```
 
+## Production Readiness Stress
+
+```bash
+scripts/production_readiness.rb --fast
+scripts/production_readiness.rb
+```
+
+`--fast` targets about two minutes. Without `--fast`, the script runs a
+one-hour stress profile. Use `--duration SECONDS` and `--seed INTEGER` to
+reproduce or shorten a run.
+
 License: MIT.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,10 +9,11 @@ Tracked phases:
 
 | Phase | Issue  | Status     |
 |-------|--------|------------|
-| R0    | #70    | Done (#122)|
-| R1    | #71    | In Progress (this PR) |
-| R2    | #72    | Backlog    |
-| R3    | #73    | Backlog    |
+| R0    | #70    | Done (#122) |
+| R1    | #71    | Done (#123) |
+| R2    | #72    | Done (#124) |
+| R3    | #73    | Done (#125) |
+| S0    | TBD    | Next |
 | Release v1.0 | #74 | Backlog |
 
 Roadmap board: <https://github.com/users/duncanita/projects/2>.

--- a/docs/plans/2026-04-26-rubocop-migration.md
+++ b/docs/plans/2026-04-26-rubocop-migration.md
@@ -1,0 +1,25 @@
+# RuboCop Migration Plan
+
+Goal: make `bundle exec rubocop` the full style/static-analysis gate, while
+keeping the current `bundle exec rake` gate green during the migration.
+
+## Current State
+
+- `bundle exec standardrb` is green and remains the active style gate.
+- Custom DAG cops are configured in `.rubocop.yml` and pass when run with:
+  `bundle exec rubocop --only DAG/NoThreadOrRactor,DAG/NoMutableAccessors,DAG/NoInPlaceMutation,DAG/NoExternalRequires`.
+- Full `bundle exec rubocop` currently reports baseline style/metrics offenses
+  because the repo has not been normalized to RuboCop defaults.
+
+## Plan
+
+1. Decide whether the final house style is Standard-compatible RuboCop or
+   vanilla RuboCop. Do not mix both as independent formatters long-term.
+2. Add an explicit RuboCop baseline configuration for metrics that are noisy
+   for tests and storage contract helpers.
+3. Autocorrect low-risk layout/string/hash-spacing offenses in one mechanical
+   commit.
+4. Review non-autocorrect metrics offenses manually, preferring focused
+   `Exclude` entries for tests over churny helper refactors.
+5. Change `Rakefile` from `standardrb` to the agreed RuboCop task only after
+   `bundle exec rubocop` is green.

--- a/lib/dag/adapters/memory/crashable_storage.rb
+++ b/lib/dag/adapters/memory/crashable_storage.rb
@@ -16,8 +16,13 @@ module DAG
           @crashed = false
         end
 
-        def begin_attempt(workflow_id:, revision:, node_id:, expected_node_state:)
-          context = {workflow_id: workflow_id, revision: revision, node_id: node_id}
+        def begin_attempt(workflow_id:, revision:, node_id:, expected_node_state:, attempt_number:)
+          context = {
+            workflow_id: workflow_id,
+            revision: revision,
+            node_id: node_id,
+            attempt_number: attempt_number
+          }
           crash_if!(:before, :begin_attempt, context)
           attempt_id = super
           crash_if!(:after, :begin_attempt, context.merge(attempt_id: attempt_id))
@@ -59,7 +64,8 @@ module DAG
             attempt_id: attempt_id,
             workflow_id: attempt[:workflow_id],
             revision: attempt[:revision],
-            node_id: attempt[:node_id]
+            node_id: attempt[:node_id],
+            attempt_number: attempt[:attempt_number]
           }
         end
 
@@ -78,7 +84,7 @@ module DAG
         end
 
         def trigger_context_matches?(context)
-          %i[workflow_id revision node_id attempt_id node_state event_type].all? do |key|
+          %i[workflow_id revision node_id attempt_id attempt_number node_state event_type].all? do |key|
             !@crash_on.key?(key) || @crash_on[key] == context[key]
           end
         end

--- a/lib/dag/adapters/memory/storage.rb
+++ b/lib/dag/adapters/memory/storage.rb
@@ -45,8 +45,15 @@ module DAG
           frozen StorageState.transition_node_state(@state, workflow_id: workflow_id, revision: revision, node_id: node_id, from: from, to: to)
         end
 
-        def begin_attempt(workflow_id:, revision:, node_id:, expected_node_state:)
-          frozen StorageState.begin_attempt(@state, workflow_id: workflow_id, revision: revision, node_id: node_id, expected_node_state: expected_node_state)
+        def begin_attempt(workflow_id:, revision:, node_id:, expected_node_state:, attempt_number:)
+          frozen StorageState.begin_attempt(
+            @state,
+            workflow_id: workflow_id,
+            revision: revision,
+            node_id: node_id,
+            expected_node_state: expected_node_state,
+            attempt_number: attempt_number
+          )
         end
 
         def commit_attempt(attempt_id:, result:, node_state:, event:)

--- a/lib/dag/adapters/memory/storage_state.rb
+++ b/lib/dag/adapters/memory/storage_state.rb
@@ -125,7 +125,11 @@ module DAG
           {workflow_id: workflow_id, revision: revision, node_id: node_id, state: to}
         end
 
-        def begin_attempt(state, workflow_id:, revision:, node_id:, expected_node_state:)
+        def begin_attempt(state, workflow_id:, revision:, node_id:, expected_node_state:, attempt_number:)
+          unless attempt_number.is_a?(Integer) && attempt_number.positive?
+            raise ArgumentError, "attempt_number must be a positive Integer"
+          end
+
           states_for_rev = fetch_node_states!(state, workflow_id, revision)
           current = states_for_rev[node_id]
           unless current == expected_node_state
@@ -134,7 +138,6 @@ module DAG
 
           state[:attempt_seq][workflow_id] += 1
           attempt_id = "#{workflow_id}/#{state[:attempt_seq][workflow_id]}"
-          attempt_number = count_attempts_internal(state, workflow_id, revision, node_id, exclude: [:aborted]) + 1
 
           states_for_rev[node_id] = :running
           state[:attempts][attempt_id] = {
@@ -154,10 +157,20 @@ module DAG
           attempt = state[:attempts].fetch(attempt_id) do
             raise ArgumentError, "Unknown attempt: #{attempt_id}"
           end
-          attempt[:result] = result
-          attempt[:state] = attempt_terminal_state_for(result)
+          unless attempt[:state] == :running
+            raise StaleStateError, "attempt #{attempt_id} state is #{attempt[:state].inspect}, expected :running"
+          end
+          terminal_state = attempt_terminal_state_for(result)
+          validate_node_state_for_result!(result, node_state)
 
           rev_states = state[:node_states][[attempt[:workflow_id], attempt[:revision]]]
+          current_node_state = rev_states[attempt[:node_id]]
+          unless current_node_state == :running
+            raise StaleStateError, "node #{attempt[:node_id]} state is #{current_node_state.inspect}, expected :running"
+          end
+
+          attempt[:result] = result
+          attempt[:state] = terminal_state
           rev_states[attempt[:node_id]] = node_state
 
           append_event_internal(state, attempt[:workflow_id], event)
@@ -249,6 +262,17 @@ module DAG
           else
             raise ArgumentError, "unexpected attempt result type: #{result.class}"
           end
+        end
+
+        def validate_node_state_for_result!(result, node_state)
+          allowed = case result
+          when DAG::Success then [:committed]
+          when DAG::Waiting then [:waiting]
+          when DAG::Failure then %i[failed pending]
+          end
+          return if allowed.include?(node_state)
+
+          raise ArgumentError, "node_state #{node_state.inspect} is invalid for #{result.class}"
         end
       end
     end

--- a/lib/dag/definition_editor.rb
+++ b/lib/dag/definition_editor.rb
@@ -35,8 +35,6 @@ module DAG
       return DAG::PlanResult.invalid("unknown target node: #{target}") unless definition.has_node?(target)
 
       replacement = mutation.replacement_graph
-      validate_replacement_graph!(replacement)
-
       removed = definition.exclusive_descendants_of(target, include_self: true)
       impacted = definition.descendants_of(target, include_self: true) - removed
       kept_nodes = definition.nodes - removed
@@ -53,23 +51,6 @@ module DAG
       )
 
       DAG::PlanResult.valid(new_definition: new_definition, invalidated_node_ids: impacted)
-    end
-
-    def validate_replacement_graph!(replacement)
-      raise ArgumentError, "replacement_graph must be a DAG::ReplacementGraph" unless replacement.is_a?(DAG::ReplacementGraph)
-      raise ArgumentError, "replacement graph must be a DAG::Graph" unless replacement.graph.is_a?(DAG::Graph)
-      validate_node_id_list!(replacement.entry_node_ids, "entry_node_ids", replacement.graph)
-      validate_node_id_list!(replacement.exit_node_ids, "exit_node_ids", replacement.graph)
-    end
-
-    def validate_node_id_list!(ids, label, graph)
-      raise ArgumentError, "#{label} must be an Array" unless ids.is_a?(Array)
-      raise ArgumentError, "#{label} cannot be empty" if ids.empty?
-
-      ids.each do |id|
-        raise ArgumentError, "#{label} entries must be Symbol or String, got #{id.class}: #{id.inspect}" unless id.is_a?(Symbol) || id.is_a?(String)
-        raise ArgumentError, "replacement #{label.sub("_node_ids", "")} node is not in graph: #{id}" unless graph.node?(id)
-      end
     end
 
     def build_replaced_graph(definition, target, removed, kept_nodes, replacement, replacement_nodes)

--- a/lib/dag/edge.rb
+++ b/lib/dag/edge.rb
@@ -4,7 +4,7 @@ module DAG
   # First-class directed edge in the DAG.
   Edge = Data.define(:from, :to, :metadata) do
     def initialize(from:, to:, metadata: {})
-      super(from: from.to_sym, to: to.to_sym, metadata: metadata.freeze)
+      super(from: from.to_sym, to: to.to_sym, metadata: DAG.frozen_copy(metadata))
     end
 
     def weight = metadata.fetch(:weight, 1)

--- a/lib/dag/event.rb
+++ b/lib/dag/event.rb
@@ -15,23 +15,23 @@ module DAG
       remove_method :[]
 
       def [](type:, workflow_id:, revision:, at_ms:, seq: nil, node_id: nil, attempt_id: nil, payload: {})
-        raise ArgumentError, "invalid event type: #{type.inspect}" unless DAG::Event::TYPES.include?(type)
-        DAG.json_safe!(payload, "$root.payload")
-
         new(
-          seq: seq,
           type: type,
           workflow_id: workflow_id,
           revision: revision,
+          at_ms: at_ms,
+          seq: seq,
           node_id: node_id,
           attempt_id: attempt_id,
-          at_ms: at_ms,
-          payload: DAG.deep_freeze(DAG.deep_dup(payload))
+          payload: payload
         )
       end
     end
 
     def initialize(type:, workflow_id:, revision:, at_ms:, seq: nil, node_id: nil, attempt_id: nil, payload: {})
+      raise ArgumentError, "invalid event type: #{type.inspect}" unless DAG::Event::TYPES.include?(type)
+      DAG.json_safe!(payload, "$root.payload")
+
       super(
         seq: seq,
         type: type,

--- a/lib/dag/failure.rb
+++ b/lib/dag/failure.rb
@@ -8,14 +8,14 @@ module DAG
       remove_method :[]
 
       def [](error:, retriable: false, metadata: {})
-        DAG.json_safe!(error, "$root.error")
-        DAG.json_safe!(metadata, "$root.metadata")
-
         new(error: error, retriable: retriable, metadata: metadata)
       end
     end
 
     def initialize(error:, retriable: false, metadata: {})
+      DAG.json_safe!(error, "$root.error")
+      DAG.json_safe!(metadata, "$root.metadata")
+
       super(
         error: DAG.deep_freeze(DAG.deep_dup(error)),
         retriable: !!retriable,

--- a/lib/dag/graph.rb
+++ b/lib/dag/graph.rb
@@ -27,7 +27,9 @@ module DAG
   # detects cycles in O(V+E).
   class Graph
     EMPTY_SET = Set.new.freeze
+    EMPTY_HASH = {}.freeze
     private_constant :EMPTY_SET
+    private_constant :EMPTY_HASH
 
     # Frozen snapshot of the node set. Mutating it never affects the graph.
     def nodes
@@ -221,7 +223,7 @@ module DAG
     end
 
     def edge_metadata(from, to)
-      @edge_metadata.dig(from.to_sym, to.to_sym) || {}
+      @edge_metadata.dig(from.to_sym, to.to_sym) || EMPTY_HASH
     end
 
     # --- Neighbor queries ---
@@ -564,7 +566,7 @@ module DAG
       (@adjacency[from] ||= Set.new) << to
       (@reverse[to] ||= Set.new) << from
       return if metadata.empty?
-      (@edge_metadata[from] ||= {})[to] = metadata.freeze
+      (@edge_metadata[from] ||= {})[to] = DAG.frozen_copy(metadata)
     end
 
     # Drops a single (from, to) entry from the nested @edge_metadata hash

--- a/lib/dag/ports/storage.rb
+++ b/lib/dag/ports/storage.rb
@@ -40,10 +40,14 @@ module DAG
         raise PortNotImplementedError
       end
 
-      def begin_attempt(workflow_id:, revision:, node_id:, expected_node_state:)
+      # The Runner owns attempt numbering and passes the already-computed
+      # number here; adapters persist it and do not recalculate.
+      def begin_attempt(workflow_id:, revision:, node_id:, expected_node_state:, attempt_number:)
         raise PortNotImplementedError
       end
 
+      # One-shot atomic terminal transition for an attempt. Adapters must reject
+      # commits for attempts that are no longer :running.
       def commit_attempt(attempt_id:, result:, node_state:, event:)
         raise PortNotImplementedError
       end

--- a/lib/dag/proposed_mutation.rb
+++ b/lib/dag/proposed_mutation.rb
@@ -13,30 +13,30 @@ module DAG
       remove_method :[]
 
       def [](kind:, target_node_id:, replacement_graph: nil, rationale: nil, confidence: 1.0, metadata: {})
-        raise ArgumentError, "invalid mutation kind: #{kind.inspect}" unless DAG::ProposedMutation::KINDS.include?(kind)
-        if kind == :replace_subtree && !replacement_graph.is_a?(DAG::ReplacementGraph)
-          raise ArgumentError, "replace_subtree requires replacement_graph"
-        end
-        if kind == :invalidate && !replacement_graph.nil?
-          raise ArgumentError, "invalidate does not accept replacement_graph"
-        end
-
-        DAG.json_safe!(rationale, "$root.rationale")
-        DAG.json_safe!(confidence, "$root.confidence")
-        DAG.json_safe!(metadata, "$root.metadata")
-
         new(
           kind: kind,
           target_node_id: target_node_id,
           replacement_graph: replacement_graph,
-          rationale: DAG.deep_freeze(DAG.deep_dup(rationale)),
+          rationale: rationale,
           confidence: confidence,
-          metadata: DAG.deep_freeze(DAG.deep_dup(metadata))
+          metadata: metadata
         )
       end
     end
 
     def initialize(kind:, target_node_id:, replacement_graph: nil, rationale: nil, confidence: 1.0, metadata: {})
+      raise ArgumentError, "invalid mutation kind: #{kind.inspect}" unless DAG::ProposedMutation::KINDS.include?(kind)
+      if kind == :replace_subtree && !replacement_graph.is_a?(DAG::ReplacementGraph)
+        raise ArgumentError, "replace_subtree requires replacement_graph"
+      end
+      if kind == :invalidate && !replacement_graph.nil?
+        raise ArgumentError, "invalidate does not accept replacement_graph"
+      end
+
+      DAG.json_safe!(rationale, "$root.rationale")
+      DAG.json_safe!(confidence, "$root.confidence")
+      DAG.json_safe!(metadata, "$root.metadata")
+
       super(
         kind: kind,
         target_node_id: target_node_id,

--- a/lib/dag/replacement_graph.rb
+++ b/lib/dag/replacement_graph.rb
@@ -6,48 +6,44 @@ module DAG
       remove_method :[]
 
       def [](graph:, entry_node_ids:, exit_node_ids:)
-        raise ArgumentError, "graph must be a DAG::Graph" unless graph.is_a?(DAG::Graph)
-        validate_node_ids_shape!(entry_node_ids, "entry_node_ids")
-        validate_node_ids_shape!(exit_node_ids, "exit_node_ids")
-        raise ArgumentError, "entry_node_ids cannot be empty" if entry_node_ids.empty?
-        raise ArgumentError, "exit_node_ids cannot be empty" if exit_node_ids.empty?
-
-        frozen_graph = graph.frozen? ? graph : graph.dup.freeze
-        validate_membership!(frozen_graph, entry_node_ids, "entry")
-        validate_membership!(frozen_graph, exit_node_ids, "exit")
-
-        new(
-          graph: frozen_graph,
-          entry_node_ids: DAG.deep_freeze(entry_node_ids.dup),
-          exit_node_ids: DAG.deep_freeze(exit_node_ids.dup)
-        )
-      end
-
-      private
-
-      def validate_node_ids_shape!(ids, label)
-        raise ArgumentError, "#{label} must be an Array" unless ids.is_a?(Array)
-
-        ids.each do |id|
-          next if id.is_a?(Symbol) || id.is_a?(String)
-
-          raise ArgumentError, "#{label} entries must be Symbol or String, got #{id.class}: #{id.inspect}"
-        end
-      end
-
-      def validate_membership!(graph, ids, kind)
-        ids.each do |id|
-          raise ArgumentError, "#{kind} node not in graph: #{id}" unless graph.node?(id)
-        end
+        new(graph: graph, entry_node_ids: entry_node_ids, exit_node_ids: exit_node_ids)
       end
     end
 
     def initialize(graph:, entry_node_ids:, exit_node_ids:)
+      raise ArgumentError, "graph must be a DAG::Graph" unless graph.is_a?(DAG::Graph)
+      validate_node_ids_shape!(entry_node_ids, "entry_node_ids")
+      validate_node_ids_shape!(exit_node_ids, "exit_node_ids")
+      raise ArgumentError, "entry_node_ids cannot be empty" if entry_node_ids.empty?
+      raise ArgumentError, "exit_node_ids cannot be empty" if exit_node_ids.empty?
+
+      frozen_graph = graph.frozen? ? graph : graph.dup.freeze
+      validate_membership!(frozen_graph, entry_node_ids, "entry")
+      validate_membership!(frozen_graph, exit_node_ids, "exit")
+
       super(
-        graph: graph,
+        graph: frozen_graph,
         entry_node_ids: DAG.deep_freeze(DAG.deep_dup(entry_node_ids)),
         exit_node_ids: DAG.deep_freeze(DAG.deep_dup(exit_node_ids))
       )
+    end
+
+    private
+
+    def validate_node_ids_shape!(ids, label)
+      raise ArgumentError, "#{label} must be an Array" unless ids.is_a?(Array)
+
+      ids.each do |id|
+        next if id.is_a?(Symbol) || id.is_a?(String)
+
+        raise ArgumentError, "#{label} entries must be Symbol or String, got #{id.class}: #{id.inspect}"
+      end
+    end
+
+    def validate_membership!(graph, ids, kind)
+      ids.each do |id|
+        raise ArgumentError, "#{kind} node not in graph: #{id}" unless graph.node?(id)
+      end
     end
   end
 end

--- a/lib/dag/run_result.rb
+++ b/lib/dag/run_result.rb
@@ -2,7 +2,23 @@
 
 module DAG
   RunResult = Data.define(:state, :last_event_seq, :outcome, :metadata) do
+    class << self
+      remove_method :[]
+
+      def [](state:, last_event_seq: nil, outcome: nil, metadata: {})
+        new(
+          state: state,
+          last_event_seq: last_event_seq,
+          outcome: outcome,
+          metadata: metadata
+        )
+      end
+    end
+
     def initialize(state:, last_event_seq: nil, outcome: nil, metadata: {})
+      DAG.json_safe!(outcome, "$root.outcome")
+      DAG.json_safe!(metadata, "$root.metadata")
+
       super(
         state: state,
         last_event_seq: last_event_seq,

--- a/lib/dag/runner.rb
+++ b/lib/dag/runner.rb
@@ -4,7 +4,7 @@ module DAG
   REQUIRED_RUNNER_DEPENDENCIES = %i[storage event_bus registry clock id_generator fingerprint serializer].freeze
 
   class Runner
-    CALL_FROM_STATES = %i[pending waiting paused].freeze
+    CALL_FROM_STATES = %i[pending].freeze
     RESUME_FROM_STATES = %i[running waiting paused].freeze
 
     RunContext = Data.define(
@@ -147,7 +147,8 @@ module DAG
         workflow_id: run.workflow_id,
         revision: run.revision,
         node_id: node_id,
-        expected_node_state: :pending
+        expected_node_state: :pending,
+        attempt_number: attempt_number
       )
 
       append_event(run,

--- a/lib/dag/runtime_profile.rb
+++ b/lib/dag/runtime_profile.rb
@@ -6,37 +6,37 @@ module DAG
       remove_method :[]
 
       def [](durability:, max_attempts_per_node:, max_workflow_retries:, event_bus_kind:, metadata: {})
-        raise ArgumentError, "invalid durability" unless DAG::RuntimeProfile::DURABILITY.include?(durability)
-        unless max_attempts_per_node.is_a?(Integer) && max_attempts_per_node.positive?
-          raise ArgumentError, "max_attempts_per_node must be a positive Integer"
-        end
-        unless max_workflow_retries.is_a?(Integer) && !max_workflow_retries.negative?
-          raise ArgumentError, "max_workflow_retries must be a non-negative Integer"
-        end
-
-        DAG.json_safe!(metadata, "$root.metadata")
-
         new(
           durability: durability,
           max_attempts_per_node: max_attempts_per_node,
           max_workflow_retries: max_workflow_retries,
           event_bus_kind: event_bus_kind,
-          metadata: DAG.deep_freeze(DAG.deep_dup(metadata))
+          metadata: metadata
         )
-      end
-
-      def default
-        self[
-          durability: :ephemeral,
-          max_attempts_per_node: 3,
-          max_workflow_retries: 0,
-          event_bus_kind: :null,
-          metadata: {}
-        ]
       end
     end
 
+    def self.default
+      self[
+        durability: :ephemeral,
+        max_attempts_per_node: 3,
+        max_workflow_retries: 0,
+        event_bus_kind: :null,
+        metadata: {}
+      ]
+    end
+
     def initialize(durability:, max_attempts_per_node:, max_workflow_retries:, event_bus_kind:, metadata: {})
+      raise ArgumentError, "invalid durability" unless DAG::RuntimeProfile::DURABILITY.include?(durability)
+      unless max_attempts_per_node.is_a?(Integer) && max_attempts_per_node.positive?
+        raise ArgumentError, "max_attempts_per_node must be a positive Integer"
+      end
+      unless max_workflow_retries.is_a?(Integer) && !max_workflow_retries.negative?
+        raise ArgumentError, "max_workflow_retries must be a non-negative Integer"
+      end
+
+      DAG.json_safe!(metadata, "$root.metadata")
+
       super(
         durability: durability,
         max_attempts_per_node: max_attempts_per_node,

--- a/lib/dag/step_input.rb
+++ b/lib/dag/step_input.rb
@@ -6,18 +6,18 @@ module DAG
       remove_method :[]
 
       def [](context:, node_id:, attempt_number: 1, metadata: {})
-        DAG.json_safe!(metadata, "$root.metadata")
-
         new(
-          context: DAG.deep_freeze(DAG.deep_dup(context)),
+          context: context,
           node_id: node_id,
           attempt_number: attempt_number,
-          metadata: DAG.deep_freeze(DAG.deep_dup(metadata))
+          metadata: metadata
         )
       end
     end
 
     def initialize(context:, node_id:, attempt_number: 1, metadata: {})
+      DAG.json_safe!(metadata, "$root.metadata")
+
       super(
         context: DAG.deep_freeze(DAG.deep_dup(context)),
         node_id: node_id,

--- a/lib/dag/success.rb
+++ b/lib/dag/success.rb
@@ -8,16 +8,6 @@ module DAG
       remove_method :[]
 
       def [](value: nil, context_patch: {}, proposed_mutations: [], metadata: {})
-        DAG.json_safe!(value, "$root.value")
-        DAG.json_safe!(context_patch, "$root.context_patch")
-        DAG.json_safe!(metadata, "$root.metadata")
-
-        proposed_mutations.each do |mutation|
-          unless mutation.is_a?(DAG::ProposedMutation)
-            raise ArgumentError, "proposed_mutations must contain ProposedMutation"
-          end
-        end
-
         new(
           value: value,
           context_patch: context_patch,
@@ -27,7 +17,12 @@ module DAG
       end
     end
 
-    def initialize(value:, context_patch: {}, proposed_mutations: [], metadata: {})
+    def initialize(value: nil, context_patch: {}, proposed_mutations: [], metadata: {})
+      DAG.json_safe!(value, "$root.value")
+      DAG.json_safe!(context_patch, "$root.context_patch")
+      DAG.json_safe!(metadata, "$root.metadata")
+      validate_proposed_mutations!(proposed_mutations)
+
       super(
         value: DAG.deep_freeze(DAG.deep_dup(value)),
         context_patch: DAG.deep_freeze(DAG.deep_dup(context_patch)),
@@ -59,5 +54,19 @@ module DAG
     def to_h = {status: :success, value: value}
     def inspect = "Success(#{value.inspect})"
     alias_method :to_s, :inspect
+
+    private
+
+    def validate_proposed_mutations!(proposed_mutations)
+      unless proposed_mutations.is_a?(Array)
+        raise ArgumentError, "proposed_mutations must be an Array"
+      end
+
+      proposed_mutations.each do |mutation|
+        unless mutation.is_a?(DAG::ProposedMutation)
+          raise ArgumentError, "proposed_mutations must contain ProposedMutation"
+        end
+      end
+    end
   end
 end

--- a/lib/dag/waiting.rb
+++ b/lib/dag/waiting.rb
@@ -6,33 +6,33 @@ module DAG
       remove_method :[]
 
       def [](reason:, resume_token: nil, not_before_ms: nil, metadata: {})
-        raise ArgumentError, "reason must be Symbol" unless reason.is_a?(Symbol)
-        unless not_before_ms.nil? || not_before_ms.is_a?(Integer)
-          raise ArgumentError, "not_before_ms must be Integer milliseconds or nil"
-        end
-
-        DAG.json_safe!(resume_token, "$root.resume_token")
-        DAG.json_safe!(metadata, "$root.metadata")
-
         new(
           reason: reason,
-          resume_token: DAG.deep_freeze(DAG.deep_dup(resume_token)),
-          not_before_ms: not_before_ms,
-          metadata: DAG.deep_freeze(DAG.deep_dup(metadata))
-        )
-      end
-
-      def at(reason:, time:, resume_token: nil, metadata: {})
-        self[
-          reason: reason,
           resume_token: resume_token,
-          not_before_ms: (time.to_f * 1000).to_i,
+          not_before_ms: not_before_ms,
           metadata: metadata
-        ]
+        )
       end
     end
 
+    def self.at(reason:, time:, resume_token: nil, metadata: {})
+      self[
+        reason: reason,
+        resume_token: resume_token,
+        not_before_ms: (time.to_f * 1000).to_i,
+        metadata: metadata
+      ]
+    end
+
     def initialize(reason:, resume_token: nil, not_before_ms: nil, metadata: {})
+      raise ArgumentError, "reason must be Symbol" unless reason.is_a?(Symbol)
+      unless not_before_ms.nil? || not_before_ms.is_a?(Integer)
+        raise ArgumentError, "not_before_ms must be Integer milliseconds or nil"
+      end
+
+      DAG.json_safe!(resume_token, "$root.resume_token")
+      DAG.json_safe!(metadata, "$root.metadata")
+
       super(
         reason: reason,
         resume_token: DAG.deep_freeze(DAG.deep_dup(resume_token)),

--- a/scripts/production_readiness.rb
+++ b/scripts/production_readiness.rb
@@ -1,0 +1,666 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "optparse"
+require "securerandom"
+require "time"
+
+require_relative "../lib/dag"
+
+module ProductionReadiness
+  class Failure < StandardError
+  end
+
+  class ProbeStep < DAG::Step::Base
+    def call(input)
+      context = input.context.to_h
+      DAG::Success[
+        value: {
+          node: input.node_id,
+          attempt_number: input.attempt_number,
+          context_size: context.size
+        },
+        context_patch: {
+          input.node_id => {
+            attempt_number: input.attempt_number,
+            predecessor_count: context.size,
+            config_marker: config.fetch(:marker, "probe")
+          }
+        },
+        metadata: {step: :probe}
+      ]
+    end
+  end
+
+  class FlakyStep < DAG::Step::Base
+    def call(input)
+      fail_until = config.fetch(:fail_until, 1)
+      if input.attempt_number <= fail_until
+        return DAG::Failure[
+          error: {
+            code: :synthetic_retry,
+            node: input.node_id,
+            attempt_number: input.attempt_number
+          },
+          retriable: true
+        ]
+      end
+
+      DAG::Success[
+        value: {node: input.node_id, recovered_at: input.attempt_number},
+        context_patch: {input.node_id => {attempt_number: input.attempt_number}},
+        metadata: {step: :flaky}
+      ]
+    end
+  end
+
+  class WaitingStep < DAG::Step::Base
+    def call(input)
+      DAG::Waiting[
+        reason: config.fetch(:reason, :external),
+        resume_token: {node: input.node_id, attempt_number: input.attempt_number},
+        not_before_ms: config[:not_before_ms],
+        metadata: {step: :waiting}
+      ]
+    end
+  end
+
+  class BadReturnStep < DAG::Step::Base
+    def call(_input)
+      :not_a_result
+    end
+  end
+
+  class RaisingStep < DAG::Step::Base
+    def call(_input)
+      raise ArgumentError, "synthetic production-readiness exception"
+    end
+  end
+
+  class MutationProposalStep < DAG::Step::Base
+    def call(input)
+      mutation = DAG::ProposedMutation[
+        kind: :invalidate,
+        target_node_id: config.fetch(:target_node_id)
+      ]
+      DAG::Success[
+        value: {node: input.node_id, proposed_mutations: 1},
+        context_patch: {input.node_id => {attempt_number: input.attempt_number}},
+        proposed_mutations: [mutation],
+        metadata: {step: :mutation_proposal}
+      ]
+    end
+  end
+
+  class Harness
+    DEFAULT_FAST_SECONDS = 120
+    DEFAULT_FULL_SECONDS = 3600
+    FAST_NODE_RANGE = 4..24
+    FULL_NODE_RANGE = 12..100
+
+    def initialize(options)
+      @options = options
+      @rng = Random.new(options.fetch(:seed))
+      @deadline = monotonic_seconds + options.fetch(:duration)
+      @metrics = Hash.new(0)
+      @last_progress_at = monotonic_seconds
+      @fingerprint = DAG::Adapters::Stdlib::Fingerprint.new
+      @serializer = DAG::Adapters::Stdlib::Serializer.new
+      @clock = DAG::Adapters::Stdlib::Clock.new
+      @id_generator = DAG::Adapters::Stdlib::IdGenerator.new
+    end
+
+    def self.parse(argv)
+      options = {
+        fast: false,
+        duration: nil,
+        seed: Random.new_seed,
+        progress_interval: 10
+      }
+
+      parser = OptionParser.new do |opts|
+        opts.banner = "Usage: scripts/production_readiness.rb [--fast] [--duration SECONDS] [--seed INTEGER]"
+        opts.on("--fast", "Run the short profile. Defaults to #{DEFAULT_FAST_SECONDS}s.") do
+          options[:fast] = true
+        end
+        opts.on("--duration SECONDS", Integer, "Override duration in seconds.") do |seconds|
+          options[:duration] = seconds
+        end
+        opts.on("--seed INTEGER", Integer, "Deterministic random seed.") do |seed|
+          options[:seed] = seed
+        end
+        opts.on("--progress-interval SECONDS", Integer, "Progress print interval.") do |seconds|
+          options[:progress_interval] = seconds
+        end
+        opts.on("-h", "--help", "Show help.") do
+          puts opts
+          exit 0
+        end
+      end
+      parser.parse!(argv)
+
+      options[:duration] ||= options[:fast] ? DEFAULT_FAST_SECONDS : DEFAULT_FULL_SECONDS
+      raise ArgumentError, "--duration must be positive" unless options[:duration].positive?
+      raise ArgumentError, "--progress-interval must be positive" unless options[:progress_interval].positive?
+
+      options
+    end
+
+    def run
+      log("ruby-dag production readiness: duration=#{@options[:duration]}s seed=#{@options[:seed]} fast=#{@options[:fast]}")
+
+      fixed_scenarios
+      until expired?
+        random_completed_workflow_scenario
+        graph_fuzz_scenario
+        flaky_retry_scenario
+        terminal_failure_scenario
+        waiting_idempotence_scenario
+        bad_step_boundary_scenario
+        crash_resume_scenario(:before_commit)
+        crash_resume_scenario(:after_commit)
+        mutation_pause_resume_scenario
+        replace_subtree_resume_scenario
+        storage_contract_edge_scenario
+        progress_if_due
+      end
+
+      log("PASS #{summary}")
+      true
+    end
+
+    private
+
+    def fixed_scenarios
+      random_completed_workflow_scenario(nodes: 1, edge_probability: 0.0)
+      random_completed_workflow_scenario(nodes: 2, edge_probability: 1.0)
+      random_completed_workflow_scenario(nodes: 48, edge_probability: 0.08)
+      graph_fuzz_scenario(nodes: 80, edge_probability: 0.05)
+      flaky_retry_scenario(fail_until: 2, max_attempts: 3)
+      terminal_failure_scenario(max_attempts: 2)
+      waiting_idempotence_scenario
+      bad_step_boundary_scenario
+      crash_resume_scenario(:before_commit)
+      crash_resume_scenario(:after_commit)
+      mutation_pause_resume_scenario
+      replace_subtree_resume_scenario
+      storage_contract_edge_scenario
+    end
+
+    def random_completed_workflow_scenario(nodes: nil, edge_probability: nil)
+      nodes ||= @rng.rand(node_range)
+      edge_probability ||= @options[:fast] ? @rng.rand(0.02..0.18) : @rng.rand(0.01..0.12)
+      definition = random_definition(nodes: nodes, edge_probability: edge_probability)
+      storage = DAG::Adapters::Memory::Storage.new
+      event_bus = DAG::Adapters::Memory::EventBus.new(buffer_size: [nodes * 4, 1000].max)
+      workflow_id = create_workflow(storage, definition)
+
+      result = runner(storage, event_bus: event_bus).call(workflow_id)
+
+      assert_equal(:completed, result.state, "random workflow did not complete")
+      assert_committed(storage, workflow_id, definition)
+      assert_event_log(storage, workflow_id)
+      assert_event_bus_frozen(event_bus)
+      assert_storage_returns_are_isolated(storage, workflow_id)
+
+      @metrics[:completed_workflows] += 1
+      @metrics[:completed_nodes] += nodes
+    end
+
+    def graph_fuzz_scenario(nodes: nil, edge_probability: nil)
+      nodes ||= @rng.rand(node_range)
+      edge_probability ||= @rng.rand(0.01..0.2)
+      definition = random_definition(nodes: nodes, edge_probability: edge_probability)
+      graph = definition.graph
+      order = graph.topological_order
+      position = order.each_with_index.to_h
+
+      assert_equal(nodes, graph.node_count, "node count drifted")
+      graph.each_edge do |edge|
+        assert(position.fetch(edge.from) < position.fetch(edge.to), "topological order violated by #{edge.inspect}")
+        assert(edge.metadata.frozen?, "edge metadata is not frozen")
+      end
+
+      h1 = definition.to_h
+      h2 = DAG.deep_dup(h1)
+      assert_equal(@fingerprint.compute(h1), @fingerprint.compute(h2), "fingerprint is not stable")
+      assert_raises(DAG::CycleError) { graph.dup.add_edge(order.last, order.first) } if nodes > 1
+
+      @metrics[:graph_fuzzes] += 1
+      @metrics[:graph_nodes] += nodes
+    end
+
+    def flaky_retry_scenario(fail_until: nil, max_attempts: nil)
+      fail_until ||= @rng.rand(1..3)
+      max_attempts ||= fail_until + 1
+      definition = DAG::Workflow::Definition.new
+        .add_node(:a, type: :flaky, config: {fail_until: fail_until})
+      storage = DAG::Adapters::Memory::Storage.new
+      workflow_id = create_workflow(storage, definition, runtime_profile: runtime_profile(max_attempts_per_node: max_attempts))
+
+      result = runner(storage).call(workflow_id)
+
+      assert_equal(:completed, result.state, "flaky workflow did not recover")
+      attempts = storage.list_attempts(workflow_id: workflow_id, revision: 1, node_id: :a)
+      assert_equal((1..(fail_until + 1)).to_a, attempts.map { |attempt| attempt[:attempt_number] }, "attempt numbers drifted")
+      assert_equal([:failed] * fail_until + [:committed], attempts.map { |attempt| attempt[:state] }, "unexpected retry states")
+
+      @metrics[:retry_recoveries] += 1
+      @metrics[:attempts] += attempts.size
+    end
+
+    def terminal_failure_scenario(max_attempts: nil)
+      max_attempts ||= @rng.rand(1..3)
+      definition = DAG::Workflow::Definition.new
+        .add_node(:a, type: :flaky, config: {fail_until: max_attempts + 100})
+      storage = DAG::Adapters::Memory::Storage.new
+      workflow_id = create_workflow(storage, definition, runtime_profile: runtime_profile(max_attempts_per_node: max_attempts))
+
+      result = runner(storage).call(workflow_id)
+
+      assert_equal(:failed, result.state, "terminal failure workflow did not fail")
+      attempts = storage.list_attempts(workflow_id: workflow_id, revision: 1, node_id: :a)
+      assert_equal(max_attempts, attempts.size, "terminal failure did not stop at budget")
+      assert_equal((1..max_attempts).to_a, attempts.map { |attempt| attempt[:attempt_number] }, "failure attempt numbers drifted")
+      assert_equal(:failed, storage.load_workflow(id: workflow_id)[:state], "workflow state did not persist failed")
+
+      @metrics[:terminal_failures] += 1
+      @metrics[:attempts] += attempts.size
+    end
+
+    def waiting_idempotence_scenario
+      definition = DAG::Workflow::Definition.new
+        .add_node(:a, type: :waiting, config: {reason: :external_io, not_before_ms: @clock.now_ms + 1000})
+      storage = DAG::Adapters::Memory::Storage.new
+      workflow_id = create_workflow(storage, definition)
+
+      result = runner(storage).call(workflow_id)
+      assert_equal(:waiting, result.state, "waiting workflow did not wait")
+      assert_equal(:waiting, storage.load_workflow(id: workflow_id)[:state], "waiting state did not persist")
+      assert_raises(DAG::StaleStateError) { runner(storage).call(workflow_id) }
+
+      resumed = runner(storage).resume(workflow_id)
+      assert_equal(:waiting, resumed.state, "waiting resume should stay waiting without external resolution")
+      attempts = storage.list_attempts(workflow_id: workflow_id, revision: 1, node_id: :a)
+      assert_equal(1, attempts.size, "resume re-ran a waiting node")
+
+      @metrics[:waiting_workflows] += 1
+    end
+
+    def bad_step_boundary_scenario
+      [
+        [:bad_return, :step_bad_return],
+        [:raising, :step_raised]
+      ].each do |type, code|
+        definition = DAG::Workflow::Definition.new.add_node(:a, type: type)
+        storage = DAG::Adapters::Memory::Storage.new
+        workflow_id = create_workflow(storage, definition)
+
+        result = runner(storage).call(workflow_id)
+        attempt = storage.list_attempts(workflow_id: workflow_id, revision: 1, node_id: :a).last
+
+        assert_equal(:failed, result.state, "#{type} did not fail workflow")
+        assert_equal(code, attempt[:result].error.fetch(:code), "#{type} mapped to wrong error code")
+      end
+
+      @metrics[:boundary_failures] += 2
+    end
+
+    def crash_resume_scenario(phase)
+      crash_on = case phase
+      when :before_commit then {method: :commit_attempt, node_id: :b, before_commit: true}
+      when :after_commit then {method: :commit_attempt, node_id: :b, after_commit: true}
+      else raise ArgumentError, "unknown crash phase: #{phase.inspect}"
+      end
+
+      storage = DAG::Adapters::Memory::CrashableStorage.new(crash_on: crash_on)
+      definition = chain_definition(%i[a b c], type: :probe)
+      workflow_id = create_workflow(storage, definition)
+
+      assert_raises(DAG::Adapters::Memory::SimulatedCrash) { runner(storage).call(workflow_id) }
+
+      healthy_storage = storage.snapshot_to_healthy
+      result = runner(healthy_storage).resume(workflow_id)
+      assert_equal(:completed, result.state, "crash #{phase} did not resume to completion")
+      assert_committed(healthy_storage, workflow_id, definition)
+
+      b_attempt_states = healthy_storage
+        .list_attempts(workflow_id: workflow_id, revision: 1, node_id: :b)
+        .map { |attempt| attempt[:state] }
+      expected = (phase == :before_commit) ? %i[aborted committed] : [:committed]
+      assert_equal(expected, b_attempt_states, "unexpected b attempt states after #{phase} crash")
+
+      @metrics[:crash_resumes] += 1
+    end
+
+    def mutation_pause_resume_scenario
+      definition = DAG::Workflow::Definition.new
+        .add_node(:a, type: :probe)
+        .add_node(:b, type: :mutation_proposal, config: {target_node_id: :c})
+        .add_node(:c, type: :probe)
+        .add_edge(:a, :b)
+        .add_edge(:b, :c)
+      storage = DAG::Adapters::Memory::Storage.new
+      event_bus = DAG::Adapters::Memory::EventBus.new
+      workflow_id = create_workflow(storage, definition)
+
+      paused = runner(storage, event_bus: event_bus).call(workflow_id)
+      assert_equal(:paused, paused.state, "mutation proposal did not pause workflow")
+
+      apply = mutation_service(storage, event_bus).apply(
+        workflow_id: workflow_id,
+        mutation: DAG::ProposedMutation[kind: :invalidate, target_node_id: :c],
+        expected_revision: 1
+      )
+      assert_equal(2, apply.revision, "invalidate did not append revision")
+      assert_equal([:c], apply.invalidated_node_ids, "invalidate reset wrong nodes")
+
+      result = runner(storage, event_bus: event_bus).resume(workflow_id)
+      assert_equal(:completed, result.state, "resume after invalidate did not complete")
+      assert_equal(:committed, storage.load_node_states(workflow_id: workflow_id, revision: 2).fetch(:c), "c was not recomputed")
+
+      @metrics[:mutations] += 1
+    end
+
+    def replace_subtree_resume_scenario
+      definition = DAG::Workflow::Definition.new
+        .add_node(:a, type: :probe)
+        .add_node(:b, type: :probe)
+        .add_node(:c, type: :probe)
+        .add_node(:d, type: :probe)
+        .add_edge(:a, :b)
+        .add_edge(:a, :c)
+        .add_edge(:b, :d)
+        .add_edge(:c, :d)
+      storage = DAG::Adapters::Memory::Storage.new
+      event_bus = DAG::Adapters::Memory::EventBus.new
+      workflow_id = create_committed_workflow(storage, definition)
+
+      replacement = DAG::ReplacementGraph[
+        graph: DAG::Graph.new.add_node(:b_prime).freeze,
+        entry_node_ids: [:b_prime],
+        exit_node_ids: [:b_prime]
+      ]
+      apply = mutation_service(storage, event_bus).apply(
+        workflow_id: workflow_id,
+        mutation: DAG::ProposedMutation[kind: :replace_subtree, target_node_id: :b, replacement_graph: replacement],
+        expected_revision: 1
+      )
+
+      assert_equal(2, apply.revision, "replace_subtree did not append revision")
+      assert(apply.definition.has_node?(:b_prime), "replacement node missing")
+      refute(apply.definition.has_node?(:b), "replaced node still present")
+
+      result = runner(storage, event_bus: event_bus).resume(workflow_id)
+      assert_equal(:completed, result.state, "resume after replace_subtree did not complete")
+      assert_equal(:committed, storage.load_node_states(workflow_id: workflow_id, revision: 2).fetch(:b_prime), "replacement node did not run")
+
+      @metrics[:mutations] += 1
+    end
+
+    def storage_contract_edge_scenario
+      storage = DAG::Adapters::Memory::Storage.new
+      definition = chain_definition(%i[a b], type: :probe)
+      workflow_id = create_workflow(storage, definition)
+
+      attempt_id = storage.begin_attempt(
+        workflow_id: workflow_id,
+        revision: 1,
+        node_id: :a,
+        expected_node_state: :pending,
+        attempt_number: 7
+      )
+      event = event(:node_committed, workflow_id: workflow_id, node_id: :a, attempt_id: attempt_id)
+      storage.commit_attempt(
+        attempt_id: attempt_id,
+        result: DAG::Success[value: :a, context_patch: {a: {nested: [1, 2, 3]}}],
+        node_state: :committed,
+        event: event
+      )
+
+      assert_equal(7, storage.list_attempts(workflow_id: workflow_id, revision: 1, node_id: :a).last[:attempt_number], "storage rewrote attempt_number")
+      assert_raises(DAG::StaleStateError) do
+        storage.commit_attempt(
+          attempt_id: attempt_id,
+          result: DAG::Success[value: :late],
+          node_state: :committed,
+          event: event(:node_committed, workflow_id: workflow_id, node_id: :a, attempt_id: attempt_id)
+        )
+      end
+      assert_raises(DAG::StaleStateError) do
+        storage.begin_attempt(
+          workflow_id: workflow_id,
+          revision: 1,
+          node_id: :a,
+          expected_node_state: :pending,
+          attempt_number: 8
+        )
+      end
+      assert_storage_returns_are_isolated(storage, workflow_id)
+
+      @metrics[:storage_edges] += 1
+    end
+
+    def random_definition(nodes:, edge_probability:)
+      definition = DAG::Workflow::Definition.new
+      node_ids = Array.new(nodes) { |index| :"n#{index}" }
+      node_ids.each do |node_id|
+        definition = definition.add_node(node_id, type: :probe, config: {marker: "m#{@rng.rand(1000)}"})
+      end
+
+      (1...nodes).each do |to_index|
+        from_index = @rng.rand(0...to_index)
+        definition = definition.add_edge(node_ids.fetch(from_index), node_ids.fetch(to_index), weight: @rng.rand(1..10))
+      end
+
+      (0...nodes).each do |from_index|
+        ((from_index + 1)...nodes).each do |to_index|
+          next if @rng.rand >= edge_probability
+
+          definition = definition.add_edge(node_ids.fetch(from_index), node_ids.fetch(to_index), weight: @rng.rand(1..10))
+        end
+      end
+
+      definition
+    end
+
+    def chain_definition(node_ids, type:)
+      node_ids.each_with_index.reduce(DAG::Workflow::Definition.new) do |definition, (node_id, index)|
+        next_definition = definition.add_node(node_id, type: type)
+        (index == 0) ? next_definition : next_definition.add_edge(node_ids.fetch(index - 1), node_id)
+      end
+    end
+
+    def registry
+      @registry ||= begin
+        reg = DAG::StepTypeRegistry.new
+        reg.register(name: :probe, klass: ProbeStep, fingerprint_payload: {v: 1})
+        reg.register(name: :flaky, klass: FlakyStep, fingerprint_payload: {v: 1})
+        reg.register(name: :waiting, klass: WaitingStep, fingerprint_payload: {v: 1})
+        reg.register(name: :bad_return, klass: BadReturnStep, fingerprint_payload: {v: 1})
+        reg.register(name: :raising, klass: RaisingStep, fingerprint_payload: {v: 1})
+        reg.register(name: :mutation_proposal, klass: MutationProposalStep, fingerprint_payload: {v: 1})
+        reg.register(name: :noop, klass: DAG::BuiltinSteps::Noop, fingerprint_payload: {v: 1})
+        reg.freeze!
+        reg
+      end
+    end
+
+    def runner(storage, event_bus: DAG::Adapters::Null::EventBus.new)
+      DAG::Runner.new(
+        storage: storage,
+        event_bus: event_bus,
+        registry: registry,
+        clock: @clock,
+        id_generator: @id_generator,
+        fingerprint: @fingerprint,
+        serializer: @serializer
+      )
+    end
+
+    def mutation_service(storage, event_bus)
+      DAG::MutationService.new(storage: storage, event_bus: event_bus, clock: @clock)
+    end
+
+    def create_workflow(storage, definition, initial_context: {}, runtime_profile: nil)
+      workflow_id = SecureRandom.uuid
+      storage.create_workflow(
+        id: workflow_id,
+        initial_definition: definition,
+        initial_context: initial_context,
+        runtime_profile: runtime_profile || self.runtime_profile
+      )
+      workflow_id
+    end
+
+    def create_committed_workflow(storage, definition)
+      workflow_id = create_workflow(storage, definition)
+      definition.topological_order.each do |node_id|
+        attempt_id = storage.begin_attempt(
+          workflow_id: workflow_id,
+          revision: definition.revision,
+          node_id: node_id,
+          expected_node_state: :pending,
+          attempt_number: 1
+        )
+        storage.commit_attempt(
+          attempt_id: attempt_id,
+          result: DAG::Success[value: node_id, context_patch: {node_id => true}],
+          node_state: :committed,
+          event: event(:node_committed, workflow_id: workflow_id, node_id: node_id, attempt_id: attempt_id)
+        )
+      end
+      storage.transition_workflow_state(id: workflow_id, from: :pending, to: :paused)
+      workflow_id
+    end
+
+    def runtime_profile(max_attempts_per_node: 3, max_workflow_retries: 1)
+      DAG::RuntimeProfile[
+        durability: :ephemeral,
+        max_attempts_per_node: max_attempts_per_node,
+        max_workflow_retries: max_workflow_retries,
+        event_bus_kind: :memory
+      ]
+    end
+
+    def event(type, workflow_id:, node_id: nil, attempt_id: nil, payload: {})
+      DAG::Event[
+        type: type,
+        workflow_id: workflow_id,
+        revision: 1,
+        node_id: node_id,
+        attempt_id: attempt_id,
+        at_ms: @clock.now_ms,
+        payload: payload
+      ]
+    end
+
+    def assert_committed(storage, workflow_id, definition)
+      states = storage.load_node_states(workflow_id: workflow_id, revision: definition.revision)
+      assert_equal(definition.nodes.sort_by(&:to_s), states.keys.sort_by(&:to_s), "node states key set drifted")
+      assert(states.values.all? { |state| state == :committed }, "not all nodes committed: #{states.inspect}")
+      definition.each_node do |node_id|
+        attempts = storage.list_attempts(workflow_id: workflow_id, revision: definition.revision, node_id: node_id)
+        assert(attempts.any? { |attempt| attempt[:state] == :committed }, "node #{node_id} has no committed attempt")
+      end
+    end
+
+    def assert_event_log(storage, workflow_id)
+      events = storage.read_events(workflow_id: workflow_id)
+      seqs = events.map(&:seq)
+      assert_equal(seqs.sort, seqs, "event seq is not monotonic")
+      assert_equal(seqs.uniq, seqs, "event seq contains duplicates")
+      assert_equal(:workflow_started, events.first&.type, "first event is not workflow_started")
+      assert_equal(1, events.count { |event| event.type == :workflow_started }, "workflow_started was emitted more than once")
+      assert(%i[workflow_completed workflow_failed workflow_waiting workflow_paused].include?(events.last&.type), "last event is not terminal")
+      events.each { |event| assert(event.frozen? && event.payload.frozen?, "event is not deeply frozen") }
+    end
+
+    def assert_event_bus_frozen(event_bus)
+      event_bus.events.each { |event| assert(event.frozen? && event.payload.frozen?, "event bus exposed mutable event") }
+    end
+
+    def assert_storage_returns_are_isolated(storage, workflow_id)
+      workflow = storage.load_workflow(id: workflow_id)
+      assert(workflow.frozen?, "load_workflow returned mutable workflow")
+      assert_raises(FrozenError) { workflow[:state] = :corrupt }
+      assert_equal(storage.load_workflow(id: workflow_id)[:state], workflow[:state], "workflow mutation leaked into storage")
+
+      definition = storage.load_current_definition(id: workflow_id)
+      states = storage.load_node_states(workflow_id: workflow_id, revision: definition.revision)
+      assert(states.frozen?, "load_node_states returned mutable hash")
+      assert_raises(FrozenError) { states[states.keys.first] = :corrupt } unless states.empty?
+
+      attempts = storage.list_attempts(workflow_id: workflow_id)
+      assert(attempts.frozen?, "list_attempts returned mutable array")
+      attempts.each { |attempt| assert(attempt.frozen?, "attempt record is mutable") }
+      assert_raises(FrozenError) { attempts << {} }
+
+      events = storage.read_events(workflow_id: workflow_id)
+      assert(events.frozen?, "read_events returned mutable array")
+      assert_raises(FrozenError) { events << :corrupt }
+    end
+
+    def node_range
+      @options[:fast] ? FAST_NODE_RANGE : FULL_NODE_RANGE
+    end
+
+    def expired?
+      monotonic_seconds >= @deadline
+    end
+
+    def progress_if_due
+      now = monotonic_seconds
+      return if now - @last_progress_at < @options[:progress_interval]
+
+      @last_progress_at = now
+      log("progress #{summary}")
+    end
+
+    def summary
+      elapsed = @options.fetch(:duration) - [@deadline - monotonic_seconds, 0].max
+      ordered = @metrics.keys.sort.map { |key| "#{key}=#{@metrics[key]}" }.join(" ")
+      "elapsed=#{format("%.1f", elapsed)}s #{ordered}"
+    end
+
+    def monotonic_seconds
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    def log(message)
+      puts("[#{Time.now.utc.iso8601}] #{message}")
+    end
+
+    def assert(condition, message)
+      raise Failure, message unless condition
+    end
+
+    def refute(condition, message)
+      assert(!condition, message)
+    end
+
+    def assert_equal(expected, actual, message)
+      return if expected == actual
+
+      raise Failure, "#{message}: expected #{expected.inspect}, got #{actual.inspect}"
+    end
+
+    def assert_raises(error_class)
+      yield
+      raise Failure, "expected #{error_class}, nothing was raised"
+    rescue error_class
+      true
+    rescue => e
+      raise Failure, "expected #{error_class}, got #{e.class}: #{e.message}"
+    end
+  end
+end
+
+begin
+  options = ProductionReadiness::Harness.parse(ARGV)
+  ProductionReadiness::Harness.new(options).run
+rescue => e
+  warn("[#{Time.now.utc.iso8601}] FAIL #{e.class}: #{e.message}")
+  warn(e.backtrace.join("\n")) if e.backtrace
+  exit 1
+end

--- a/spec/graph_test.rb
+++ b/spec/graph_test.rb
@@ -909,6 +909,19 @@ class GraphTest < Minitest::Test
     assert_equal({weight: 7}, duped.edge_metadata(:a, :b))
   end
 
+  def test_edge_metadata_is_deep_frozen_and_isolated_from_caller_mutation
+    tags = ["initial"]
+    graph = DAG::Graph.new.add_node(:a).add_node(:b)
+    graph.add_edge(:a, :b, tags: tags)
+    graph.freeze
+
+    tags << "mutated"
+
+    assert_equal({tags: ["initial"]}, graph.edge_metadata(:a, :b))
+    assert graph.edge_metadata(:a, :b)[:tags].frozen?
+    assert_raises(FrozenError) { graph.edge_metadata(:a, :b)[:tags] << "nope" }
+  end
+
   def test_edge_metadata_in_subgraph
     graph = build_graph([:a, :b, :c], [])
     graph.add_edge(:a, :b, weight: 2)

--- a/spec/r0/ports_test.rb
+++ b/spec/r0/ports_test.rb
@@ -12,7 +12,7 @@ class R0PortsTest < Minitest::Test
     load_current_definition: {id: "x"},
     load_node_states: {workflow_id: "x", revision: 1},
     transition_node_state: {workflow_id: "x", revision: 1, node_id: :a, from: :pending, to: :running},
-    begin_attempt: {workflow_id: "x", revision: 1, node_id: :a, expected_node_state: :pending},
+    begin_attempt: {workflow_id: "x", revision: 1, node_id: :a, expected_node_state: :pending, attempt_number: 1},
     commit_attempt: {attempt_id: "x", result: nil, node_state: :committed, event: nil},
     abort_running_attempts: {workflow_id: "x"},
     list_attempts: {workflow_id: "x"},

--- a/spec/r1/memory_storage_cas_test.rb
+++ b/spec/r1/memory_storage_cas_test.rb
@@ -22,13 +22,30 @@ class MemoryStorageCasTest < Minitest::Test
     end
   end
 
-  def test_count_attempts_excludes_aborted
+  def test_count_attempts_includes_non_aborted_attempts
     assert_equal 0, @storage.count_attempts(workflow_id: @workflow_id, revision: 1, node_id: :a)
-    a1 = @storage.begin_attempt(workflow_id: @workflow_id, revision: 1, node_id: :a, expected_node_state: :pending)
-    @storage.commit_attempt(attempt_id: a1, result: DAG::Success[value: 1, context_patch: {}], node_state: :pending, event: build_event(:node_committed, workflow_id: @workflow_id))
+    a1 = @storage.begin_attempt(
+      workflow_id: @workflow_id,
+      revision: 1,
+      node_id: :a,
+      expected_node_state: :pending,
+      attempt_number: 1
+    )
+    @storage.commit_attempt(
+      attempt_id: a1,
+      result: DAG::Failure[error: {code: :retry}, retriable: true],
+      node_state: :pending,
+      event: build_event(:node_failed, workflow_id: @workflow_id)
+    )
     @storage.abort_running_attempts(workflow_id: @workflow_id) # nothing to abort
 
-    a2 = @storage.begin_attempt(workflow_id: @workflow_id, revision: 1, node_id: :a, expected_node_state: :pending)
+    a2 = @storage.begin_attempt(
+      workflow_id: @workflow_id,
+      revision: 1,
+      node_id: :a,
+      expected_node_state: :pending,
+      attempt_number: 2
+    )
     refute_equal a1, a2
     assert_equal 2, @storage.count_attempts(workflow_id: @workflow_id, revision: 1, node_id: :a)
   end

--- a/spec/r1/runner_outcomes_test.rb
+++ b/spec/r1/runner_outcomes_test.rb
@@ -99,7 +99,7 @@ class RunnerOutcomesTest < Minitest::Test
     workflow_id = create_workflow(storage, simple_definition)
     storage.transition_workflow_state(id: workflow_id, from: :pending, to: :paused)
 
-    result = runner.call(workflow_id)
+    result = runner.resume(workflow_id)
     assert_equal :completed, result.state
   end
 
@@ -108,6 +108,15 @@ class RunnerOutcomesTest < Minitest::Test
     runner = build_runner(storage: storage)
     workflow_id = create_workflow(storage, simple_definition)
     storage.transition_workflow_state(id: workflow_id, from: :pending, to: :running)
+
+    assert_raises(DAG::StaleStateError) { runner.call(workflow_id) }
+  end
+
+  def test_call_rejects_paused_workflow
+    storage = DAG::Adapters::Memory::Storage.new
+    runner = build_runner(storage: storage)
+    workflow_id = create_workflow(storage, simple_definition)
+    storage.transition_workflow_state(id: workflow_id, from: :pending, to: :paused)
 
     assert_raises(DAG::StaleStateError) { runner.call(workflow_id) }
   end

--- a/spec/r1/storage_state_extras_test.rb
+++ b/spec/r1/storage_state_extras_test.rb
@@ -124,14 +124,26 @@ class StorageStateExtrasTest < Minitest::Test
   def test_begin_attempt_unknown_revision_raises
     workflow_id = create_workflow(@storage, @definition)
     assert_raises(DAG::StaleRevisionError) do
-      @storage.begin_attempt(workflow_id: workflow_id, revision: 99, node_id: :a, expected_node_state: :pending)
+      @storage.begin_attempt(
+        workflow_id: workflow_id,
+        revision: 99,
+        node_id: :a,
+        expected_node_state: :pending,
+        attempt_number: 1
+      )
     end
   end
 
   def test_begin_attempt_state_mismatch_raises
     workflow_id = create_workflow(@storage, @definition)
     assert_raises(DAG::StaleStateError) do
-      @storage.begin_attempt(workflow_id: workflow_id, revision: 1, node_id: :a, expected_node_state: :committed)
+      @storage.begin_attempt(
+        workflow_id: workflow_id,
+        revision: 1,
+        node_id: :a,
+        expected_node_state: :committed,
+        attempt_number: 1
+      )
     end
   end
 
@@ -143,15 +155,47 @@ class StorageStateExtrasTest < Minitest::Test
 
   def test_commit_attempt_unexpected_result_type_raises
     workflow_id = create_workflow(@storage, @definition)
-    attempt_id = @storage.begin_attempt(workflow_id: workflow_id, revision: 1, node_id: :a, expected_node_state: :pending)
+    attempt_id = @storage.begin_attempt(
+      workflow_id: workflow_id,
+      revision: 1,
+      node_id: :a,
+      expected_node_state: :pending,
+      attempt_number: 1
+    )
     assert_raises(ArgumentError) do
       @storage.commit_attempt(attempt_id: attempt_id, result: :not_a_result, node_state: :committed, event: build_event(workflow_id: workflow_id))
     end
   end
 
+  def test_commit_attempt_rejects_node_state_that_does_not_match_result
+    workflow_id = create_workflow(@storage, @definition)
+    attempt_id = @storage.begin_attempt(
+      workflow_id: workflow_id,
+      revision: 1,
+      node_id: :a,
+      expected_node_state: :pending,
+      attempt_number: 1
+    )
+
+    assert_raises(ArgumentError) do
+      @storage.commit_attempt(
+        attempt_id: attempt_id,
+        result: DAG::Success[value: 1, context_patch: {}],
+        node_state: :pending,
+        event: build_event(workflow_id: workflow_id)
+      )
+    end
+  end
+
   def test_abort_running_attempts_marks_running_as_aborted
     workflow_id = create_workflow(@storage, @definition)
-    attempt_id = @storage.begin_attempt(workflow_id: workflow_id, revision: 1, node_id: :a, expected_node_state: :pending)
+    attempt_id = @storage.begin_attempt(
+      workflow_id: workflow_id,
+      revision: 1,
+      node_id: :a,
+      expected_node_state: :pending,
+      attempt_number: 1
+    )
     aborted = @storage.abort_running_attempts(workflow_id: workflow_id)
     assert_includes aborted, attempt_id
   end

--- a/spec/r1/types_validation_test.rb
+++ b/spec/r1/types_validation_test.rb
@@ -70,9 +70,57 @@ class TypesValidationTest < Minitest::Test
     end
   end
 
+  def test_event_new_rejects_unknown_type
+    assert_raises(ArgumentError) do
+      DAG::Event.new(type: :nope, workflow_id: "x", revision: 1, at_ms: 0)
+    end
+  end
+
+  def test_data_factories_reject_positional_arguments
+    graph = DAG::Graph.new.add_node(:a).freeze
+    cases = [
+      -> { DAG::Success[1] },
+      -> { DAG::Failure[{code: :x}] },
+      -> { DAG::Waiting[:external] },
+      -> { DAG::Event[:workflow_started, "wf", 1, 0] },
+      -> { DAG::RuntimeProfile[:ephemeral, 1, 0, :null] },
+      -> { DAG::StepInput[DAG::ExecutionContext.new, :a] },
+      -> { DAG::ReplacementGraph[graph, [:a], [:a]] },
+      -> { DAG::RunResult[:completed] }
+    ]
+
+    cases.each do |factory_call|
+      assert_raises(ArgumentError) { factory_call.call }
+    end
+  end
+
+  def test_data_with_revalidates_through_initialize
+    assert_raises(ArgumentError) do
+      DAG::Success[value: 1].with(value: Time.now)
+    end
+  end
+
   def test_success_factory_rejects_non_mutation_in_proposed_mutations
     assert_raises(ArgumentError) do
       DAG::Success[value: 1, proposed_mutations: ["not a mutation"]]
+    end
+  end
+
+  def test_success_new_rejects_non_json_safe_value
+    assert_raises(ArgumentError) do
+      DAG::Success.new(value: Time.now)
+    end
+  end
+
+  def test_success_factory_defaults_value_to_nil
+    result = DAG::Success[]
+    assert_nil result.value
+    assert_equal({}, result.context_patch)
+  end
+
+  def test_failure_new_rejects_non_json_safe_error
+    assert_raises(ArgumentError) do
+      DAG::Failure.new(error: {time: Time.now})
     end
   end
 

--- a/spec/r2/resume_after_crash_test.rb
+++ b/spec/r2/resume_after_crash_test.rb
@@ -47,6 +47,23 @@ class ResumeAfterCrashTest < Minitest::Test
     assert_equal :committed, node_state(healthy_storage, workflow_id, :c)
   end
 
+  def test_begin_attempt_crash_can_match_attempt_number
+    storage = DAG::Adapters::Memory::CrashableStorage.new(
+      crash_on: {method: :begin_attempt, node_id: :a, attempt_number: 7, before: true}
+    )
+    workflow_id = create_workflow(storage, simple_definition)
+
+    assert_raises(DAG::Adapters::Memory::SimulatedCrash) do
+      storage.begin_attempt(
+        workflow_id: workflow_id,
+        revision: 1,
+        node_id: :a,
+        expected_node_state: :pending,
+        attempt_number: 7
+      )
+    end
+  end
+
   private
 
   def logging_chain

--- a/spec/r2/resume_in_flight_attempt_test.rb
+++ b/spec/r2/resume_in_flight_attempt_test.rb
@@ -14,7 +14,8 @@ class ResumeInFlightAttemptTest < Minitest::Test
       workflow_id: workflow_id,
       revision: 1,
       node_id: :a,
-      expected_node_state: :pending
+      expected_node_state: :pending,
+      attempt_number: 1
     )
 
     result = build_runner(storage: storage, registry: registry).resume(workflow_id)

--- a/spec/r3/malformed_mutation_test.rb
+++ b/spec/r3/malformed_mutation_test.rb
@@ -3,134 +3,119 @@
 require_relative "../test_helper"
 
 class R3MalformedMutationTest < Minitest::Test
-  def test_plan_returns_invalid_when_replacement_graph_is_not_a_replacement_graph
-    plan = plan_replace(replacement_graph: Object.new)
-    assert_invalid plan, /replacement_graph must be a DAG::ReplacementGraph/
+  def test_plan_returns_invalid_when_mutation_is_not_a_proposed_mutation
+    plan = DAG::DefinitionEditor.new.plan(simple_definition, Object.new)
+
+    refute plan.valid?
+    assert_match(/mutation must be a DAG::ProposedMutation/, plan.reason)
   end
 
-  def test_plan_returns_invalid_when_replacement_graph_is_nil
-    plan = plan_replace(replacement_graph: nil)
-    assert_invalid plan, /replacement_graph must be a DAG::ReplacementGraph/
-  end
-
-  def test_plan_returns_invalid_when_replacement_inner_graph_is_nil
-    bad = DAG::ReplacementGraph.new(graph: nil, entry_node_ids: [:x], exit_node_ids: [:x])
-    plan = plan_replace(replacement_graph: bad)
-    assert_invalid plan, /replacement graph must be a DAG::Graph/
-  end
-
-  def test_plan_returns_invalid_when_replacement_inner_graph_is_not_a_graph
-    bad = DAG::ReplacementGraph.new(graph: "not a graph", entry_node_ids: [:x], exit_node_ids: [:x])
-    plan = plan_replace(replacement_graph: bad)
-    assert_invalid plan, /replacement graph must be a DAG::Graph/
-  end
-
-  def test_plan_returns_invalid_when_entry_node_ids_empty
-    bad = DAG::ReplacementGraph.new(
-      graph: DAG::Graph.new.add_node(:x).freeze,
-      entry_node_ids: [],
-      exit_node_ids: [:x]
-    )
-    plan = plan_replace(replacement_graph: bad)
-    assert_invalid plan, /entry_node_ids cannot be empty/
-  end
-
-  def test_plan_returns_invalid_when_exit_node_ids_empty
-    bad = DAG::ReplacementGraph.new(
-      graph: DAG::Graph.new.add_node(:x).freeze,
-      entry_node_ids: [:x],
-      exit_node_ids: []
-    )
-    plan = plan_replace(replacement_graph: bad)
-    assert_invalid plan, /exit_node_ids cannot be empty/
-  end
-
-  def test_plan_returns_invalid_when_entry_node_not_in_graph
-    bad = DAG::ReplacementGraph.new(
-      graph: DAG::Graph.new.add_node(:x).freeze,
-      entry_node_ids: [:not_in_graph],
-      exit_node_ids: [:x]
-    )
-    plan = plan_replace(replacement_graph: bad)
-    assert_invalid plan, /replacement entry node is not in graph/
-  end
-
-  def test_plan_returns_invalid_when_exit_node_not_in_graph
-    bad = DAG::ReplacementGraph.new(
-      graph: DAG::Graph.new.add_node(:x).freeze,
-      entry_node_ids: [:x],
-      exit_node_ids: [:not_in_graph]
-    )
-    plan = plan_replace(replacement_graph: bad)
-    assert_invalid plan, /replacement exit node is not in graph/
-  end
-
-  def test_plan_returns_invalid_when_entry_node_ids_not_an_array
-    bad = DAG::ReplacementGraph.new(
-      graph: DAG::Graph.new.add_node(:x).freeze,
-      entry_node_ids: 42,
-      exit_node_ids: [:x]
-    )
-    plan = plan_replace(replacement_graph: bad)
-    assert_invalid plan, /entry_node_ids must be an Array/
-  end
-
-  def test_plan_returns_invalid_when_entry_node_ids_contains_non_symbolic
-    bad = DAG::ReplacementGraph.new(
-      graph: DAG::Graph.new.add_node(:x).freeze,
-      entry_node_ids: [42],
-      exit_node_ids: [:x]
-    )
-    plan = plan_replace(replacement_graph: bad)
-    assert_invalid plan, /entry_node_ids entries must be Symbol or String/
-  end
-
-  def test_plan_returns_invalid_when_entry_node_ids_contains_nil
-    bad = DAG::ReplacementGraph.new(
-      graph: DAG::Graph.new.add_node(:x).freeze,
-      entry_node_ids: [nil],
-      exit_node_ids: [:x]
-    )
-    plan = plan_replace(replacement_graph: bad)
-    assert_invalid plan, /entry_node_ids entries must be Symbol or String/
-  end
-
-  def test_replacement_graph_factory_rejects_non_array_entry_node_ids
-    graph = DAG::Graph.new.add_node(:x).freeze
-
+  def test_proposed_mutation_new_rejects_non_replacement_graph
     error = assert_raises(ArgumentError) do
-      DAG::ReplacementGraph[graph: graph, entry_node_ids: 42, exit_node_ids: [:x]]
+      DAG::ProposedMutation.new(
+        kind: :replace_subtree,
+        target_node_id: :a,
+        replacement_graph: Object.new
+      )
     end
 
-    assert_match(/entry_node_ids must be an Array/, error.message)
+    assert_match(/replace_subtree requires replacement_graph/, error.message)
   end
 
-  def test_replacement_graph_factory_rejects_non_symbolic_entry_node_ids
-    graph = DAG::Graph.new.add_node(:x).freeze
-
+  def test_proposed_mutation_new_rejects_nil_replacement_graph
     error = assert_raises(ArgumentError) do
-      DAG::ReplacementGraph[graph: graph, entry_node_ids: [nil], exit_node_ids: [:x]]
+      DAG::ProposedMutation.new(kind: :replace_subtree, target_node_id: :a, replacement_graph: nil)
     end
 
-    assert_match(/entry_node_ids entries must be Symbol or String/, error.message)
+    assert_match(/replace_subtree requires replacement_graph/, error.message)
+  end
+
+  def test_replacement_graph_new_rejects_nil_inner_graph
+    assert_replacement_graph_error(/graph must be a DAG::Graph/) do
+      DAG::ReplacementGraph.new(graph: nil, entry_node_ids: [:x], exit_node_ids: [:x])
+    end
+  end
+
+  def test_replacement_graph_new_rejects_non_graph_inner_graph
+    assert_replacement_graph_error(/graph must be a DAG::Graph/) do
+      DAG::ReplacementGraph.new(graph: "not a graph", entry_node_ids: [:x], exit_node_ids: [:x])
+    end
+  end
+
+  def test_replacement_graph_new_rejects_empty_entry_node_ids
+    assert_replacement_graph_error(/entry_node_ids cannot be empty/) do
+      DAG::ReplacementGraph.new(
+        graph: DAG::Graph.new.add_node(:x).freeze,
+        entry_node_ids: [],
+        exit_node_ids: [:x]
+      )
+    end
+  end
+
+  def test_replacement_graph_new_rejects_empty_exit_node_ids
+    assert_replacement_graph_error(/exit_node_ids cannot be empty/) do
+      DAG::ReplacementGraph.new(
+        graph: DAG::Graph.new.add_node(:x).freeze,
+        entry_node_ids: [:x],
+        exit_node_ids: []
+      )
+    end
+  end
+
+  def test_replacement_graph_new_rejects_entry_node_not_in_graph
+    assert_replacement_graph_error(/entry node not in graph/) do
+      DAG::ReplacementGraph.new(
+        graph: DAG::Graph.new.add_node(:x).freeze,
+        entry_node_ids: [:not_in_graph],
+        exit_node_ids: [:x]
+      )
+    end
+  end
+
+  def test_replacement_graph_new_rejects_exit_node_not_in_graph
+    assert_replacement_graph_error(/exit node not in graph/) do
+      DAG::ReplacementGraph.new(
+        graph: DAG::Graph.new.add_node(:x).freeze,
+        entry_node_ids: [:x],
+        exit_node_ids: [:not_in_graph]
+      )
+    end
+  end
+
+  def test_replacement_graph_new_rejects_non_array_entry_node_ids
+    assert_replacement_graph_error(/entry_node_ids must be an Array/) do
+      DAG::ReplacementGraph.new(
+        graph: DAG::Graph.new.add_node(:x).freeze,
+        entry_node_ids: 42,
+        exit_node_ids: [:x]
+      )
+    end
+  end
+
+  def test_replacement_graph_new_rejects_non_symbolic_entry_node_ids
+    assert_replacement_graph_error(/entry_node_ids entries must be Symbol or String/) do
+      DAG::ReplacementGraph.new(
+        graph: DAG::Graph.new.add_node(:x).freeze,
+        entry_node_ids: [42],
+        exit_node_ids: [:x]
+      )
+    end
+  end
+
+  def test_replacement_graph_new_rejects_nil_entry_node_ids
+    assert_replacement_graph_error(/entry_node_ids entries must be Symbol or String/) do
+      DAG::ReplacementGraph.new(
+        graph: DAG::Graph.new.add_node(:x).freeze,
+        entry_node_ids: [nil],
+        exit_node_ids: [:x]
+      )
+    end
   end
 
   private
 
-  def plan_replace(replacement_graph:)
-    mutation = DAG::ProposedMutation.new(
-      kind: :replace_subtree,
-      target_node_id: :a,
-      replacement_graph: replacement_graph,
-      rationale: nil,
-      confidence: 1.0,
-      metadata: {}
-    )
-    DAG::DefinitionEditor.new.plan(simple_definition, mutation)
-  end
-
-  def assert_invalid(plan, reason_pattern)
-    refute plan.valid?
-    assert_match reason_pattern, plan.reason
+  def assert_replacement_graph_error(pattern)
+    error = assert_raises(ArgumentError) { yield }
+    assert_match pattern, error.message
   end
 end

--- a/spec/support/storage_contract/attempt_atomicity.rb
+++ b/spec/support/storage_contract/attempt_atomicity.rb
@@ -11,7 +11,8 @@ module StorageContract
         workflow_id: workflow_id,
         revision: 1,
         node_id: :a,
-        expected_node_state: :pending
+        expected_node_state: :pending,
+        attempt_number: 1
       )
 
       stamped = storage.commit_attempt(
@@ -35,7 +36,8 @@ module StorageContract
         workflow_id: workflow_id,
         revision: 1,
         node_id: :a,
-        expected_node_state: :pending
+        expected_node_state: :pending,
+        attempt_number: 1
       )
 
       assert_equal [attempt_id], storage.abort_running_attempts(workflow_id: workflow_id)
@@ -44,6 +46,48 @@ module StorageContract
       assert_equal :aborted, attempt[:state]
       assert_equal :pending, storage.load_node_states(workflow_id: workflow_id, revision: 1)[:a]
       assert_equal 0, storage.count_attempts(workflow_id: workflow_id, revision: 1, node_id: :a)
+    end
+
+    def test_contract_begin_attempt_persists_supplied_attempt_number
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      storage.begin_attempt(
+        workflow_id: workflow_id,
+        revision: 1,
+        node_id: :a,
+        expected_node_state: :pending,
+        attempt_number: 7
+      )
+
+      attempt = storage.list_attempts(workflow_id: workflow_id, revision: 1, node_id: :a).first
+      assert_equal 7, attempt[:attempt_number]
+    end
+
+    def test_contract_commit_attempt_is_one_shot
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      attempt_id = storage.begin_attempt(
+        workflow_id: workflow_id,
+        revision: 1,
+        node_id: :a,
+        expected_node_state: :pending,
+        attempt_number: 1
+      )
+      storage.commit_attempt(
+        attempt_id: attempt_id,
+        result: DAG::Success[value: :a, context_patch: {}],
+        node_state: :committed,
+        event: contract_event(workflow_id: workflow_id, node_id: :a, attempt_id: attempt_id)
+      )
+
+      assert_raises(DAG::StaleStateError) do
+        storage.commit_attempt(
+          attempt_id: attempt_id,
+          result: DAG::Failure[error: {code: :late}],
+          node_state: :failed,
+          event: contract_event(type: :node_failed, workflow_id: workflow_id, node_id: :a, attempt_id: attempt_id)
+        )
+      end
     end
   end
 end

--- a/spec/support/storage_contract/revision_cas.rb
+++ b/spec/support/storage_contract/revision_cas.rb
@@ -27,7 +27,8 @@ module StorageContract
         workflow_id: workflow_id,
         revision: 1,
         node_id: :a,
-        expected_node_state: :pending
+        expected_node_state: :pending,
+        attempt_number: 1
       )
       storage.commit_attempt(
         attempt_id: attempt_id,

--- a/spec/support/workflow_builders.rb
+++ b/spec/support/workflow_builders.rb
@@ -48,7 +48,8 @@ module WorkflowBuilders
       workflow_id: workflow_id,
       revision: revision,
       node_id: node_id,
-      expected_node_state: :pending
+      expected_node_state: :pending,
+      attempt_number: 1
     )
     storage.commit_attempt(
       attempt_id: attempt_id,


### PR DESCRIPTION
## What changed

- Moved public tagged-type validation behind keyword-only `[]` factories that delegate to `initialize`, preserving a single validation path while rejecting positional `Data` construction.
- Enforced deep immutability and one-shot attempt semantics around graph metadata, storage attempts, and runner attempt numbering.
- Aligned the storage port/docs/tests so `Runner` computes `attempt_number` and storage only persists the supplied value.
- Restricted `Runner#call` to pending workflows while keeping `resume` for in-flight states.
- Added crash-test coverage for `attempt_number` matching and a RuboCop migration plan.
- Added `scripts/production_readiness.rb` for fast and one-hour workflow runner stress/readiness runs.

## Why

Roadmap v3.4 requires immutable public value objects, deterministic attempt numbering owned by the runner, and storage adapters that do not silently derive runtime policy. The root cause here was a combination of validation living partly in factories and `Data.define` reopening positional constructors when the custom `[]` methods were removed.

The readiness script gives us a repeatable production-grade pressure harness around the in-memory runner boundary: random DAG execution, retry budgets, waiting/idempotence, crash/resume, mutation apply/resume, storage CAS edges, event-log monotonicity, and returned-value immutability.

## Validation

- `bundle exec ruby -Itest -Ispec spec/r1/types_validation_test.rb spec/r2/resume_after_crash_test.rb spec/r1/memory_storage_cas_test.rb`
- `scripts/production_readiness.rb --fast --duration 5 --progress-interval 2 --seed 1234`
- `bundle exec rake`
- `bundle exec standardrb --format simple`
- `bundle exec rubocop --only DAG/NoThreadOrRactor,DAG/NoMutableAccessors,DAG/NoInPlaceMutation,DAG/NoExternalRequires lib/dag`
- `git diff --check`

Note: full `bundle exec rubocop` still reports the existing baseline offenses; this PR documents the migration path in `docs/plans/2026-04-26-rubocop-migration.md`.