### PR TITLE
ci: add nightly production-readiness workflow

### DIFF
--- a/.github/workflows/production-readiness.yml
+++ b/.github/workflows/production-readiness.yml
@@ -1,0 +1,59 @@
+name: Production Readiness
+
+on:
+  schedule:
+    # Nightly at 03:00 UTC. Catches regressions invisible to the per-PR
+    # rake gate (e.g. timing-sensitive crash recovery, GC growth,
+    # determinism drift) without slowing every PR by ~2 minutes.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: 'Run duration in seconds (default 120 = --fast profile).'
+        required: false
+        default: '120'
+      seed:
+        description: 'Deterministic seed (Integer). Pass `random` to opt into a fresh seed.'
+        required: false
+        default: '1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-readiness-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prodready:
+    name: production_readiness.rb
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Run production_readiness.rb
+        run: |
+          ruby scripts/production_readiness.rb \
+            --fast \
+            --seed "${SEED}" \
+            --duration "${DURATION}" \
+            --report-file prodready.json
+        env:
+          SEED: ${{ github.event.inputs.seed || '1' }}
+          DURATION: ${{ github.event.inputs.duration || '120' }}
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prodready-report
+          path: prodready.json
+          if-no-files-found: warn
+          retention-days: 30


### PR DESCRIPTION
Closes #140.

## What

New \`.github/workflows/production-readiness.yml\` that runs \`scripts/production_readiness.rb\` on a nightly schedule + on demand.

| | |
|---|---|
| Triggers | \`schedule: 0 3 * * *\` UTC + \`workflow_dispatch\` |
| Runner | ubuntu-latest, Ruby 3.4, 30 min timeout |
| Concurrency | grouped per ref; \`cancel-in-progress: false\` so a late dispatch can't mask a nightly fail |
| Inputs | \`duration\` (default 120s), \`seed\` (default 1; \`random\` for fresh) |
| Permissions | \`contents: read\` only |
| Artifact | \`prodready.json\` uploaded on every run (incl. failures), 30 day retention |

## Why separate

\`.github/workflows/ci.yml\` and \`ruby.yml\` already run \`bundle exec rake\` on every push/PR. Folding the production-readiness sweep into them would slow every PR by ~2 minutes for no marginal coverage — the rake gate is unit/contract, the harness is for invariants under stress (crash recovery, GC growth, determinism drift, perf regressions).

## Manual dispatch usage

Once merged, run via:

\`\`\`bash
gh workflow run production-readiness.yml -f duration=300 -f seed=42
\`\`\`

Or from the Actions tab UI.

## Test plan

- [x] YAML parses correctly (\`ruby -ryaml\` round-trip).
- [ ] Manual dispatch on main after merge succeeds end-to-end.
- [ ] Artifact \`prodready-report\` downloadable from the run page.
- [ ] Nightly schedule fires (verify the morning after merge).

## Out of scope

- Slack/email notifications on fail (Actions email-on-fail default is enough).
- Auto-issue creation on fail.
- Weekly full-profile (3600s) sweep — can be added later as a separate trigger if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)