### PR TITLE
fix(production_readiness): --report json stdout contract

### DIFF
--- a/.github/workflows/production-readiness.yml
+++ b/.github/workflows/production-readiness.yml
@@ -1,0 +1,59 @@
+name: Production Readiness
+
+on:
+  schedule:
+    # Nightly at 03:00 UTC. Catches regressions invisible to the per-PR
+    # rake gate (e.g. timing-sensitive crash recovery, GC growth,
+    # determinism drift) without slowing every PR by ~2 minutes.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: 'Run duration in seconds (default 120 = --fast profile).'
+        required: false
+        default: '120'
+      seed:
+        description: 'Deterministic seed (Integer). Pass `random` to opt into a fresh seed.'
+        required: false
+        default: '1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-readiness-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prodready:
+    name: production_readiness.rb
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Run production_readiness.rb
+        run: |
+          ruby scripts/production_readiness.rb \
+            --fast \
+            --seed "${SEED}" \
+            --duration "${DURATION}" \
+            --report-file prodready.json
+        env:
+          SEED: ${{ github.event.inputs.seed || '1' }}
+          DURATION: ${{ github.event.inputs.duration || '120' }}
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prodready-report
+          path: prodready.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/production_readiness.rb
+++ b/scripts/production_readiness.rb
@@ -1348,13 +1348,28 @@ module ProductionReadiness
         error: error
       )) + "\n"
 
-      path = @options[:report_file]
-      File.write(path, encoded) if path
-      $stdout.write(encoded) if @options[:report] == :json
+      emit_report_to_stdout(encoded, strict: strict) if @options[:report] == :json
+      emit_report_to_file(@options[:report_file], encoded, strict: strict) if @options[:report_file]
     rescue => e
       raise if strict
 
-      warn("[#{Time.now.utc.iso8601}] WARN failed to write report: #{e.class}: #{e.message}")
+      warn("[#{Time.now.utc.iso8601}] WARN failed to encode report: #{e.class}: #{e.message}")
+    end
+
+    def emit_report_to_stdout(encoded, strict:)
+      $stdout.write(encoded)
+    rescue => e
+      raise if strict
+
+      warn("[#{Time.now.utc.iso8601}] WARN failed to write JSON report to stdout: #{e.class}: #{e.message}")
+    end
+
+    def emit_report_to_file(path, encoded, strict:)
+      File.write(path, encoded)
+    rescue => e
+      raise if strict
+
+      warn("[#{Time.now.utc.iso8601}] WARN failed to write JSON report to #{path}: #{e.class}: #{e.message}")
     end
 
     def report_payload(status:, started_at:, finished_at:, error:)

--- a/scripts/production_readiness.rb
+++ b/scripts/production_readiness.rb
@@ -240,7 +240,7 @@ module ProductionReadiness
 
       finished_at = Time.now.utc
       assert_minimum_metrics
-      write_report(status: "pass", started_at: @started_at, finished_at: finished_at, strict: true)
+      write_report(status: "pass", started_at: @started_at, finished_at: finished_at)
       log("PASS #{summary}")
       true
     rescue => e
@@ -249,8 +249,7 @@ module ProductionReadiness
         status: "fail",
         started_at: @started_at || finished_at,
         finished_at: finished_at,
-        error: {class: e.class.name, message: e.message},
-        strict: false
+        error: {class: e.class.name, message: e.message}
       )
       raise
     end
@@ -1338,7 +1337,7 @@ module ProductionReadiness
       [(per_second * duration).floor, 1].max
     end
 
-    def write_report(status:, started_at:, finished_at:, strict:, error: nil)
+    def write_report(status:, started_at:, finished_at:, error: nil)
       return unless @options[:report] == :json || @options[:report_file]
 
       encoded = JSON.pretty_generate(report_payload(
@@ -1348,27 +1347,21 @@ module ProductionReadiness
         error: error
       )) + "\n"
 
-      emit_report_to_stdout(encoded, strict: strict) if @options[:report] == :json
-      emit_report_to_file(@options[:report_file], encoded, strict: strict) if @options[:report_file]
+      emit_report_to_stdout(encoded) if @options[:report] == :json
+      emit_report_to_file(@options[:report_file], encoded) if @options[:report_file]
     rescue => e
-      raise if strict
-
       warn("[#{Time.now.utc.iso8601}] WARN failed to encode report: #{e.class}: #{e.message}")
     end
 
-    def emit_report_to_stdout(encoded, strict:)
+    def emit_report_to_stdout(encoded)
       $stdout.write(encoded)
     rescue => e
-      raise if strict
-
       warn("[#{Time.now.utc.iso8601}] WARN failed to write JSON report to stdout: #{e.class}: #{e.message}")
     end
 
-    def emit_report_to_file(path, encoded, strict:)
+    def emit_report_to_file(path, encoded)
       File.write(path, encoded)
     rescue => e
-      raise if strict
-
       warn("[#{Time.now.utc.iso8601}] WARN failed to write JSON report to #{path}: #{e.class}: #{e.message}")
     end
 

--- a/scripts/production_readiness.rb
+++ b/scripts/production_readiness.rb
@@ -186,12 +186,13 @@ module ProductionReadiness
         duration: nil,
         seed: DEFAULT_SEED,
         progress_interval: 10,
+        report: nil,
         report_file: nil,
         thresholds_path: DEFAULT_THRESHOLDS_PATH
       }
 
       parser = OptionParser.new do |opts|
-        opts.banner = "Usage: scripts/production_readiness.rb [--fast] [--duration SECONDS] [--seed INTEGER|random] [--report-file PATH] [--thresholds PATH]"
+        opts.banner = "Usage: scripts/production_readiness.rb [--fast] [--duration SECONDS] [--seed INTEGER|random] [--report json] [--report-file PATH] [--thresholds PATH]"
         opts.on("--fast", "Run the short profile. Defaults to #{DEFAULT_FAST_SECONDS}s.") do
           options[:fast] = true
         end
@@ -203,6 +204,12 @@ module ProductionReadiness
         end
         opts.on("--progress-interval SECONDS", Integer, "Progress print interval.") do |seconds|
           options[:progress_interval] = seconds
+        end
+        opts.on("--report FORMAT", "Write a machine-readable report to stdout. Supported: json.") do |format|
+          normalized = format.downcase
+          raise OptionParser::InvalidArgument, "--report supports only json" unless normalized == "json"
+
+          options[:report] = :json
         end
         opts.on("--report-file PATH", "Write a machine-readable JSON report to PATH on exit.") do |path|
           options[:report_file] = path
@@ -233,12 +240,18 @@ module ProductionReadiness
 
       finished_at = Time.now.utc
       assert_minimum_metrics
-      write_report(status: "pass", started_at: @started_at, finished_at: finished_at)
+      write_report(status: "pass", started_at: @started_at, finished_at: finished_at, strict: true)
       log("PASS #{summary}")
       true
     rescue => e
       finished_at = Time.now.utc
-      write_report(status: "fail", started_at: @started_at || finished_at, finished_at: finished_at, error: {class: e.class.name, message: e.message})
+      write_report(
+        status: "fail",
+        started_at: @started_at || finished_at,
+        finished_at: finished_at,
+        error: {class: e.class.name, message: e.message},
+        strict: false
+      )
       raise
     end
 
@@ -274,6 +287,20 @@ module ProductionReadiness
     end
 
     def fixed_scenarios
+      core_fixed_scenarios.each do |scenario|
+        break if expired?
+        scenario.call
+      end
+
+      return if short_duration?
+
+      expensive_fixed_scenarios.each do |scenario|
+        break if expired?
+        scenario.call
+      end
+    end
+
+    def core_fixed_scenarios
       [
         -> { random_completed_workflow_scenario(nodes: 1, edge_probability: 0.0) },
         -> { random_completed_workflow_scenario(nodes: 2, edge_probability: 1.0) },
@@ -290,17 +317,19 @@ module ProductionReadiness
         -> { storage_contract_edge_scenario },
         -> { retry_workflow_scenario },
         -> { subscriber_failure_scenario },
-        -> { bus_overflow_scenario },
+        -> { bus_overflow_scenario }
+      ]
+    end
+
+    def expensive_fixed_scenarios
+      [
         -> { large_graph_scenario(shape: :chain_1000) },
         -> { large_graph_scenario(shape: :fanout_500) },
         -> { large_graph_scenario(shape: :diamond_50x50) },
         -> { long_lived_storage_scenario },
         -> { crash_matrix_scenario },
         -> { determinism_scenario }
-      ].each do |scenario|
-        break if expired?
-        scenario.call
-      end
+      ]
     end
 
     def random_completed_workflow_scenario(nodes: nil, edge_probability: nil)
@@ -1214,6 +1243,10 @@ module ProductionReadiness
       @options[:fast] ? FAST_NODE_RANGE : FULL_NODE_RANGE
     end
 
+    def short_duration?
+      @options.fetch(:duration) < DEFAULT_FAST_SECONDS
+    end
+
     def expired?
       monotonic_seconds >= @deadline
     end
@@ -1237,7 +1270,8 @@ module ProductionReadiness
     end
 
     def log(message)
-      puts("[#{Time.now.utc.iso8601}] #{message}")
+      io = (@options[:report] == :json) ? $stderr : $stdout
+      io.puts("[#{Time.now.utc.iso8601}] #{message}")
     end
 
     def assert(condition, message)
@@ -1287,7 +1321,7 @@ module ProductionReadiness
     def assert_minimum_metrics
       duration = @options.fetch(:duration)
       shortfalls = METRIC_FLOORS.filter_map do |metric, per_second|
-        floor = [(per_second * duration).floor, 1].max
+        floor = metric_floor(per_second, duration)
         actual = @metrics[metric]
         next if actual >= floor
 
@@ -1298,14 +1332,36 @@ module ProductionReadiness
       raise Failure, "metric coverage below floor: #{shortfalls.join(", ")}"
     end
 
-    def write_report(status:, started_at:, finished_at:, error: nil)
-      path = @options[:report_file]
-      return unless path
+    def metric_floor(per_second, duration)
+      return short_duration? ? 0 : 1 if per_second.zero?
 
+      [(per_second * duration).floor, 1].max
+    end
+
+    def write_report(status:, started_at:, finished_at:, strict:, error: nil)
+      return unless @options[:report] == :json || @options[:report_file]
+
+      encoded = JSON.pretty_generate(report_payload(
+        status: status,
+        started_at: started_at,
+        finished_at: finished_at,
+        error: error
+      )) + "\n"
+
+      path = @options[:report_file]
+      File.write(path, encoded) if path
+      $stdout.write(encoded) if @options[:report] == :json
+    rescue => e
+      raise if strict
+
+      warn("[#{Time.now.utc.iso8601}] WARN failed to write report: #{e.class}: #{e.message}")
+    end
+
+    def report_payload(status:, started_at:, finished_at:, error:)
       report = {
         status: status,
         seed: @options[:seed],
-        duration_s: @options.fetch(:duration),
+        duration: @options.fetch(:duration),
         fast: @options[:fast],
         started_at: started_at.iso8601,
         finished_at: finished_at.iso8601,
@@ -1314,9 +1370,7 @@ module ProductionReadiness
       }
       report[:error] = error if error
 
-      File.write(path, JSON.pretty_generate(report) + "\n")
-    rescue => e
-      warn("[#{Time.now.utc.iso8601}] WARN failed to write --report-file #{path}: #{e.class}: #{e.message}")
+      report
     end
   end
 end


### PR DESCRIPTION
## Summary

- Adds `--report json` to stream the report payload to stdout (logs are redirected to stderr in this mode so the JSON stays clean), complementing `--report-file PATH`.
- Splits `fixed_scenarios` into a core tier and an expensive tier (large graphs, long-lived storage, crash matrix, determinism) so `--duration` shorter than the fast default (120s) skips the expensive cells. Lets the metric floor accept zero on those duration-independent metrics for short runs.
- Reworks `write_report` so report I/O is best-effort and decoupled per target: a failing `--report-file` no longer blocks `--report json` stdout, no longer raises on the success path, and no longer trips `run`'s rescue into emitting a second JSON document on stdout. Run status now reflects the run, not the report I/O.
- Renames the report key `duration_s` → `duration` for consistency with the CLI option.

The earlier commit on this branch (`ci: add nightly production-readiness workflow`) was squash-merged on main as #141 with identical content; the merge will be a no-op for that file.

Closes follow-up work to #130.

## Test plan

- [x] `bundle exec rake test` (424 runs, 0 failures)
- [x] `bundle exec standardrb scripts/production_readiness.rb`
- [x] Manual: `--report json --report-file /no/such/dir/r.json` on success → exactly 1 `pass` JSON on stdout, WARN on stderr, rc=0
- [x] Manual: same flags on synthetic failure → exactly 1 `fail` JSON on stdout, WARN on stderr, original error preserved
- [x] Manual: `--report json` only on success → 1 `pass` JSON on stdout, no extra writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)