### PR TITLE
Effects PR0: atomic retry and deterministic context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,17 +44,21 @@ The roadmap port (Appendix C) lists 15 methods. Implementing R1's
 `Runner#retry_workflow` per its DoD requires one operation that cannot be
 expressed via the 15 documented primitives:
 
-- **`prepare_workflow_retry(id:)`** — atomically (a) finds nodes in state
-  `:failed` for the workflow's current revision, (b) marks each
+- **`prepare_workflow_retry(id:, from: :failed, to: :pending, event: nil)`**
+  — atomically (a) verifies the workflow is still in `from`, (b) verifies
+  `workflow_retry_count < max_workflow_retries`, (c) finds nodes in state
+  `:failed` for the workflow's current revision, (d) marks each
   corresponding `:failed` attempt as `:aborted` so `count_attempts`
-  excludes them and the per-node attempt budget restarts, (c) transitions
-  those nodes back to `:pending`, and (d) increments the workflow's
-  retry-count tracking. Returns `{reset: [node_id, ...],
-  workflow_retry_count:}`.
+  excludes them and the per-node attempt budget restarts, (e) transitions
+  those nodes back to `:pending`, (f) increments the workflow's retry-count
+  tracking, (g) transitions the workflow row to `to`, and (h) optionally
+  appends `event` in the same storage step. Returns
+  `{id:, state:, reset: [node_id, ...], workflow_retry_count:, event:}`.
 
 This is justified by R1 DoD line 586 which mandates
 `Runner#retry_workflow` resets `:failed` nodes and "ricrea attempt nuovi";
-with only the 15 documented primitives the budget restart is not achievable.
+with only the 15 documented primitives the budget restart and stale-read-safe
+workflow retry budget check are not achievable.
 
 A second extension widens an existing canonical method:
 
@@ -122,9 +126,10 @@ Two layers, in order of dependency:
   - Built-ins: `DAG::BuiltinSteps::{Noop, Passthrough}`. `:branch` is
     deferred to a later phase.
   - `DAG::Runner` — frozen kernel. `#call(workflow_id)` runs the layered
-    algorithm; `#retry_workflow(workflow_id)` enforces
-    `max_workflow_retries` and raises `WorkflowRetryExhaustedError` when
-    the budget is spent.
+    algorithm; `#retry_workflow(workflow_id)` delegates the failed-to-pending
+    retry boundary to storage, then calls the workflow again. The storage
+    port enforces `max_workflow_retries` and raises
+    `WorkflowRetryExhaustedError` when the budget is spent.
 
 ## Key files
 
@@ -230,9 +235,10 @@ public surface) without paying ceremony for private scaffolding.
 - `StandardError` raised in `#call` is converted to
   `Failure[error: {code: :step_raised, class:, message:}, retriable: false]`.
   `NoMemoryError`, `SystemExit`, and `Interrupt` propagate.
-- `count_attempts` excludes `:aborted` attempts. `Runner#retry_workflow`
-  marks failed attempts as `:aborted` so the per-node attempt budget
-  resets across workflow retries.
+- `count_attempts` excludes `:aborted` attempts.
+  `Storage#prepare_workflow_retry` marks failed attempts as `:aborted` so
+  the per-node attempt budget resets across workflow retries, and owns the
+  atomic workflow retry-count guard.
 - `Memory::Storage` is single-process only. The mutable bookkeeping lives
   in `DAG::Adapters::Memory::StorageState`, which is the ONLY spot under
   `lib/dag/**` allowed to mutate hashes in place. The

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -139,6 +139,26 @@ This is a port extension over the canonical roadmap signature
 justification. SQLite (S0) implements the same atomicity via a single
 transaction.
 
+`prepare_workflow_retry` is the atomic durability boundary for explicit
+workflow retry:
+
+```ruby
+storage.prepare_workflow_retry(id:, from: :failed, to: :pending, event: nil)
+# returns {id:, state:, reset:, workflow_retry_count:, event: stamped_or_nil}
+```
+
+The operation checks the workflow is still in `from` and that
+`workflow_retry_count < max_workflow_retries`, aborts failed attempts
+for failed nodes in the current revision, resets those nodes to `:pending`,
+increments `workflow_retry_count`, transitions the workflow to `to`, and
+optionally appends `event:` in the same storage step. `Runner#retry_workflow`
+must not follow this with a separate `transition_workflow_state`, and must
+not pre-check the budget outside the atomic boundary: a stale read of
+`workflow_retry_count` between two concurrent retries (with the workflow
+re-failing in between) would let both pass the Ruby-level check and bypass
+the budget. The atomic guard inside `prepare_workflow_retry` is the source
+of truth for both the state CAS and the retry budget.
+
 The Runner owns attempt numbering. It computes:
 
 ```ruby

--- a/lib/dag/adapters/memory/crashable_storage.rb
+++ b/lib/dag/adapters/memory/crashable_storage.rb
@@ -62,6 +62,15 @@ module DAG
           row
         end
 
+        # (see Ports::Storage#prepare_workflow_retry)
+        def prepare_workflow_retry(id:, from: :failed, to: :pending, event: nil)
+          context = {workflow_id: id, from: from, to: to}
+          crash_if!(:before, :prepare_workflow_retry, context)
+          row = super
+          crash_if!(:after, :prepare_workflow_retry, context)
+          row
+        end
+
         # Export the underlying state into a fresh `Memory::Storage`
         # without crash injection. Mirrors a process restart after the
         # simulated crash has been observed.

--- a/lib/dag/adapters/memory/storage.rb
+++ b/lib/dag/adapters/memory/storage.rb
@@ -102,8 +102,8 @@ module DAG
         end
 
         # (see Ports::Storage#prepare_workflow_retry)
-        def prepare_workflow_retry(id:)
-          frozen StorageState.prepare_workflow_retry(@state, id: id)
+        def prepare_workflow_retry(id:, from: :failed, to: :pending, event: nil)
+          frozen StorageState.prepare_workflow_retry(@state, id: id, from: from, to: to, event: event)
         end
 
         private

--- a/lib/dag/adapters/memory/storage_state.rb
+++ b/lib/dag/adapters/memory/storage_state.rb
@@ -271,11 +271,23 @@ module DAG
         end
 
         # Implements `Ports::Storage#prepare_workflow_retry` (port extension).
-        # Atomic: abort prior `:failed` attempts, reset their nodes to
-        # `:pending`, increment `workflow_retry_count`.
+        # Atomic retry boundary: guard workflow state and retry budget, abort
+        # prior `:failed` attempts, reset their nodes to `:pending`, increment
+        # `workflow_retry_count`, transition the workflow, and optionally
+        # append a durable event.
         # @api private
-        def prepare_workflow_retry(state, id:)
+        def prepare_workflow_retry(state, id:, from: :failed, to: :pending, event: nil)
           row = fetch_workflow!(state, id)
+          unless row[:state] == from
+            raise StaleStateError, "workflow #{id} state is #{row[:state].inspect}, expected #{from.inspect}"
+          end
+
+          max_retries = row[:runtime_profile].max_workflow_retries
+          if row[:workflow_retry_count] >= max_retries
+            raise WorkflowRetryExhaustedError,
+              "workflow retries exhausted (#{row[:workflow_retry_count]}/#{max_retries})"
+          end
+
           revision = row[:current_revision]
           states_for_rev = fetch_node_states!(state, id, revision)
           failed_node_ids = states_for_rev.select { |_, s| s == :failed }.keys
@@ -288,8 +300,10 @@ module DAG
           end
           failed_node_ids.each { |node_id| states_for_rev[node_id] = :pending }
           row[:workflow_retry_count] += 1
+          row[:state] = to
+          stamped = event ? append_event_internal(state, id, event) : nil
 
-          {reset: failed_node_ids, workflow_retry_count: row[:workflow_retry_count]}
+          {id: id, state: to, reset: failed_node_ids, workflow_retry_count: row[:workflow_retry_count], event: stamped}
         end
 
         # Internal helper used by `count_attempts` and friends.

--- a/lib/dag/ports/storage.rb
+++ b/lib/dag/ports/storage.rb
@@ -179,15 +179,27 @@ module DAG
         raise PortNotImplementedError
       end
 
-      # Port extension (see CLAUDE.md "Port extensions"). Atomically:
+      # Port extension (see CLAUDE.md "Port extensions"). With a CAS guard on
+      # workflow state and on the retry budget, atomically:
       # (a) find :failed nodes for the workflow's current revision,
       # (b) mark each corresponding :failed attempt as :aborted,
       # (c) transition those nodes back to :pending,
-      # (d) increment the workflow's retry-count tracking.
+      # (d) increment the workflow's retry-count tracking,
+      # (e) transition the workflow row from `from` to `to`,
+      # (f) append the supplied durable event, when present.
+      #
+      # The retry-budget check (`workflow_retry_count < max_workflow_retries`)
+      # lives inside the atomic boundary so concurrent retries cannot bypass
+      # it via stale reads from outside the transaction.
       #
       # @param id [String]
-      # @return [Hash] {reset: [node_id, ...], workflow_retry_count: Integer}
-      def prepare_workflow_retry(id:)
+      # @param from [Symbol] expected current workflow state
+      # @param to [Symbol] target workflow state
+      # @param event [DAG::Event, nil] optional event to append in the same atomic step
+      # @raise [DAG::StaleStateError] when current state is not `from`
+      # @raise [DAG::WorkflowRetryExhaustedError] when the retry budget is spent
+      # @return [Hash] {id:, state:, reset:, workflow_retry_count:, event: stamped_event_or_nil}
+      def prepare_workflow_retry(id:, from: :failed, to: :pending, event: nil)
         raise PortNotImplementedError
       end
     end

--- a/lib/dag/runner.rb
+++ b/lib/dag/runner.rb
@@ -286,10 +286,10 @@ module DAG
     end
 
     # Pick the canonical committed attempt independent of `list_attempts`
-    # ordering: highest `attempt_number`, with `attempt_id` ASCII as the
-    # tie-break (matches the `id.to_s` ASCII tie-break used by the topo
-    # sort). Single-pass; avoids the intermediate Array and per-element
-    # key Array that `select`/`max_by` would allocate on this hot path.
+    # ordering: highest `attempt_number`, with `attempt_id.to_s` ASCII as
+    # a defensive tie-break. Single-pass; avoids the intermediate Array
+    # and per-element key Array that `select`/`max_by` would allocate on
+    # this hot path.
     def canonical_committed_attempt(attempts)
       best = nil
       best_id = nil

--- a/lib/dag/runner.rb
+++ b/lib/dag/runner.rb
@@ -92,15 +92,7 @@ module DAG
     # @raise [DAG::StaleStateError] when the workflow is not `:failed`
     # @raise [DAG::WorkflowRetryExhaustedError] when the budget is spent
     def retry_workflow(workflow_id)
-      workflow = @storage.load_workflow(id: workflow_id)
-      raise StaleStateError, "workflow not in :failed state (#{workflow[:state].inspect})" unless workflow[:state] == :failed
-
-      retry_count = workflow[:workflow_retry_count]
-      max = workflow[:runtime_profile].max_workflow_retries
-      raise WorkflowRetryExhaustedError, "workflow retries exhausted (#{retry_count}/#{max})" if retry_count >= max
-
-      @storage.prepare_workflow_retry(id: workflow_id)
-      @storage.transition_workflow_state(id: workflow_id, from: :failed, to: :pending)
+      @storage.prepare_workflow_retry(id: workflow_id, from: :failed, to: :pending)
       call(workflow_id)
     end
 

--- a/lib/dag/runner.rb
+++ b/lib/dag/runner.rb
@@ -277,12 +277,38 @@ module DAG
       ctx = run.base_context
       run.predecessors_by_node[node_id].each do |pred|
         attempts = @storage.list_attempts(workflow_id: run.workflow_id, revision: run.revision, node_id: pred)
-        committed = attempts.reverse_each.find { |a| a[:state] == :committed }
+        committed = canonical_committed_attempt(attempts)
         next unless committed
 
         ctx = ctx.merge(committed[:result].context_patch)
       end
       ctx
+    end
+
+    # Pick the canonical committed attempt independent of `list_attempts`
+    # ordering: highest `attempt_number`, with `attempt_id` ASCII as the
+    # tie-break (matches the `id.to_s` ASCII tie-break used by the topo
+    # sort). Single-pass; avoids the intermediate Array and per-element
+    # key Array that `select`/`max_by` would allocate on this hot path.
+    def canonical_committed_attempt(attempts)
+      best = nil
+      best_id = nil
+      attempts.each do |a|
+        next unless a[:state] == :committed
+        n = a.fetch(:attempt_number)
+        if best.nil? || n > best.fetch(:attempt_number)
+          best = a
+          best_id = nil
+        elsif n == best.fetch(:attempt_number)
+          best_id ||= best.fetch(:attempt_id).to_s
+          candidate_id = a.fetch(:attempt_id).to_s
+          if candidate_id > best_id
+            best = a
+            best_id = candidate_id
+          end
+        end
+      end
+      best
     end
 
     def safe_call_step(definition, node_id, input)

--- a/spec/r1/context_merge_order_test.rb
+++ b/spec/r1/context_merge_order_test.rb
@@ -16,16 +16,11 @@ class ContextMergeOrderTest < Minitest::Test
     b_class = Class.new(DAG::Step::Base) do
       def call(_input) = DAG::Success[value: :from_b, context_patch: {shared: "b"}]
     end
-    sink_class = Class.new(DAG::Step::Base) do
-      def call(input)
-        DAG::Success[value: input.context.to_h, context_patch: input.context.to_h]
-      end
-    end
 
     registry = DAG::StepTypeRegistry.new
     registry.register(name: :a_step, klass: a_class, fingerprint_payload: {v: 1})
     registry.register(name: :b_step, klass: b_class, fingerprint_payload: {v: 1})
-    registry.register(name: :sink_step, klass: sink_class, fingerprint_payload: {v: 1})
+    registry.register(name: :sink_step, klass: context_dump_step_class, fingerprint_payload: {v: 1})
     registry.freeze!
 
     runner = build_runner(storage: storage, registry: registry)
@@ -56,5 +51,68 @@ class ContextMergeOrderTest < Minitest::Test
       fingerprint.compute(sink[:result].context_patch)
     end
     assert_equal 1, digests.uniq.size, "context fingerprint must be stable across 100 runs"
+  end
+
+  def test_effective_context_uses_highest_committed_attempt_independent_of_storage_order
+    storage_class = Class.new(DAG::Adapters::Memory::Storage) do
+      def initialize(seed:)
+        super()
+        @random = Random.new(seed)
+      end
+
+      def list_attempts(workflow_id:, revision: nil, node_id: nil)
+        attempts = super
+        return attempts unless node_id == :a
+
+        [
+          attempt_record(workflow_id, revision, 2, "attempt-b", "newer"),
+          attempt_record(workflow_id, revision, 1, "attempt-z", "older")
+        ].shuffle(random: @random)
+      end
+
+      private
+
+      def attempt_record(workflow_id, revision, attempt_number, attempt_id, value)
+        {
+          attempt_id: attempt_id,
+          workflow_id: workflow_id,
+          revision: revision,
+          node_id: :a,
+          attempt_number: attempt_number,
+          state: :committed,
+          result: DAG::Success[value: value, context_patch: {shared: value}]
+        }
+      end
+    end
+
+    registry = DAG::StepTypeRegistry.new
+    registry.register(name: :passthrough, klass: DAG::BuiltinSteps::Passthrough, fingerprint_payload: {v: 1})
+    registry.register(name: :sink_step, klass: context_dump_step_class, fingerprint_payload: {v: 1})
+    registry.freeze!
+
+    definition = DAG::Workflow::Definition.new
+      .add_node(:a, type: :passthrough)
+      .add_node(:c, type: :sink_step)
+      .add_edge(:a, :c)
+
+    observed = Array.new(5) do |seed|
+      storage = storage_class.new(seed: seed)
+      workflow_id = create_workflow(storage, definition)
+      build_runner(storage: storage, registry: registry).call(workflow_id)
+
+      sink_attempt = storage.list_attempts(workflow_id: workflow_id, node_id: :c).last
+      sink_attempt[:result].value[:shared]
+    end
+    assert_equal ["newer"], observed.uniq
+  end
+
+  private
+
+  def context_dump_step_class
+    @context_dump_step_class ||= Class.new(DAG::Step::Base) do
+      def call(input)
+        DAG::Success[value: input.context.to_h, context_patch: input.context.to_h]
+      end
+    end
   end
 end

--- a/spec/r1/retry_workflow_test.rb
+++ b/spec/r1/retry_workflow_test.rb
@@ -49,6 +49,49 @@ class RetryWorkflowTest < Minitest::Test
     assert_raises(DAG::StaleStateError) { runner.retry_workflow(workflow_id) }
   end
 
+  def test_retry_workflow_uses_prepare_as_the_failed_to_pending_boundary
+    storage_class = Class.new(DAG::Adapters::Memory::Storage) do
+      def transition_workflow_state(id:, from:, to:, event: nil)
+        if from == :failed && to == :pending
+          raise "retry transition must happen inside prepare_workflow_retry"
+        end
+
+        super
+      end
+    end
+    storage = storage_class.new
+    registry, _counter = registry_with_failing_step(failures_before_success: 1)
+    runner = build_runner(storage: storage, registry: registry)
+
+    definition = DAG::Workflow::Definition.new.add_node(:flaky, type: :flaky)
+    workflow_id = create_workflow(storage, definition,
+      runtime_profile: profile(max_attempts_per_node: 1, max_workflow_retries: 1))
+
+    assert_equal :failed, runner.call(workflow_id).state
+    assert_equal :completed, runner.retry_workflow(workflow_id).state
+  end
+
+  def test_crash_after_prepare_workflow_retry_leaves_no_split_retry_state
+    storage = DAG::Adapters::Memory::CrashableStorage.new(
+      crash_on: {method: :prepare_workflow_retry, after: true, from: :failed, to: :pending}
+    )
+    registry, _counter = registry_with_failing_step(failures_before_success: 2)
+    runner = build_runner(storage: storage, registry: registry)
+
+    definition = DAG::Workflow::Definition.new.add_node(:flaky, type: :flaky)
+    workflow_id = create_workflow(storage, definition,
+      runtime_profile: profile(max_attempts_per_node: 1, max_workflow_retries: 2))
+
+    assert_equal :failed, runner.call(workflow_id).state
+    assert_raises(DAG::Adapters::Memory::SimulatedCrash) { runner.retry_workflow(workflow_id) }
+
+    healthy_storage = storage.snapshot_to_healthy
+    workflow = healthy_storage.load_workflow(id: workflow_id)
+    assert_equal :pending, workflow[:state]
+    assert_equal 1, workflow[:workflow_retry_count]
+    assert_equal :pending, node_state(healthy_storage, workflow_id, :flaky)
+  end
+
   def test_retry_does_not_overwrite_aborted_attempt_records
     storage = DAG::Adapters::Memory::Storage.new
     registry, _counter = registry_with_failing_step(failures_before_success: 4)

--- a/spec/r1/storage_state_extras_test.rb
+++ b/spec/r1/storage_state_extras_test.rb
@@ -204,6 +204,63 @@ class StorageStateExtrasTest < Minitest::Test
     assert_raises(DAG::UnknownWorkflowError) { @storage.prepare_workflow_retry(id: "ghost") }
   end
 
+  def test_prepare_workflow_retry_enforces_budget_inside_atomic_boundary
+    workflow_id = create_workflow(@storage, @definition,
+      runtime_profile: DAG::RuntimeProfile[
+        durability: :ephemeral,
+        max_attempts_per_node: 1,
+        max_workflow_retries: 1,
+        event_bus_kind: :null
+      ])
+    @storage.transition_workflow_state(id: workflow_id, from: :pending, to: :failed)
+    @storage.prepare_workflow_retry(id: workflow_id, from: :failed, to: :pending)
+    @storage.transition_workflow_state(id: workflow_id, from: :pending, to: :failed)
+
+    assert_raises(DAG::WorkflowRetryExhaustedError) do
+      @storage.prepare_workflow_retry(id: workflow_id, from: :failed, to: :pending)
+    end
+    workflow = @storage.load_workflow(id: workflow_id)
+    assert_equal :failed, workflow[:state]
+    assert_equal 1, workflow[:workflow_retry_count]
+  end
+
+  def test_prepare_workflow_retry_transitions_workflow_and_rejects_duplicate_prepare
+    workflow_id = create_workflow(@storage, @definition,
+      runtime_profile: DAG::RuntimeProfile[
+        durability: :ephemeral,
+        max_attempts_per_node: 1,
+        max_workflow_retries: 2,
+        event_bus_kind: :null
+      ])
+    attempt_id = @storage.begin_attempt(
+      workflow_id: workflow_id,
+      revision: 1,
+      node_id: :a,
+      expected_node_state: :pending,
+      attempt_number: 1
+    )
+    @storage.commit_attempt(
+      attempt_id: attempt_id,
+      result: DAG::Failure[error: {code: :boom}, retriable: true],
+      node_state: :failed,
+      event: build_event(:node_failed, workflow_id: workflow_id)
+    )
+    @storage.transition_workflow_state(id: workflow_id, from: :pending, to: :failed)
+
+    result = @storage.prepare_workflow_retry(id: workflow_id, from: :failed, to: :pending)
+
+    assert_equal :pending, result[:state]
+    assert_equal [:a], result[:reset]
+    assert_equal 1, result[:workflow_retry_count]
+    assert_equal :pending, @storage.load_workflow(id: workflow_id)[:state]
+    assert_equal :pending, node_state(@storage, workflow_id, :a)
+    assert_equal :aborted, @storage.list_attempts(workflow_id: workflow_id, node_id: :a).first[:state]
+    assert_raises(DAG::StaleStateError) do
+      @storage.prepare_workflow_retry(id: workflow_id, from: :failed, to: :pending)
+    end
+    assert_equal 1, @storage.load_workflow(id: workflow_id)[:workflow_retry_count]
+  end
+
   def test_read_events_filters_after_seq_and_limit
     workflow_id = create_workflow(@storage, @definition)
     e1 = @storage.append_event(workflow_id: workflow_id, event: build_event(:node_started))


### PR DESCRIPTION
## Summary
- make workflow retry preparation a single storage boundary with state and retry-budget guards
- remove Runner's separate failed-to-pending transition during retry
- canonicalize committed predecessor attempt selection independent of storage ordering
- document the retry boundary in CONTRACT and CLAUDE guidance

## Tests
- bundle exec rake

Closes #144