### PR TITLE
fix(kernel): make terminal state transition + event atomic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,18 +52,37 @@ expressed via the 15 documented primitives:
   retry-count tracking. Returns `{reset: [node_id, ...],
   workflow_retry_count:}`.
 
-This is the only documented extension. It is justified by R1 DoD line 586
-which mandates `Runner#retry_workflow` resets `:failed` nodes and
-"ricrea attempt nuovi"; with only the 15 documented primitives the budget
-restart is not achievable.
+This is justified by R1 DoD line 586 which mandates
+`Runner#retry_workflow` resets `:failed` nodes and "ricrea attempt nuovi";
+with only the 15 documented primitives the budget restart is not achievable.
 
-R2 clarifies the existing `abort_running_attempts(workflow_id:)` port method:
-adapters must mark in-flight attempts as `:aborted` and reset matching
-current-revision nodes still in `:running` back to `:pending`. This is not a
-new method, but it is required so `Runner#resume` can recompute eligibility
-after a process crash.
+A second extension widens an existing canonical method:
 
-All other R1/R2 work uses the documented methods.
+- **`transition_workflow_state(id:, from:, to:, event: nil)`** — the
+  roadmap signature is `(id:, from:, to:)` (Appendix C/I, line 2609). The
+  optional `event:` kwarg is added so a workflow-level state transition
+  can durably append the corresponding terminal event in the same atomic
+  step. When `event:` is `nil` the behavior is identical to the canonical
+  signature; the return value becomes `{id:, state:, event: stamped_or_nil}`.
+
+  This is justified by R2's crash-resume durability invariant. Without the
+  extension, `Runner#transition_and_emit_terminal` had to make two
+  separate storage calls (`transition_workflow_state` then `append_event`),
+  and a crash between them durably leaves the workflow row in a terminal
+  state (`:completed` / `:failed` / `:waiting` / `:paused`) with no
+  matching terminal event — a state from which `Runner#resume` cannot
+  recover (`acquire_running` rejects terminal states). The same pattern
+  already exists on `commit_attempt(event:)` and `append_revision(event:)`;
+  this brings workflow-level transitions in line with attempt-level and
+  revision-level ones.
+
+R2 also clarifies the existing `abort_running_attempts(workflow_id:)` port
+method: adapters must mark in-flight attempts as `:aborted` and reset
+matching current-revision nodes still in `:running` back to `:pending`.
+This is not a new method, but it is required so `Runner#resume` can
+recompute eligibility after a process crash.
+
+All other R1/R2/R3 work uses the documented methods.
 
 ## Commands
 

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -116,6 +116,29 @@ together. If a process crashes before that boundary, the step may be invoked
 again on resume. If it crashes after the boundary, resume starts from the next
 eligible node.
 
+`transition_workflow_state` is the equivalent atomic durability boundary for
+**workflow-level** state changes. It accepts an optional `event:` keyword:
+
+```ruby
+storage.transition_workflow_state(id:, from:, to:, event: nil)
+# returns {id:, state:, event: stamped_or_nil}
+```
+
+When `event:` is supplied, the row transition and the event append happen in
+the same atomic step. The Runner uses this for every terminal and
+quasi-terminal transition (`:running -> :completed`, `:running -> :failed`,
+`:running -> :paused`, `:running -> :waiting`) so that a crash can never
+leave the workflow row in a terminal state without its corresponding
+terminal event in the log. The `event:`-less form is reserved for internal
+transitions that have no associated event (e.g. `:pending -> :running` in
+`acquire_running`, where `:workflow_started` is emitted later by an
+idempotent path that scans the event log).
+
+This is a port extension over the canonical roadmap signature
+`(id:, from:, to:)`. See `CLAUDE.md` "Port extensions" for the full
+justification. SQLite (S0) implements the same atomicity via a single
+transaction.
+
 The Runner owns attempt numbering. It computes:
 
 ```ruby

--- a/lib/dag/adapters/memory/crashable_storage.rb
+++ b/lib/dag/adapters/memory/crashable_storage.rb
@@ -45,7 +45,7 @@ module DAG
           stamped
         end
 
-        def transition_workflow_state(id:, from:, to:)
+        def transition_workflow_state(id:, from:, to:, event: nil)
           context = {workflow_id: id, from: from, to: to}
           crash_if!(:before, :transition_workflow_state, context)
           row = super

--- a/lib/dag/adapters/memory/storage.rb
+++ b/lib/dag/adapters/memory/storage.rb
@@ -21,8 +21,8 @@ module DAG
           frozen StorageState.load_workflow(@state, id: id)
         end
 
-        def transition_workflow_state(id:, from:, to:)
-          frozen StorageState.transition_workflow_state(@state, id: id, from: from, to: to)
+        def transition_workflow_state(id:, from:, to:, event: nil)
+          frozen StorageState.transition_workflow_state(@state, id: id, from: from, to: to, event: event)
         end
 
         def append_revision(id:, parent_revision:, definition:, invalidated_node_ids:, event:)

--- a/lib/dag/adapters/memory/storage_state.rb
+++ b/lib/dag/adapters/memory/storage_state.rb
@@ -65,13 +65,14 @@ module DAG
           fetch_workflow!(state, id).dup
         end
 
-        def transition_workflow_state(state, id:, from:, to:)
+        def transition_workflow_state(state, id:, from:, to:, event: nil)
           row = fetch_workflow!(state, id)
           unless row[:state] == from
             raise StaleStateError, "workflow #{id} state is #{row[:state].inspect}, expected #{from.inspect}"
           end
           row[:state] = to
-          {id: id, state: to}
+          stamped = event ? append_event_internal(state, id, event) : nil
+          {id: id, state: to, event: stamped}
         end
 
         def append_revision(state, id:, parent_revision:, definition:, invalidated_node_ids:, event:)

--- a/lib/dag/ports/storage.rb
+++ b/lib/dag/ports/storage.rb
@@ -13,7 +13,12 @@ module DAG
         raise PortNotImplementedError
       end
 
-      def transition_workflow_state(id:, from:, to:)
+      # Atomically transitions the workflow row from `from` to `to`, and if a
+      # non-nil event is supplied, appends it durably in the same step. The
+      # atomicity is required so that durable terminal state and its
+      # corresponding terminal event cannot diverge under crash. Returns
+      # {id:, state:, event: stamped_event_or_nil}.
+      def transition_workflow_state(id:, from:, to:, event: nil)
         raise PortNotImplementedError
       end
 

--- a/lib/dag/runner.rb
+++ b/lib/dag/runner.rb
@@ -176,8 +176,13 @@ module DAG
         commit_and_emit(run, node_id, attempt_id, attempt_number, result, :committed, :node_committed, {})
         return :continue if result.proposed_mutations.empty?
 
-        @storage.transition_workflow_state(id: run.workflow_id, from: :running, to: :paused)
-        append_event(run, type: :workflow_paused, payload: {by_node: node_id, mutation_count: result.proposed_mutations.size})
+        atomic_transition_with_event(
+          run,
+          from: :running,
+          to: :paused,
+          event_type: :workflow_paused,
+          payload: {by_node: node_id, mutation_count: result.proposed_mutations.size}
+        )
         :paused
 
       when DAG::Waiting
@@ -194,8 +199,13 @@ module DAG
 
         commit_and_emit(run, node_id, attempt_id, attempt_number, result, :failed, :node_failed,
           {retriable: false, error: result.error})
-        @storage.transition_workflow_state(id: run.workflow_id, from: :running, to: :failed)
-        append_event(run, type: :workflow_failed, payload: {failed_node: node_id, error: result.error})
+        atomic_transition_with_event(
+          run,
+          from: :running,
+          to: :failed,
+          event_type: :workflow_failed,
+          payload: {failed_node: node_id, error: result.error}
+        )
         :failed_terminal
       end
     end
@@ -272,9 +282,18 @@ module DAG
     end
 
     def transition_and_emit_terminal(run, state, event_type, payload)
-      @storage.transition_workflow_state(id: run.workflow_id, from: :running, to: state)
-      append_event(run, type: event_type, payload: payload)
+      atomic_transition_with_event(run, from: :running, to: state, event_type: event_type, payload: payload)
       build_run_result(run, state)
+    end
+
+    # Atomic at the storage layer: the row transition and the event append
+    # cannot diverge under crash. The event_bus publish happens after the
+    # storage call returns and is best-effort (non-durable).
+    def atomic_transition_with_event(run, from:, to:, event_type:, payload:)
+      event = build_event(run, type: event_type, payload: payload)
+      result = @storage.transition_workflow_state(id: run.workflow_id, from: from, to: to, event: event)
+      stamped = result.is_a?(Hash) ? result[:event] : nil
+      @event_bus.publish(stamped) if stamped
     end
 
     def build_run_result(run, state)

--- a/scripts/production_readiness.rb
+++ b/scripts/production_readiness.rb
@@ -835,17 +835,20 @@ module ProductionReadiness
       [:chain3, :commit_attempt, :before, {node_id: :c}],
       [:chain3, :commit_attempt, :after, {node_id: :c}],
       # CrashableStorage#append_event only intercepts the public Storage#append_event
-      # path; per-attempt :node_* events go via append_event_internal during
-      # commit_attempt (already covered by the commit_attempt rows above).
-      # Workflow-lifecycle events (:workflow_started, :workflow_completed,
-      # :workflow_failed, :workflow_paused, :workflow_waiting) are the ones
-      # that actually flow through the public method and are crash-relevant.
+      # path. Per-attempt :node_* events go via append_event_internal during
+      # commit_attempt (covered by commit_attempt rows). Terminal lifecycle
+      # events (:workflow_completed, :workflow_failed, :workflow_paused,
+      # :workflow_waiting) are now atomic with their state transition (issue
+      # #138 fix): they ride inside transition_workflow_state(event:), not
+      # through public append_event. So append_event crash cells target only
+      # :workflow_started, which still uses the standalone path; the rest are
+      # covered by the transition_workflow_state rows below.
       [:chain3, :append_event, :before, {event_type: :workflow_started}],
       [:chain3, :append_event, :after, {event_type: :workflow_started}],
-      [:chain3, :append_event, :before, {event_type: :workflow_completed}],
-      [:chain3, :append_event, :after, {event_type: :workflow_completed}],
       [:chain3, :transition_workflow_state, :before, {from: :pending, to: :running}],
       [:chain3, :transition_workflow_state, :after, {from: :pending, to: :running}],
+      [:chain3, :transition_workflow_state, :before, {from: :running, to: :completed}],
+      [:chain3, :transition_workflow_state, :after, {from: :running, to: :completed}],
       # single-node — only_node coverage
       [:single, :begin_attempt, :before, {node_id: :a}],
       [:single, :begin_attempt, :after, {node_id: :a}],
@@ -884,8 +887,34 @@ module ProductionReadiness
       end
       assert_committed(healthy, workflow_id, definition)
       assert_no_duplicate_workflow_started(healthy, workflow_id, label)
+      assert_terminal_event_consistency(healthy, workflow_id, label)
 
       @metrics[:crash_matrix_cells] += 1
+    end
+
+    TERMINAL_STATE_TO_EVENT = {
+      completed: :workflow_completed,
+      failed: :workflow_failed,
+      waiting: :workflow_waiting,
+      paused: :workflow_paused
+    }.freeze
+
+    # If the workflow row is durable in a terminal state, the event log MUST
+    # contain the corresponding terminal event. Without this check the harness
+    # accepts a partial commit where the row transition succeeded but the
+    # terminal event was lost — a real crash hazard before the storage made
+    # the two atomic.
+    def assert_terminal_event_consistency(storage, workflow_id, label)
+      state = storage.load_workflow(id: workflow_id)[:state]
+      expected_event = TERMINAL_STATE_TO_EVENT[state]
+      return unless expected_event
+
+      events = storage.read_events(workflow_id: workflow_id)
+      count = events.count { |e| e.type == expected_event }
+      return if count == 1
+
+      raise Failure,
+        "crash[#{label}] workflow row is :#{state} but event log has #{count} :#{expected_event} events (expected exactly 1)"
     end
 
     def drive_to_terminal(storage, workflow_id, label, max_steps: 4)


### PR DESCRIPTION
Closes #138.

## The bug

Codex stop-time review on PR #137 (Group D) flagged: *"crash matrix accepts terminal workflows with missing terminal events"*. The harness was right — there was a real kernel bug it failed to catch.

`Runner#transition_and_emit_terminal` (lib/dag/runner.rb) called \`transition_workflow_state\` followed by \`append_event\` in two separate storage calls. A crash between them durably leaves the workflow row in \`:completed\` (or \`:failed\` / \`:waiting\` / \`:paused\`) with **no** corresponding terminal event in the log.

Why this matters:
- Any consumer reading the event log to know "did this workflow finish?" sees no terminal event and infers it's still in flight, even though the workflow row says \`:completed\`.
- \`runner.resume\` cannot repair: \`acquire_running\` rejects \`:completed\` with \`StaleStateError\`. Once the partial state is durable, no path back to consistency.
- Same shape applies to \`handle_outcome\` for \`:paused\` (mutation) and \`:failed\` (terminal failure).

## Fix

Extend \`Storage#transition_workflow_state\` with an optional \`event:\` parameter, analogous to \`commit_attempt\` and \`append_revision\`. \`Memory::Storage\` performs both updates inside the single mutator call (atomic by construction); SQLite (S0) will use a single transaction.

\`\`\`ruby
@storage.transition_workflow_state(id:, from:, to:, event: nil)
# returns {id:, state:, event: stamped_or_nil}
\`\`\`

Runner now builds the event upfront and passes it as the kwarg; \`@event_bus.publish\` happens after the storage call returns. Three call sites consolidated into one helper \`atomic_transition_with_event\`.

\`acquire_running\`'s \`pending → running\` transition has no terminal event tied to it (\`workflow_started\` rides on a separate idempotent path), so it does not require the new arg. Other call sites (retry_workflow, mutation_service) keep the old shape.

\`CrashableStorage\` updated to propagate the new kwarg.

## Harness assertion (closes the detection gap)

\`crash_matrix_scenario\` now runs \`assert_terminal_event_consistency\` after \`drive_to_terminal\`. If the workflow row is in a terminal state, the corresponding terminal event MUST exist exactly once in the log — this is the check that was missing from PR #137 and that allowed the bug to slip past the matrix.

Synthetic-divergence probe confirms detection: a manually-built storage state with workflow row \`:completed\` and zero \`:workflow_completed\` events makes the assertion FAIL with a precise message.

## Crash matrix updated

Two obsolete cells removed (\`append_event :before/:after {event_type: :workflow_completed}\` — the event no longer flows through public \`append_event\`) and replaced with two new cells (\`transition_workflow_state :before/:after {from: :running, to: :completed}\`) that exercise the new atomic primitive end-to-end. Matrix size unchanged at 24 cells.

## Test plan

- [x] \`bundle exec rake\` green: 424 runs, 39531 assertions, 0 failures.
- [x] \`--fast --duration 30 --seed 1\` PASS, all 24 crash matrix cells pass including the new transition-terminal cells.
- [x] Synthetic divergence (manually constructed) caught by \`assert_terminal_event_consistency\`.
- [x] R0/R1/R2/R3 storage contract suite still green.

## Roadmap traceability

- Storage port extension documented in \`lib/dag/ports/storage.rb\`.
- Atomic transition+event semantics align with the existing pattern of \`commit_attempt(event:)\` and \`append_revision(event:)\` — the new arg makes terminal/quasi-terminal workflow transitions follow the same contract as attempt-level transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)