### PR TITLE
fix(r3): make `:invalidated` a distinct node state per Roadmap v3.4

### DIFF
--- a/lib/dag/adapters/memory/storage_state.rb
+++ b/lib/dag/adapters/memory/storage_state.rb
@@ -88,7 +88,9 @@ module DAG
           previous_states = state[:node_states][[id, parent_revision]] || {}
           invalidated = invalidated_node_ids.map(&:to_sym)
           new_states = stored_definition.nodes.each_with_object({}) do |node_id, acc|
-            acc[node_id] = if invalidated.include?(node_id) || !previous_states.key?(node_id)
+            acc[node_id] = if invalidated.include?(node_id)
+              :invalidated
+            elsif !previous_states.key?(node_id)
               :pending
             else
               previous_states[node_id]

--- a/lib/dag/runner.rb
+++ b/lib/dag/runner.rb
@@ -69,8 +69,8 @@ module DAG
         eligible = eligible_nodes(run)
         break if eligible.empty?
 
-        eligible.each do |node_id|
-          case execute_node(run, node_id)
+        eligible.each do |node_id, current_state|
+          case execute_node(run, node_id, current_state)
           when :paused
             paused = true
             break
@@ -129,14 +129,21 @@ module DAG
         payload: {initial_context: run.base_context.to_h})
     end
 
+    ELIGIBLE_NODE_STATES = %i[pending invalidated].freeze
+    private_constant :ELIGIBLE_NODE_STATES
+
     def eligible_nodes(run)
       states = @storage.load_node_states(workflow_id: run.workflow_id, revision: run.revision)
-      run.definition.topological_order.select do |node_id|
-        states[node_id] == :pending && run.predecessors_by_node[node_id].all? { |pred| states[pred] == :committed }
+      run.definition.topological_order.filter_map do |node_id|
+        current = states[node_id]
+        next unless ELIGIBLE_NODE_STATES.include?(current)
+        next unless run.predecessors_by_node[node_id].all? { |pred| states[pred] == :committed }
+
+        [node_id, current]
       end
     end
 
-    def execute_node(run, node_id)
+    def execute_node(run, node_id, current_state)
       attempt_number = @storage.count_attempts(
         workflow_id: run.workflow_id,
         revision: run.revision,
@@ -147,7 +154,7 @@ module DAG
         workflow_id: run.workflow_id,
         revision: run.revision,
         node_id: node_id,
-        expected_node_state: :pending,
+        expected_node_state: current_state,
         attempt_number: attempt_number
       )
 
@@ -255,7 +262,7 @@ module DAG
 
       states = @storage.load_node_states(workflow_id: run.workflow_id, revision: run.revision).values
 
-      if states.all? { |s| s == :committed || s == :invalidated }
+      if states.all? { |s| s == :committed }
         transition_and_emit_terminal(run, :completed, :workflow_completed, {})
       elsif states.any? { |s| s == :waiting }
         transition_and_emit_terminal(run, :waiting, :workflow_waiting, {})

--- a/scripts/production_readiness.rb
+++ b/scripts/production_readiness.rb
@@ -391,9 +391,17 @@ module ProductionReadiness
       assert(apply.definition.has_node?(:b_prime), "replacement node missing")
       refute(apply.definition.has_node?(:b), "replaced node still present")
 
+      states_after_apply = storage.load_node_states(workflow_id: workflow_id, revision: 2)
+      assert_equal(:committed, states_after_apply.fetch(:a), "preserved root drifted from :committed")
+      assert_equal(:committed, states_after_apply.fetch(:c), "preserved parallel branch drifted from :committed")
+      assert_equal(:invalidated, states_after_apply.fetch(:d), "preserved-impacted node must be :invalidated post-apply")
+      assert_equal(:pending, states_after_apply.fetch(:b_prime), "newly introduced replacement node must be :pending post-apply")
+
       result = runner(storage, event_bus: event_bus).resume(workflow_id)
       assert_equal(:completed, result.state, "resume after replace_subtree did not complete")
-      assert_equal(:committed, storage.load_node_states(workflow_id: workflow_id, revision: 2).fetch(:b_prime), "replacement node did not run")
+      states_after_resume = storage.load_node_states(workflow_id: workflow_id, revision: 2)
+      assert_equal(:committed, states_after_resume.fetch(:b_prime), "replacement node did not run")
+      assert_equal(:committed, states_after_resume.fetch(:d), "invalidated join did not re-execute")
 
       @metrics[:mutations] += 1
     end

--- a/spec/r1/runner_outcomes_test.rb
+++ b/spec/r1/runner_outcomes_test.rb
@@ -130,12 +130,12 @@ class RunnerOutcomesTest < Minitest::Test
     runner = build_runner(storage: storage, event_bus: event_bus)
     workflow_id = create_workflow(storage, simple_definition)
 
-    # Park `a` in :invalidated (R3-territory state). For R1 there is no
-    # natural transition that produces this without a mutation, so we cheat
-    # via the storage CAS for the test only.
-    storage.transition_node_state(workflow_id: workflow_id, revision: 1, node_id: :a, from: :pending, to: :invalidated)
-    # `b`'s predecessor `a` is :invalidated (not :committed) so eligibility
-    # never lights up, but `b` is still :pending and no node is :waiting.
+    # Park `a` in :running. Mimics an orphan attempt left over by an unclean
+    # crash: under #call (no abort_running_attempts) the runner finds no
+    # eligible nodes (`:running` is not eligible, and `b`'s predecessor is
+    # not `:committed`) and no node is `:waiting`, so finalize must surface
+    # `:failed` with the diagnostic rather than silently succeed.
+    storage.transition_node_state(workflow_id: workflow_id, revision: 1, node_id: :a, from: :pending, to: :running)
 
     result = runner.call(workflow_id)
     assert_equal :failed, result.state

--- a/spec/r1/storage_state_extras_test.rb
+++ b/spec/r1/storage_state_extras_test.rb
@@ -79,7 +79,7 @@ class StorageStateExtrasTest < Minitest::Test
     )
     assert_equal 2, result[:revision]
     states = @storage.load_node_states(workflow_id: workflow_id, revision: 2)
-    assert_equal :pending, states[:a]
+    assert_equal :invalidated, states[:a]
     assert_equal :pending, states[:c]
   end
 

--- a/spec/r3/invalidate_test.rb
+++ b/spec/r3/invalidate_test.rb
@@ -24,9 +24,9 @@ class R3InvalidateTest < Minitest::Test
 
     states = storage.load_node_states(workflow_id: workflow_id, revision: 2)
     assert_equal :committed, states[:a]
-    assert_equal :pending, states[:b]
-    assert_equal :pending, states[:c]
-    assert_equal :pending, states[:d]
+    assert_equal :invalidated, states[:b]
+    assert_equal :invalidated, states[:c]
+    assert_equal :invalidated, states[:d]
 
     stored_event = storage.read_events(workflow_id: workflow_id).last
     assert_equal :mutation_applied, stored_event.type

--- a/spec/r3/invalidated_state_distinct_test.rb
+++ b/spec/r3/invalidated_state_distinct_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+# Roadmap v3.4 §7.4 NODE_STATES makes :invalidated a distinct node state per
+# revision (line 964–971), §R3 line 727/750/756 require that nodes whose
+# upstream output changed be marked :invalidated (not :pending) immediately
+# after a mutation. The mandatory test on line 2493 of the roadmap asserts
+# `:invalidated` right after `mutation_service.apply`. This test mirrors that
+# contract and follows up with a resume to verify the runner re-executes
+# invalidated nodes back to :committed.
+class R3InvalidatedStateDistinctTest < Minitest::Test
+  def test_invalidate_marks_descendants_invalidated_then_resume_recommits
+    storage = DAG::Adapters::Memory::Storage.new
+    workflow_id = create_committed_workflow(storage, three_node_chain(:a, :b, :c))
+    runner = build_runner(storage: storage)
+    service = DAG::MutationService.new(
+      storage: storage,
+      event_bus: DAG::Adapters::Null::EventBus.new,
+      clock: DAG::Adapters::Stdlib::Clock.new
+    )
+
+    service.apply(
+      workflow_id: workflow_id,
+      mutation: DAG::ProposedMutation[kind: :invalidate, target_node_id: :b],
+      expected_revision: 1
+    )
+
+    states_after_apply = storage.load_node_states(workflow_id: workflow_id, revision: 2)
+    assert_equal :committed, states_after_apply[:a]
+    assert_equal :invalidated, states_after_apply[:b]
+    assert_equal :invalidated, states_after_apply[:c]
+
+    result = runner.resume(workflow_id)
+
+    assert_equal :completed, result.state
+    states_after_resume = storage.load_node_states(workflow_id: workflow_id, revision: 2)
+    assert_equal :committed, states_after_resume[:a]
+    assert_equal :committed, states_after_resume[:b]
+    assert_equal :committed, states_after_resume[:c]
+  end
+
+  def test_replace_subtree_marks_preserved_impacted_invalidated
+    storage = DAG::Adapters::Memory::Storage.new
+    workflow_id = create_committed_workflow(storage, diamond_definition)
+    service = DAG::MutationService.new(
+      storage: storage,
+      event_bus: DAG::Adapters::Null::EventBus.new,
+      clock: DAG::Adapters::Stdlib::Clock.new
+    )
+
+    service.apply(
+      workflow_id: workflow_id,
+      mutation: DAG::ProposedMutation[
+        kind: :replace_subtree,
+        target_node_id: :b,
+        replacement_graph: DAG::ReplacementGraph[
+          graph: DAG::Graph.new.add_node(:b_prime).freeze,
+          entry_node_ids: [:b_prime],
+          exit_node_ids: [:b_prime]
+        ]
+      ],
+      expected_revision: 1
+    )
+
+    states = storage.load_node_states(workflow_id: workflow_id, revision: 2)
+    assert_equal :committed, states[:a]
+    assert_equal :committed, states[:c]
+    assert_equal :pending, states[:b_prime], "newly introduced replacement node must be :pending"
+    assert_equal :invalidated, states[:d], "preserved-impacted node must be :invalidated, not :pending"
+    refute_includes states.keys, :b
+  end
+
+  def test_invalidated_node_attempt_number_restarts_on_new_revision
+    storage = DAG::Adapters::Memory::Storage.new
+    workflow_id = create_committed_workflow(storage, three_node_chain(:a, :b, :c))
+    runner = build_runner(storage: storage)
+    service = DAG::MutationService.new(
+      storage: storage,
+      event_bus: DAG::Adapters::Null::EventBus.new,
+      clock: DAG::Adapters::Stdlib::Clock.new
+    )
+
+    service.apply(
+      workflow_id: workflow_id,
+      mutation: DAG::ProposedMutation[kind: :invalidate, target_node_id: :b],
+      expected_revision: 1
+    )
+    runner.resume(workflow_id)
+
+    rev2_b_attempts = storage.list_attempts(workflow_id: workflow_id, revision: 2, node_id: :b)
+    assert_equal [1], rev2_b_attempts.map { |a| a[:attempt_number] },
+      "revision 2 attempt_number for re-executed :invalidated node must restart at 1"
+  end
+
+  private
+
+  def diamond_definition
+    DAG::Workflow::Definition.new
+      .add_node(:a, type: :passthrough)
+      .add_node(:b, type: :passthrough)
+      .add_node(:c, type: :passthrough)
+      .add_node(:d, type: :passthrough)
+      .add_edge(:a, :b)
+      .add_edge(:a, :c)
+      .add_edge(:b, :d)
+      .add_edge(:c, :d)
+  end
+end

--- a/spec/r3/replace_subtree_preserves_parallel_test.rb
+++ b/spec/r3/replace_subtree_preserves_parallel_test.rb
@@ -40,7 +40,7 @@ class R3ReplaceSubtreePreservesParallelTest < Minitest::Test
     assert_equal :committed, states[:a]
     assert_equal :committed, states[:c]
     assert_equal :pending, states[:b_prime]
-    assert_equal :pending, states[:d]
+    assert_equal :invalidated, states[:d]
     refute_includes states.keys, :b
   end
 

--- a/spec/support/storage_contract/revision_cas.rb
+++ b/spec/support/storage_contract/revision_cas.rb
@@ -48,7 +48,7 @@ module StorageContract
 
       states = storage.load_node_states(workflow_id: workflow_id, revision: 2)
       assert_equal :committed, states[:a]
-      assert_equal :pending, states[:b]
+      assert_equal :invalidated, states[:b]
       assert_equal :pending, states[:c]
       assert_equal 2, storage.load_current_definition(id: workflow_id).revision
       assert_equal :mutation_applied, result[:event].type


### PR DESCRIPTION
Closes #128.

## Summary

After `MutationService#apply`, nodes flagged in `invalidated_node_ids` were stored as `:pending` instead of `:invalidated`. Storage and runner were co-bugged: `eligible_nodes` only matched `:pending`, `finalize` accepted `:invalidated` as terminal-OK (dead branch), and `begin_attempt` hardcoded `expected_node_state: :pending`. Fixing one in isolation would have surfaced the latent bug.

This realigns the implementation with **Roadmap v3.4 §7.4** (`NODE_STATES` canonical line 964-971), **§R3 lines 727/750/756** (`replace_subtree` / `invalidate` semantics), and the mandatory test on **line 2493** (`assert_equal :invalidated, node_state(...)` immediately after `apply`).

## Six edits

1. `storage_state.rb append_revision`: split `:invalidated` (in `invalidated_node_ids`) from `:pending` (new node).
2. `runner.rb eligible_nodes`: accept `:pending` or `:invalidated`, return `[node_id, current_state]` pairs.
3. `runner.rb execute_node`: forward observed state as `expected_node_state` (no more `:pending` hardcode).
4. `runner.rb finalize`: drop the dead `:invalidated` branch.
5. `spec/r3/invalidated_state_distinct_test.rb` (new): roadmap contract — `:invalidated` post-apply, `:committed` post-resume, `attempt_number` restarts at 1 on new revision.
6. `scripts/production_readiness.rb` `replace_subtree_resume_scenario`: assert `:invalidated` on affected join before resume.

## Pre-existing tests realigned

These were mirroring the bug; they now match the contract:

- `spec/r3/invalidate_test.rb` — B/C/D `:invalidated` (not `:pending`).
- `spec/r3/replace_subtree_preserves_parallel_test.rb` — D `:invalidated`.
- `spec/r1/storage_state_extras_test.rb` — invalidated node `:invalidated`.
- `spec/support/storage_contract/revision_cas.rb` — B `:invalidated`.

The diagnostic-finalize test in `spec/r1/runner_outcomes_test.rb` previously parked `:a` in `:invalidated` to exercise the dead branch — now reformulated using a `:running` orphan to mimic an unclean post-crash state under `#call`.

## Test plan

- [x] `bundle exec rake` (test + standardrb) green: 424 runs, 39531 assertions, 0 failures.
- [x] `scripts/production_readiness.rb --fast --duration 30 --seed 42` PASS.
- [x] Custom `Dag/*` cops: no new offenses on touched files.

## Roadmap reference

Roadmap v3.4 §R3, §7.4 lines 964-971, lines 727/750/756, line 2493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)