### PR TITLE
ci: drop Ruby 3.2 and 3.3 from CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.3', '3.4', '4.0']
+        ruby-version: ['3.4', '4.0']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4', '4.0']
+        ruby-version: ['3.3', '3.4', '4.0']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Removes both `'3.2'` and `'3.3'` from `.github/workflows/ruby.yml` matrix.
- Roadmap v3.4 §3 frozen decisions: minimum supported Ruby is **3.4**.
- The `test (3.2)` job was a persistent false positive blocking otherwise-green PRs.
- Codex stop-time review flagged 3.3 as also unsupported per the same roadmap clause.

## Test plan

- [ ] CI runs only `3.4` and `4.0` after merge.
- [ ] No green check is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)