### PR TITLE
Effects PR3: wire effects into runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,10 @@ Two layers, in order of dependency:
     algorithm; `#retry_workflow(workflow_id)` delegates the failed-to-pending
     retry boundary to storage, then calls the workflow again. The storage
     port enforces `max_workflow_retries` and raises
-    `WorkflowRetryExhaustedError` when the budget is spent.
+    `WorkflowRetryExhaustedError` when the budget is spent. The Runner also
+    prepares effect intents returned by `Success` / `Waiting`, computes their
+    payload fingerprints via the injected fingerprint port, and passes
+    `PreparedIntent` values to storage inside `commit_attempt`.
 
 ## Key files
 
@@ -261,8 +264,11 @@ public surface) without paying ceremony for private scaffolding.
   `spec/support/` are auto-included.
 - All graph nodes are symbols internally (`.to_sym` on input).
 - Step inputs flow through `DAG::StepInput[context: ec, node_id:,
-  attempt_number:, metadata: {workflow_id:, revision:}]` where `ec` is an
-  `ExecutionContext`. `input.context` is always an `ExecutionContext`.
+  attempt_number:, metadata: {workflow_id:, revision:, effects:}]` where
+  `ec` is an `ExecutionContext`. `input.context` is always an
+  `ExecutionContext`. `metadata[:effects]` is a JSON-safe Hash keyed by
+  effect `ref`, scoped to the current workflow revision and node. It excludes
+  effect lease fields and storage timestamps.
 - Effective context for a node = `initial_context` + each predecessor's
   committed-attempt `context_patch`, applied in `id.to_s` ASCII order
   over predecessors. Later predecessor wins on key collision. Bit-identical

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -39,9 +39,10 @@ workflows.
 `proposed_effects` is an Array of `DAG::Effects::Intent`. On `Success`, effects
 are detached: they describe external work that does not block committing the
 node. On `Waiting`, effects are blocking: they describe external work that must
-finish before the step can produce its final result. PR2 adds durable storage
-reservation for the prepared effect intents; dispatch and concrete handlers
-remain outside the runner.
+finish before the step can produce its final result. The Runner prepares these
+intents with execution coordinates and payload fingerprints, then storage
+reserves them atomically with the attempt commit. Dispatch and concrete
+handlers remain outside the runner.
 
 ## Effects Value Layer
 
@@ -96,6 +97,51 @@ or the effect is still pending/retriable, it returns
 is `:succeeded`, it yields the durable effect result to the continuation and
 requires the continuation to return a legal step result. If the snapshot is
 `:failed_terminal`, it returns a non-retriable `Failure`.
+
+## Runner Effect Integration
+
+Every step input includes an effect snapshot scoped to the current workflow
+revision and current node:
+
+```ruby
+input.metadata[:effects]
+```
+
+The snapshot is a JSON-safe Hash keyed by effect `ref`. Values are plain frozen
+Hashes, not `DAG::Effects::Record` objects, so `StepInput` remains durable and
+JSON-safe. The snapshot contains stable effect data:
+
+```text
+id
+ref
+type
+key
+payload
+payload_fingerprint
+blocking
+status
+result
+error
+external_ref
+not_before_ms
+metadata
+```
+
+Lease fields and storage timestamps are intentionally excluded from
+`StepInput`; they are dispatcher coordination data, not step input data.
+
+When a step returns `Success` or `Waiting` with `proposed_effects`, the Runner
+converts each `Intent` into a `PreparedIntent` before calling storage. It uses
+the injected fingerprint port to compute `payload_fingerprint` from
+`intent.payload`, fills in workflow/revision/node/attempt coordinates, and sets
+`blocking: true` for `Waiting` and `blocking: false` for `Success`.
+
+For `:node_waiting` events, the durable event payload includes:
+
+```ruby
+effect_refs: [...]
+effect_count: Integer
+```
 
 ## Effect Storage Contract
 

--- a/lib/dag/runner.rb
+++ b/lib/dag/runner.rb
@@ -290,9 +290,12 @@ module DAG
       ]
     end
 
+    EMPTY_EFFECTS = [].freeze
+    private_constant :EMPTY_EFFECTS
+
     def prepare_effects(run, node_id:, attempt_id:, result:, created_at_ms:)
-      return [] unless result.respond_to?(:proposed_effects)
-      return [] if result.proposed_effects.empty?
+      return EMPTY_EFFECTS unless result.respond_to?(:proposed_effects)
+      return EMPTY_EFFECTS if result.proposed_effects.empty?
 
       blocking = result.is_a?(DAG::Waiting)
       result.proposed_effects.map do |intent|

--- a/lib/dag/runner.rb
+++ b/lib/dag/runner.rb
@@ -250,16 +250,29 @@ module DAG
     end
 
     def commit_and_emit(run, node_id, attempt_id, attempt_number, result, node_state, event_type, extra_payload)
+      now_ms = @clock.now_ms
+      prepared_effects = prepare_effects(
+        run,
+        node_id: node_id,
+        attempt_id: attempt_id,
+        result: result,
+        created_at_ms: now_ms
+      )
+      payload = extra_payload
+        .merge(attempt_number: attempt_number)
+        .merge(effect_event_payload(event_type, prepared_effects))
       event = build_event(run,
         type: event_type,
         node_id: node_id,
         attempt_id: attempt_id,
-        payload: extra_payload.merge(attempt_number: attempt_number))
+        at_ms: now_ms,
+        payload: payload)
       stamped = @storage.commit_attempt(
         attempt_id: attempt_id,
         result: result,
         node_state: node_state,
-        event: event
+        event: event,
+        effects: prepared_effects
       )
       @event_bus.publish(stamped)
     end
@@ -269,8 +282,77 @@ module DAG
         context: effective_context(run, node_id),
         node_id: node_id,
         attempt_number: attempt_number,
-        metadata: {workflow_id: run.workflow_id, revision: run.revision}
+        metadata: {
+          workflow_id: run.workflow_id,
+          revision: run.revision,
+          effects: effects_snapshot_for(run, node_id)
+        }
       ]
+    end
+
+    def prepare_effects(run, node_id:, attempt_id:, result:, created_at_ms:)
+      return [] unless result.respond_to?(:proposed_effects)
+      return [] if result.proposed_effects.empty?
+
+      blocking = result.is_a?(DAG::Waiting)
+      result.proposed_effects.map do |intent|
+        DAG::Effects::PreparedIntent.from_intent(
+          intent: intent,
+          workflow_id: run.workflow_id,
+          revision: run.revision,
+          node_id: node_id,
+          attempt_id: attempt_id,
+          payload_fingerprint: @fingerprint.compute(intent.payload),
+          blocking: blocking,
+          created_at_ms: created_at_ms
+        )
+      end.freeze
+    end
+
+    def effect_event_payload(event_type, prepared_effects)
+      return {} unless event_type == :node_waiting
+
+      {
+        effect_refs: prepared_effects.map(&:ref),
+        effect_count: prepared_effects.size
+      }
+    end
+
+    EFFECT_SNAPSHOT_FIELDS = %i[
+      id
+      ref
+      type
+      key
+      payload
+      payload_fingerprint
+      blocking
+      status
+      result
+      error
+      external_ref
+      not_before_ms
+      metadata
+    ].freeze
+    private_constant :EFFECT_SNAPSHOT_FIELDS
+
+    def effects_snapshot_for(run, node_id)
+      records = @storage.list_effects_for_node(
+        workflow_id: run.workflow_id,
+        revision: run.revision,
+        node_id: node_id
+      )
+
+      records
+        .sort_by(&:ref)
+        .each_with_object({}) do |record, snapshot|
+          snapshot[record.ref] = effect_snapshot(record)
+        end
+    end
+
+    def effect_snapshot(record)
+      EFFECT_SNAPSHOT_FIELDS.each_with_object({}) do |field, snapshot|
+        snapshot[field] = record.public_send(field)
+      end
     end
 
     def effective_context(run, node_id)
@@ -371,12 +453,12 @@ module DAG
       )
     end
 
-    def build_event(run, type:, payload:, node_id: nil, attempt_id: nil)
+    def build_event(run, type:, payload:, node_id: nil, attempt_id: nil, at_ms: nil)
       DAG::Event[
         type: type,
         workflow_id: run.workflow_id,
         revision: run.revision,
-        at_ms: @clock.now_ms,
+        at_ms: at_ms || @clock.now_ms,
         node_id: node_id,
         attempt_id: attempt_id,
         payload: payload

--- a/lib/dag/step_input.rb
+++ b/lib/dag/step_input.rb
@@ -2,8 +2,8 @@
 
 module DAG
   # Carrier the Runner passes to each step's `#call`. `context` is a
-  # deep-frozen `ExecutionContext`; `metadata` carries `workflow_id` and
-  # `revision`.
+  # deep-frozen `ExecutionContext`; `metadata` carries `workflow_id`,
+  # `revision`, and the node-scoped effect snapshot under `:effects`.
   # @api public
   StepInput = Data.define(:context, :node_id, :attempt_number, :metadata) do
     class << self

--- a/spec/r2/runner_effects_test.rb
+++ b/spec/r2/runner_effects_test.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class RunnerEffectsTest < Minitest::Test
+  def test_waiting_with_proposed_effect_reserves_record_and_waiting_event_payload
+    storage = DAG::Adapters::Memory::Storage.new
+    intent = effect_intent(key: "approval")
+    registry = registry_with_effect_await_step(intent: intent)
+    runner = build_runner(storage: storage, registry: registry)
+    workflow_id = create_workflow(storage, DAG::Workflow::Definition.new.add_node(:a, type: :await_effect))
+
+    result = runner.call(workflow_id)
+
+    assert_equal :waiting, result.state
+    assert_equal :waiting, node_state(storage, workflow_id, :a)
+
+    records = storage.list_effects_for_node(workflow_id: workflow_id, revision: 1, node_id: :a)
+    assert_equal 1, records.size
+    assert_equal intent.ref, records.first.ref
+    assert_equal fingerprint.compute(intent.payload), records.first.payload_fingerprint
+    assert records.first.blocking
+
+    waiting_event = storage.read_events(workflow_id: workflow_id).find { |event| event.type == :node_waiting }
+    assert_equal [intent.ref], waiting_event.payload[:effect_refs]
+    assert_equal 1, waiting_event.payload[:effect_count]
+  end
+
+  def test_resume_before_terminal_effect_does_not_rerun_waiting_node
+    storage = DAG::Adapters::Memory::Storage.new
+    intent = effect_intent(key: "slow")
+    calls = []
+    registry = registry_with_effect_await_step(intent: intent, calls: calls)
+    runner = build_runner(storage: storage, registry: registry)
+    workflow_id = create_workflow(storage, DAG::Workflow::Definition.new.add_node(:a, type: :await_effect))
+
+    runner.call(workflow_id)
+    result = runner.resume(workflow_id)
+
+    assert_equal :waiting, result.state
+    assert_equal 1, calls.size
+    assert_equal :waiting, node_state(storage, workflow_id, :a)
+  end
+
+  def test_resume_after_effect_success_reruns_node_with_effect_snapshot
+    storage = DAG::Adapters::Memory::Storage.new
+    intent = effect_intent(key: "done")
+    calls = []
+    registry = registry_with_effect_await_step(intent: intent, calls: calls)
+    runner = build_runner(storage: storage, registry: registry)
+    workflow_id = create_workflow(storage, DAG::Workflow::Definition.new.add_node(:a, type: :await_effect))
+
+    runner.call(workflow_id)
+    effect = storage.list_effects_for_node(workflow_id: workflow_id, revision: 1, node_id: :a).first
+    mark_effect_succeeded_and_release(storage, effect.id, result: {value: "ok"})
+
+    result = runner.resume(workflow_id)
+
+    assert_equal :completed, result.state
+    assert_equal 2, calls.size
+    second_input = calls.last
+    snapshot = second_input.metadata[:effects][intent.ref]
+    assert_equal :succeeded, snapshot[:status]
+    assert_equal({value: "ok"}, snapshot[:result])
+    assert snapshot.frozen?
+
+    attempt = storage.list_attempts(workflow_id: workflow_id, revision: 1, node_id: :a).last
+    assert_equal :committed, attempt[:state]
+    assert_equal({effect_value: "ok"}, attempt[:result].context_patch)
+  end
+
+  def test_step_sees_only_effects_for_its_own_node
+    storage = DAG::Adapters::Memory::Storage.new
+    intent = effect_intent(key: "node-a")
+    observed_b_effects = []
+    registry = DAG::StepTypeRegistry.new
+    wait_class = Class.new(DAG::Step::Base) do
+      define_method(:call) do |_input|
+        DAG::Waiting[reason: :effect_pending, proposed_effects: [intent]]
+      end
+    end
+    capture_class = Class.new(DAG::Step::Base) do
+      define_method(:call) do |input|
+        observed_b_effects << input.metadata.fetch(:effects)
+        DAG::Success[value: :b, context_patch: {}]
+      end
+    end
+    registry.register(name: :wait_a, klass: wait_class, fingerprint_payload: {v: 1})
+    registry.register(name: :capture_b, klass: capture_class, fingerprint_payload: {v: 1})
+    registry.freeze!
+    runner = build_runner(storage: storage, registry: registry)
+    definition = DAG::Workflow::Definition.new
+      .add_node(:a, type: :wait_a)
+      .add_node(:b, type: :capture_b)
+    workflow_id = create_workflow(storage, definition)
+
+    result = runner.call(workflow_id)
+
+    assert_equal :waiting, result.state
+    assert_equal [{}], observed_b_effects
+    assert_equal 1, storage.list_effects_for_node(workflow_id: workflow_id, revision: 1, node_id: :a).size
+    assert_empty storage.list_effects_for_node(workflow_id: workflow_id, revision: 1, node_id: :b)
+  end
+
+  def test_success_with_proposed_effect_records_detached_effect_and_commits_node
+    storage = DAG::Adapters::Memory::Storage.new
+    intent = effect_intent(key: "detached", payload: {task: "notify"})
+    registry = DAG::StepTypeRegistry.new
+    success_class = Class.new(DAG::Step::Base) do
+      define_method(:call) do |_input|
+        DAG::Success[value: :ok, context_patch: {ok: true}, proposed_effects: [intent]]
+      end
+    end
+    registry.register(name: :success_effect, klass: success_class, fingerprint_payload: {v: 1})
+    registry.freeze!
+    runner = build_runner(storage: storage, registry: registry)
+    workflow_id = create_workflow(storage, DAG::Workflow::Definition.new.add_node(:a, type: :success_effect))
+
+    result = runner.call(workflow_id)
+
+    assert_equal :completed, result.state
+    assert_equal :committed, node_state(storage, workflow_id, :a)
+    attempt = storage.list_attempts(workflow_id: workflow_id, revision: 1, node_id: :a).first
+    records = storage.list_effects_for_attempt(attempt_id: attempt[:attempt_id])
+    assert_equal 1, records.size
+    assert_equal intent.ref, records.first.ref
+    refute records.first.blocking
+    assert_equal :reserved, records.first.status
+  end
+
+  def test_non_effect_workflow_still_gets_empty_effect_snapshot
+    storage = DAG::Adapters::Memory::Storage.new
+    observed_effects = []
+    registry = DAG::StepTypeRegistry.new
+    klass = Class.new(DAG::Step::Base) do
+      define_method(:call) do |input|
+        observed_effects << input.metadata.fetch(:effects)
+        DAG::Success[value: :ok, context_patch: {}]
+      end
+    end
+    registry.register(name: :plain, klass: klass, fingerprint_payload: {v: 1})
+    registry.freeze!
+    runner = build_runner(storage: storage, registry: registry)
+    workflow_id = create_workflow(storage, DAG::Workflow::Definition.new.add_node(:a, type: :plain))
+
+    result = runner.call(workflow_id)
+
+    assert_equal :completed, result.state
+    assert_equal [{}], observed_effects
+  end
+
+  private
+
+  def effect_intent(key:, payload: {value: 1})
+    DAG::Effects::Intent[type: "test", key: key, payload: payload, metadata: {source: "spec"}]
+  end
+
+  def registry_with_effect_await_step(intent:, calls: [])
+    registry = DAG::StepTypeRegistry.new
+    klass = Class.new(DAG::Step::Base) do
+      define_method(:call) do |input|
+        calls << input
+        DAG::Effects::Await.call(input, intent) do |effect_result|
+          DAG::Success[
+            value: effect_result,
+            context_patch: {effect_value: effect_result.fetch(:value)}
+          ]
+        end
+      end
+    end
+    registry.register(name: :await_effect, klass: klass, fingerprint_payload: {v: 1})
+    registry.freeze!
+    registry
+  end
+
+  def fingerprint
+    @fingerprint ||= DAG::Adapters::Stdlib::Fingerprint.new
+  end
+
+  def mark_effect_succeeded_and_release(storage, effect_id, result:)
+    claimed = storage.claim_ready_effects(limit: 1, owner_id: "worker", lease_ms: 500, now_ms: 1_000)
+    assert_equal [effect_id], claimed.map(&:id)
+    storage.mark_effect_succeeded(
+      effect_id: effect_id,
+      owner_id: "worker",
+      result: result,
+      external_ref: "external-#{effect_id}",
+      now_ms: 1_100
+    )
+    storage.release_nodes_satisfied_by_effect(effect_id: effect_id, now_ms: 1_200)
+  end
+end


### PR DESCRIPTION
## Summary
- add node-scoped effect snapshots to StepInput metadata
- prepare proposed effects in Runner with payload fingerprints and execution coordinates
- pass prepared effects into storage.commit_attempt for atomic reservation
- add node_waiting event effect references
- cover waiting, resume, release, detached effects, node scoping, and non-effect workflows

## Tests
- bundle exec rake

Closes #147