### PR TITLE
docs: define kernel boundary contract

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -1,7 +1,31 @@
 # ruby-dag Boundary Contract
 
-`ruby-dag` exposes the kernel contracts below. Consumers own application
-semantics, external side effects, approvals, budgets, and UI streaming.
+`ruby-dag` is an implementation-agnostic DAG execution kernel. Its public
+contract defines where kernel scheduling and durable execution protocols end and
+consumer application behavior begins.
+
+## Kernel Boundary
+
+`ruby-dag` owns only:
+
+- graph, definition, revision, and scheduling semantics;
+- `Runner` orchestration over injected ports;
+- step result transport;
+- abstract effect intent reservation and dispatch coordination;
+- mutation/revision APIs;
+- retry/recovery rules;
+- event log and diagnostic contract.
+
+### Non-goals
+
+Consumers own:
+
+- concrete storage adapters beyond memory examples;
+- concrete effect handlers;
+- LLM/model/tool semantics;
+- application-level budgets, approvals, policy, and UI streaming;
+- consumer-owned runtime/domain objects, orchestration facades, per-run
+  application context/results, and channel/stream behavior.
 
 ## Step Protocol
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,17 @@ workflow retries are disabled unless you opt in. For workflows that should be
 retryable, pass a profile with a positive `max_workflow_retries`; `3` is a
 reasonable starting point for scripts and small durable consumers.
 
-`DAG::Toolkit.in_memory_kit` is a convenience for examples and tests; production
-callers construct the seven `DAG::Runner` ports explicitly so production-grade
-adapters can be injected.
+`DAG::Toolkit.in_memory_kit` is a convenience for examples and tests.
+Production callers inject the public ports (`storage:`,
+`event_bus:`, `registry:`, `clock:`, `id_generator:`, `fingerprint:`, and
+`serializer:`) when constructing `DAG::Runner`; durable production adapters can
+live in consumer repositories. Delphi can be treated as a reference consumer,
+not part of the kernel contract.
+
+> Non-normative reference-consumer note: consumer-owned runtime objects,
+> application context, result wrappers, and channel behavior are examples of
+> application semantics. A consumer wrapper is not `DAG::RunResult`, and
+> reference-consumer choices do not constrain other consumers.
 
 ## Resume after waiting
 

--- a/spec/r0/kernel_boundary_docs_test.rb
+++ b/spec/r0/kernel_boundary_docs_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class R0KernelBoundaryDocsTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def normalized(text)
+    text.split.join(" ")
+  end
+
+  def test_contract_leads_with_kernel_boundary_and_non_goals
+    contract = File.read(File.join(ROOT, "CONTRACT.md"))
+
+    boundary_index = contract.index("## Kernel Boundary")
+    step_protocol_index = contract.index("## Step Protocol")
+
+    refute_nil boundary_index, "CONTRACT.md must start with an explicit kernel boundary section"
+    refute_nil step_protocol_index, "CONTRACT.md must still document the step protocol"
+    assert_operator boundary_index, :<, step_protocol_index
+
+    normalized_contract = normalized(contract)
+
+    [
+      "`ruby-dag` owns only",
+      "### Non-goals",
+      "graph, definition, revision, and scheduling semantics",
+      "`Runner` orchestration over injected ports",
+      "step result transport",
+      "abstract effect intent reservation and dispatch coordination",
+      "mutation/revision APIs",
+      "retry/recovery rules",
+      "event log and diagnostic contract",
+      "Consumers own",
+      "concrete storage adapters beyond memory examples",
+      "concrete effect handlers",
+      "LLM/model/tool semantics",
+      "application-level budgets, approvals, policy, and UI streaming",
+      "consumer-owned runtime/domain objects, orchestration facades, per-run application context/results, and channel/stream behavior"
+    ].each do |required_text|
+      assert_includes normalized_contract, required_text
+    end
+
+    refute_includes normalized_contract, "Delphi-specific"
+    refute_includes normalized_contract, "Delphi"
+    refute_includes normalized_contract, "Delphic"
+    refute_includes normalized_contract, "`Plan`"
+    refute_includes normalized_contract, "`Agent`"
+    refute_includes normalized_contract, "`RunContext`"
+    refute_includes normalized_contract, "`RunResult`"
+  end
+
+  def test_readme_explains_production_ports_and_consumer_adapters
+    readme = File.read(File.join(ROOT, "README.md"))
+    normalized_readme = normalized(readme)
+
+    assert_includes normalized_readme, "Production callers inject the public ports"
+    %w[storage event_bus registry clock id_generator fingerprint serializer].each do |port_name|
+      assert_includes normalized_readme, "`#{port_name}:`"
+    end
+    assert_includes normalized_readme, "durable production adapters can live in consumer repositories"
+    assert_includes normalized_readme, "Delphi can be treated as a reference consumer"
+    assert_includes normalized_readme, "not part of the kernel contract"
+    assert_includes normalized_readme, "Non-normative reference-consumer note"
+    assert_includes normalized_readme, "consumer-owned runtime objects"
+    assert_includes normalized_readme, "application context, result wrappers, and channel behavior"
+    assert_includes normalized_readme, "not `DAG::RunResult`"
+    assert_includes normalized_readme, "do not constrain other consumers"
+    refute_includes normalized_readme, "`Plan`"
+    refute_includes normalized_readme, "`Agent`"
+    refute_includes normalized_readme, "`RunContext`"
+  end
+end


### PR DESCRIPTION
## Summary
- Make CONTRACT.md start from the implementation-agnostic kernel boundary and explicit non-goals.
- Clarify README production port injection and durable adapter ownership.
- Add R0 docs guardrails that keep consumer concepts out of the normative contract while allowing Delphi only as a non-normative reference consumer.

## Issues
- Closes #158
- Advances #157

## Tests
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec ruby -Itest -Ispec spec/r0/kernel_boundary_docs_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec ruby scripts/production_readiness.rb --fast`
- Static diff scan for hardcoded secrets, shell injection, eval/exec, pickle, and SQL string formatting patterns: no findings

## Review Notes
- Initial review flagged README/test coupling to hard-coded Delphi internals; fixed by keeping README generic and using Delphi only as a reference-consumer framing.
- Final review: no remaining blockers.

## Architecture Decisions
- Boundary choice: CONTRACT.md remains fully implementation-agnostic; README may mention Delphi only as a non-normative reference consumer and must not name Delphi runtime/domain objects.

## CLAUDE.md Updates
- None.

## Known Follow-ups
- Continue #157 with the next narrow RD slice after this PR lands.
