### PR TITLE
feat(kernel): define scoped runtime snapshot semantics

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -172,6 +172,46 @@ effect_refs: [...]
 effect_count: Integer
 ```
 
+## StepInput Runtime Snapshot
+
+Steps can read the public runtime boundary through:
+
+```ruby
+snapshot = input.runtime_snapshot
+```
+
+`input.runtime_snapshot` returns an immutable `DAG::RuntimeSnapshot` with the
+current workflow id, revision, node id, attempt id, and attempt number. It also
+carries the same `DAG::PlanVersion` coordinate as `snapshot.plan_version`.
+
+The snapshot includes predecessor snapshots under `#predecessors`. These
+predecessor snapshots are limited to canonical committed `Success` results for
+the current revision and are keyed by predecessor node id. Each value is a
+plain frozen Hash with:
+
+```text
+value
+context_patch
+metadata
+```
+
+Predecessor lookup uses storage's canonical committed-result projection when
+available, so preserved nodes after a revision append can contribute explicit
+current-revision context without exposing older attempts. It does not expose
+unrelated node attempts or implicit results from older revisions.
+
+The snapshot includes node-scoped effect snapshots for the current
+workflow/revision/node under `#effects`. Values are the same public frozen Hashes
+used by `input.metadata[:effects]`; they contain stable effect data only. The
+snapshot does not expose lease owners, lease deadlines, storage timestamps,
+unrelated node attempts, or consumer runtime objects.
+
+`#metadata` is reserved for JSON-safe extension metadata supplied by the kernel
+or future compatible adapters. It is intentionally separate from the internal
+`StepInput#metadata` carrier so steps get a stable public runtime shape instead
+of storage internals. All nested values in `RuntimeSnapshot` are JSON-safe and
+deep-frozen.
+
 ## Effect Dispatcher Contract
 
 `DAG::Effects::Dispatcher` is an abstract boundary coordinator. It claims

--- a/README.md
+++ b/README.md
@@ -76,6 +76,34 @@ left in `:running` is unwedged by aborting in-flight attempts before
 recomputing eligibility. Already-committed nodes are not rerun in the
 same revision.
 
+## Step input runtime snapshot
+
+Custom steps receive a `DAG::StepInput`. For workflow/runtime coordinates and
+stable predecessor/effect data, prefer the public snapshot boundary:
+
+```ruby
+class InspectInputStep < DAG::Step::Base
+  def call(input)
+    snapshot = input.runtime_snapshot
+    DAG::Success[value: {
+      workflow_id: snapshot.workflow_id,
+      revision: snapshot.revision,
+      node_id: snapshot.node_id,
+      attempt: snapshot.attempt_number,
+      predecessor_values: snapshot.predecessors.transform_values { |p| p.fetch(:value) },
+      effect_refs: snapshot.effects.keys
+    }]
+  end
+end
+```
+
+`DAG::RuntimeSnapshot` is immutable and JSON-safe. It exposes current workflow,
+revision, node, and attempt coordinates; canonical committed predecessor
+`Success` snapshots for the current revision; and node-scoped effect snapshots.
+It intentionally excludes dispatcher lease fields, storage timestamps,
+unrelated node attempts, and consumer-owned runtime objects. See
+`examples/runtime_snapshot.rb` for a runnable end-to-end example.
+
 ## Effect Intents
 
 Steps describe side effects as abstract intents instead of performing

--- a/examples/runtime_snapshot.rb
+++ b/examples/runtime_snapshot.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "ruby-dag"
+
+class RuntimeSnapshotSourceStep < DAG::Step::Base
+  def call(_input)
+    DAG::Success[value: {message: "hello"}, context_patch: {source_value: "hello"}]
+  end
+end
+
+class RuntimeSnapshotInspectStep < DAG::Step::Base
+  def call(input)
+    snapshot = input.runtime_snapshot
+    source = snapshot.predecessors.fetch(:source).fetch(:value).fetch(:message)
+
+    puts "workflow_id=#{snapshot.workflow_id}"
+    puts "revision=#{snapshot.revision}"
+    puts "node_id=#{snapshot.node_id}"
+    puts "attempt_number=#{snapshot.attempt_number}"
+    puts "predecessor_source=#{source}"
+    puts "context_source=#{input.context[:source_value]}"
+    puts "effect_count=#{snapshot.effects.size}"
+
+    DAG::Success[value: :inspected, context_patch: {}]
+  end
+end
+
+registry = DAG::StepTypeRegistry.new
+registry.register(name: :source, klass: RuntimeSnapshotSourceStep, fingerprint_payload: {v: 1})
+registry.register(name: :inspect, klass: RuntimeSnapshotInspectStep, fingerprint_payload: {v: 1})
+registry.freeze!
+
+kit = DAG::Toolkit.in_memory_kit(registry: registry)
+definition = DAG::Workflow::Definition.new
+  .add_node(:source, type: :source)
+  .add_node(:inspect, type: :inspect)
+  .add_edge(:source, :inspect)
+
+workflow_id = kit.runner.id_generator.call
+kit.storage.create_workflow(
+  id: workflow_id,
+  initial_definition: definition,
+  initial_context: {},
+  runtime_profile: DAG::RuntimeProfile.default
+)
+
+result = kit.runner.call(workflow_id)
+puts "workflow_state=#{result.state}"

--- a/lib/dag/runner.rb
+++ b/lib/dag/runner.rb
@@ -224,7 +224,7 @@ module DAG
         attempt_id: attempt_id,
         payload: {attempt_number: attempt_number})
 
-      input = build_step_input(run, node_id, attempt_number)
+      input = build_step_input(run, node_id, attempt_id, attempt_number)
       result = safe_call_step(run, node_id, input)
 
       handle_outcome(run, node_id, attempt_id, attempt_number, result)
@@ -298,14 +298,19 @@ module DAG
       @event_bus.publish(stamped)
     end
 
-    def build_step_input(run, node_id, attempt_number)
+    def build_step_input(run, node_id, attempt_id, attempt_number)
+      predecessors = run.predecessors_by_node[node_id]
+      committed_results = committed_results_for_predecessors(run, predecessors)
+
       DAG::StepInput[
-        context: effective_context(run, node_id),
+        context: effective_context_from_results(run.base_context, predecessors, committed_results),
         node_id: node_id,
         attempt_number: attempt_number,
         metadata: {
           workflow_id: run.workflow_id,
           revision: run.revision,
+          attempt_id: attempt_id,
+          predecessors: predecessor_snapshots(predecessors, committed_results),
           effects: effects_snapshot_for(run, node_id)
         }
       ]
@@ -356,10 +361,8 @@ module DAG
         end
     end
 
-    def effective_context(run, node_id)
-      ctx = run.base_context
-      predecessors = run.predecessors_by_node[node_id]
-      committed_results = committed_results_for_predecessors(run, predecessors)
+    def effective_context_from_results(base_context, predecessors, committed_results)
+      ctx = base_context
       predecessors.each do |pred|
         result = committed_results[pred]
         next unless result
@@ -367,6 +370,19 @@ module DAG
         ctx = ctx.merge(result.context_patch)
       end
       ctx
+    end
+
+    def predecessor_snapshots(predecessors, committed_results)
+      predecessors.each_with_object({}) do |pred, snapshots|
+        result = committed_results[pred]
+        next unless result
+
+        snapshots[pred] = {
+          value: result.value,
+          context_patch: result.context_patch,
+          metadata: result.metadata
+        }
+      end
     end
 
     def committed_results_for_predecessors(run, predecessors)

--- a/lib/dag/runtime_snapshot.rb
+++ b/lib/dag/runtime_snapshot.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module DAG
+  # Public, immutable runtime data visible to a step for one node attempt.
+  # It is derived from StepInput metadata so consumers can inspect the scoped
+  # execution boundary without reaching into storage internals.
+  # @api public
+  RuntimeSnapshot = Data.define(
+    :workflow_id,
+    :revision,
+    :node_id,
+    :attempt_id,
+    :attempt_number,
+    :predecessors,
+    :effects,
+    :metadata
+  ) do
+    class << self
+      remove_method :[]
+
+      # @param workflow_id [String]
+      # @param revision [Integer]
+      # @param node_id [Symbol]
+      # @param attempt_id [String]
+      # @param attempt_number [Integer]
+      # @param predecessors [Hash] canonical predecessor Success snapshots
+      # @param effects [Hash] node-scoped effect snapshots
+      # @param metadata [Hash] JSON-safe extension data
+      # @return [RuntimeSnapshot]
+      def [](
+        workflow_id:,
+        revision:,
+        node_id:,
+        attempt_id:,
+        attempt_number:,
+        predecessors: {},
+        effects: {},
+        metadata: {}
+      )
+        new(
+          workflow_id: workflow_id,
+          revision: revision,
+          node_id: node_id,
+          attempt_id: attempt_id,
+          attempt_number: attempt_number,
+          predecessors: predecessors,
+          effects: effects,
+          metadata: metadata
+        )
+      end
+    end
+
+    def initialize(
+      workflow_id:,
+      revision:,
+      node_id:,
+      attempt_id:,
+      attempt_number:,
+      predecessors: {},
+      effects: {},
+      metadata: {}
+    )
+      DAG::Validation.string!(workflow_id, "workflow_id")
+      DAG::Validation.revision!(revision)
+      DAG::Validation.node_id!(node_id)
+      DAG::Validation.string!(attempt_id, "attempt_id")
+      DAG::Validation.positive_integer!(attempt_number, "attempt_number")
+      DAG::Validation.hash!(predecessors, "predecessors")
+      DAG::Validation.hash!(effects, "effects")
+      DAG::Validation.hash!(metadata, "metadata")
+      DAG.json_safe!(predecessors, "$root.predecessors")
+      DAG.json_safe!(effects, "$root.effects")
+      DAG.json_safe!(metadata, "$root.metadata")
+
+      super(
+        workflow_id: DAG.frozen_copy(workflow_id),
+        revision: revision,
+        node_id: node_id.to_sym,
+        attempt_id: DAG.frozen_copy(attempt_id),
+        attempt_number: attempt_number,
+        predecessors: DAG.frozen_copy(predecessors),
+        effects: DAG.frozen_copy(effects),
+        metadata: DAG.frozen_copy(metadata)
+      )
+    end
+
+    # @return [DAG::PlanVersion]
+    def plan_version = DAG::PlanVersion[workflow_id: workflow_id, revision: revision]
+  end
+end

--- a/lib/dag/step_input.rb
+++ b/lib/dag/step_input.rb
@@ -2,8 +2,9 @@
 
 module DAG
   # Carrier the Runner passes to each step's `#call`. `context` is a
-  # deep-frozen `ExecutionContext`; `metadata` carries `workflow_id`,
-  # `revision`, and the node-scoped effect snapshot under `:effects`.
+  # deep-frozen `ExecutionContext`; `metadata` carries the JSON-safe runtime
+  # data used by {#runtime_snapshot}, including the node-scoped effect snapshot
+  # under `:effects`.
   # @api public
   StepInput = Data.define(:context, :node_id, :attempt_number, :metadata) do
     class << self
@@ -33,6 +34,20 @@ module DAG
         attempt_number: attempt_number,
         metadata: DAG.frozen_copy(metadata)
       )
+    end
+
+    # @return [DAG::RuntimeSnapshot] public runtime boundary for this attempt
+    def runtime_snapshot
+      DAG::RuntimeSnapshot[
+        workflow_id: metadata.fetch(:workflow_id),
+        revision: metadata.fetch(:revision),
+        node_id: node_id,
+        attempt_id: metadata.fetch(:attempt_id),
+        attempt_number: attempt_number,
+        predecessors: metadata.fetch(:predecessors, {}),
+        effects: metadata.fetch(:effects, {}),
+        metadata: metadata.fetch(:runtime_metadata, {})
+      ]
     end
   end
 end

--- a/lib/dag/types.rb
+++ b/lib/dag/types.rb
@@ -2,6 +2,7 @@
 
 require_relative "effects"
 require_relative "waiting"
+require_relative "runtime_snapshot"
 require_relative "step_input"
 require_relative "replacement_graph"
 require_relative "proposed_mutation"

--- a/spec/r0/kernel_boundary_docs_test.rb
+++ b/spec/r0/kernel_boundary_docs_test.rb
@@ -50,6 +50,19 @@ class R0KernelBoundaryDocsTest < Minitest::Test
     refute_includes normalized_contract, "`RunResult`"
   end
 
+  def test_contract_documents_step_input_runtime_snapshot_boundary
+    contract = File.read(File.join(ROOT, "CONTRACT.md"))
+    normalized_contract = normalized(contract)
+
+    assert_includes normalized_contract, "## StepInput Runtime Snapshot"
+    assert_includes normalized_contract, "`input.runtime_snapshot`"
+    assert_includes normalized_contract, "current workflow id, revision, node id, attempt id, and attempt number"
+    assert_includes normalized_contract, "predecessor snapshots are limited to canonical committed `Success` results for the current revision"
+    assert_includes normalized_contract, "node-scoped effect snapshots for the current workflow/revision/node"
+    assert_includes normalized_contract, "JSON-safe extension metadata"
+    assert_includes normalized_contract, "does not expose lease owners, lease deadlines, storage timestamps, unrelated node attempts, or consumer runtime objects"
+  end
+
   def test_readme_explains_production_ports_and_consumer_adapters
     readme = File.read(File.join(ROOT, "README.md"))
     normalized_readme = normalized(readme)

--- a/spec/r3/runtime_snapshot_example_test.rb
+++ b/spec/r3/runtime_snapshot_example_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "open3"
+require_relative "../test_helper"
+
+class R3RuntimeSnapshotExampleTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def test_runtime_snapshot_example_runs_as_a_process
+    stdout, stderr, status = Open3.capture3(
+      Gem.ruby,
+      "-Ilib",
+      "examples/runtime_snapshot.rb",
+      chdir: ROOT
+    )
+
+    assert status.success?, stderr
+    assert_empty stderr
+    assert_includes stdout, "revision=1"
+    assert_includes stdout, "node_id=inspect"
+    assert_includes stdout, "attempt_number=1"
+    assert_includes stdout, "predecessor_source=hello"
+    assert_includes stdout, "context_source=hello"
+    assert_includes stdout, "effect_count=0"
+  end
+end

--- a/spec/r3/scoped_step_input_test.rb
+++ b/spec/r3/scoped_step_input_test.rb
@@ -1,0 +1,316 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class ScopedStepInputTest < Minitest::Test
+  def test_runner_exposes_runtime_snapshot_with_current_coordinates
+    storage = DAG::Adapters::Memory::Storage.new
+    observed = []
+    registry = DAG::StepTypeRegistry.new
+    capture_class = Class.new(DAG::Step::Base) do
+      define_method(:call) do |input|
+        observed << input.runtime_snapshot
+        DAG::Success[value: :ok, context_patch: {}]
+      end
+    end
+    registry.register(name: :capture, klass: capture_class, fingerprint_payload: {v: 1})
+    registry.freeze!
+    definition = DAG::Workflow::Definition.new.add_node(:capture, type: :capture)
+    workflow_id = create_workflow(storage, definition)
+
+    result = build_runner(storage: storage, registry: registry).call(workflow_id)
+
+    assert_equal :completed, result.state
+    snapshot = observed.fetch(0)
+    assert_instance_of DAG::RuntimeSnapshot, snapshot
+    assert_equal workflow_id, snapshot.workflow_id
+    assert_equal 1, snapshot.revision
+    assert_equal :capture, snapshot.node_id
+    assert_equal "#{workflow_id}/1", snapshot.attempt_id
+    assert_equal 1, snapshot.attempt_number
+    assert_equal DAG::PlanVersion[workflow_id: workflow_id, revision: 1], snapshot.plan_version
+    assert_equal({}, snapshot.predecessors)
+    assert_equal({}, snapshot.effects)
+  end
+
+  def test_runtime_snapshot_predecessors_use_canonical_committed_results
+    storage_class = Class.new(DAG::Adapters::Memory::Storage) do
+      def list_committed_results_for_predecessors(workflow_id:, revision:, predecessors:)
+        return super unless predecessors.map(&:to_sym).include?(:source)
+
+        attempts = [
+          attempt_record(workflow_id, revision, 2, "attempt-b", "newer"),
+          attempt_record(workflow_id, revision, 1, "attempt-z", "older")
+        ].reverse
+        {source: attempts.max_by { |attempt| [attempt.fetch(:attempt_number), attempt.fetch(:attempt_id).to_s] }.fetch(:result)}
+      end
+
+      private
+
+      def attempt_record(workflow_id, revision, attempt_number, attempt_id, value)
+        {
+          attempt_id: attempt_id,
+          workflow_id: workflow_id,
+          revision: revision,
+          node_id: :source,
+          attempt_number: attempt_number,
+          state: :committed,
+          result: DAG::Success[
+            value: {label: value},
+            context_patch: {shared: value},
+            metadata: {canonical: value == "newer"}
+          ]
+        }
+      end
+    end
+    storage = storage_class.new
+    observed_snapshots = []
+    observed_contexts = []
+    registry = registry_with_sink(observed_snapshots, observed_contexts)
+    definition = DAG::Workflow::Definition.new
+      .add_node(:source, type: :source)
+      .add_node(:sink, type: :sink)
+      .add_edge(:source, :sink)
+    workflow_id = create_workflow(storage, definition, initial_context: {seed: 1})
+
+    result = build_runner(storage: storage, registry: registry).call(workflow_id)
+
+    assert_equal :completed, result.state
+    snapshot = observed_snapshots.fetch(0)
+    assert_equal({label: "newer"}, snapshot.predecessors.fetch(:source).fetch(:value))
+    assert_equal({shared: "newer"}, snapshot.predecessors.fetch(:source).fetch(:context_patch))
+    assert_equal({canonical: true}, snapshot.predecessors.fetch(:source).fetch(:metadata))
+    assert_equal({seed: 1, shared: "newer"}, observed_contexts.fetch(0))
+  end
+
+  def test_runtime_snapshot_is_deep_frozen_and_fresh_copied
+    metadata = {
+      workflow_id: "wf",
+      revision: 1,
+      attempt_id: "wf/1",
+      predecessors: {
+        source: {
+          value: {items: ["original"]},
+          context_patch: {shared: "source"},
+          metadata: {tags: ["stable"]}
+        }
+      },
+      effects: {
+        "effect:one" => {status: :succeeded, result: {values: [1]}}
+      },
+      runtime_metadata: {labels: ["public"]}
+    }
+    input = DAG::StepInput[
+      context: {local: {items: ["context"]}},
+      node_id: :node,
+      attempt_number: 1,
+      metadata: metadata
+    ]
+
+    snapshot = input.runtime_snapshot
+    metadata[:predecessors][:source][:value][:items] << "mutated"
+    metadata[:effects]["effect:one"][:result][:values] << 2
+    metadata[:runtime_metadata][:labels] << "mutated"
+
+    assert_equal ["original"], snapshot.predecessors.fetch(:source).fetch(:value).fetch(:items)
+    assert_equal [1], snapshot.effects.fetch("effect:one").fetch(:result).fetch(:values)
+    assert_equal ["public"], snapshot.metadata.fetch(:labels)
+    assert snapshot.frozen?
+    assert snapshot.predecessors.frozen?
+    assert snapshot.predecessors.fetch(:source).fetch(:value).fetch(:items).frozen?
+    assert snapshot.effects.fetch("effect:one").fetch(:result).fetch(:values).frozen?
+    assert snapshot.metadata.fetch(:labels).frozen?
+  end
+
+  def test_runtime_snapshot_rejects_non_json_safe_extension_metadata
+    error = assert_raises(ArgumentError) do
+      DAG::RuntimeSnapshot[
+        workflow_id: "wf",
+        revision: 1,
+        node_id: :node,
+        attempt_id: "wf/1",
+        attempt_number: 1,
+        metadata: {bad: Object.new}
+      ]
+    end
+
+    assert_match(/non JSON-safe value/, error.message)
+  end
+
+  def test_runtime_snapshot_predecessors_use_current_revision_projection_for_preserved_nodes
+    storage = DAG::Adapters::Memory::Storage.new
+    observed_snapshots = []
+    observed_contexts = []
+    registry = registry_with_sink(observed_snapshots, observed_contexts)
+    definition = DAG::Workflow::Definition.new
+      .add_node(:source, type: :source)
+      .add_node(:sink, type: :sink)
+      .add_edge(:source, :sink)
+    workflow_id = create_workflow(storage, definition)
+    commit_node(storage, workflow_id, 1, :source)
+    storage.transition_workflow_state(id: workflow_id, from: :pending, to: :paused)
+
+    storage.append_revision(
+      id: workflow_id,
+      parent_revision: 1,
+      definition: definition,
+      invalidated_node_ids: [:sink],
+      event: nil
+    )
+    result = build_runner(storage: storage, registry: registry).resume(workflow_id)
+
+    assert_equal :completed, result.state
+    assert_empty storage.list_attempts(workflow_id: workflow_id, revision: 2, node_id: :source)
+    snapshot = observed_snapshots.fetch(0)
+    assert_equal 2, snapshot.revision
+    assert_equal({value: :source, context_patch: {source: true}, metadata: {}}, snapshot.predecessors.fetch(:source))
+    assert_equal({source: true}, observed_contexts.fetch(0))
+  end
+
+  def test_runtime_snapshot_effects_do_not_leak_across_nodes
+    storage = DAG::Adapters::Memory::Storage.new
+    intent = effect_intent(key: "node-a")
+    observed_b_effects = []
+    registry = DAG::StepTypeRegistry.new
+    wait_class = Class.new(DAG::Step::Base) do
+      define_method(:call) do |_input|
+        DAG::Waiting[reason: :effect_pending, proposed_effects: [intent]]
+      end
+    end
+    capture_class = Class.new(DAG::Step::Base) do
+      define_method(:call) do |input|
+        observed_b_effects << input.runtime_snapshot.effects
+        DAG::Success[value: :b, context_patch: {}]
+      end
+    end
+    registry.register(name: :wait, klass: wait_class, fingerprint_payload: {v: 1})
+    registry.register(name: :capture, klass: capture_class, fingerprint_payload: {v: 1})
+    registry.freeze!
+    definition = DAG::Workflow::Definition.new
+      .add_node(:a, type: :wait)
+      .add_node(:b, type: :capture)
+    workflow_id = create_workflow(storage, definition)
+
+    result = build_runner(storage: storage, registry: registry).call(workflow_id)
+
+    assert_equal :waiting, result.state
+    assert_empty observed_b_effects.fetch(0)
+    assert_equal 1, storage.list_effects_for_node(workflow_id: workflow_id, revision: 1, node_id: :a).size
+  end
+
+  def test_runtime_snapshot_effects_are_scoped_to_current_node_revision
+    storage = DAG::Adapters::Memory::Storage.new
+    snapshots = []
+    intent = effect_intent(key: "approval")
+    registry = DAG::StepTypeRegistry.new
+    klass = Class.new(DAG::Step::Base) do
+      define_method(:call) do |input|
+        snapshots << input.runtime_snapshot
+        if snapshots.size == 1
+          DAG::Waiting[reason: :effect_pending, proposed_effects: [intent]]
+        else
+          DAG::Success[value: :rerun, context_patch: {}]
+        end
+      end
+    end
+    registry.register(name: :effectful, klass: klass, fingerprint_payload: {v: 1})
+    registry.freeze!
+    definition = DAG::Workflow::Definition.new.add_node(:node, type: :effectful)
+    workflow_id = create_workflow(storage, definition)
+
+    first = build_runner(storage: storage, registry: registry).call(workflow_id)
+    assert_equal :waiting, first.state
+    effect = storage.list_effects_for_node(workflow_id: workflow_id, revision: 1, node_id: :node).fetch(0)
+    claimed = storage.claim_ready_effects(limit: 1, owner_id: "worker", lease_ms: 500, now_ms: 1_000)
+    assert_equal [effect.id], claimed.map(&:id)
+
+    storage.append_revision(
+      id: workflow_id,
+      parent_revision: 1,
+      definition: definition,
+      invalidated_node_ids: [:node],
+      event: nil
+    )
+    resumed = build_runner(storage: storage, registry: registry).resume(workflow_id)
+
+    assert_equal :completed, resumed.state
+    assert_equal 1, snapshots.fetch(0).revision
+    assert_equal 2, snapshots.fetch(1).revision
+    assert_empty snapshots.fetch(1).effects
+  end
+
+  def test_runtime_snapshot_effects_exclude_lease_and_storage_fields
+    storage = DAG::Adapters::Memory::Storage.new
+    snapshots = []
+    intent = effect_intent(key: "done")
+    registry = DAG::StepTypeRegistry.new
+    klass = Class.new(DAG::Step::Base) do
+      define_method(:call) do |input|
+        snapshots << input.runtime_snapshot
+        effect_snapshot = input.runtime_snapshot.effects[intent.ref]
+        if effect_snapshot&.fetch(:status, nil) == :succeeded
+          DAG::Success[value: :ok, context_patch: {}]
+        else
+          DAG::Waiting[reason: :effect_pending, proposed_effects: [intent]]
+        end
+      end
+    end
+    registry.register(name: :await_effect, klass: klass, fingerprint_payload: {v: 1})
+    registry.freeze!
+    workflow_id = create_workflow(storage, DAG::Workflow::Definition.new.add_node(:node, type: :await_effect))
+
+    first = build_runner(storage: storage, registry: registry).call(workflow_id)
+    assert_equal :waiting, first.state
+    effect = storage.list_effects_for_node(workflow_id: workflow_id, revision: 1, node_id: :node).fetch(0)
+    mark_effect_succeeded_and_release(storage, effect.id, result: {approved: true})
+    resumed = build_runner(storage: storage, registry: registry).resume(workflow_id)
+
+    assert_equal :completed, resumed.state
+    effect_snapshot = snapshots.fetch(1).effects.fetch(intent.ref)
+    assert_equal :succeeded, effect_snapshot.fetch(:status)
+    assert_equal({approved: true}, effect_snapshot.fetch(:result))
+    refute_includes effect_snapshot.keys, :lease_owner
+    refute_includes effect_snapshot.keys, :lease_until_ms
+    refute_includes effect_snapshot.keys, :created_at_ms
+    refute_includes effect_snapshot.keys, :updated_at_ms
+  end
+
+  private
+
+  def registry_with_sink(observed_snapshots, observed_contexts)
+    registry = DAG::StepTypeRegistry.new
+    source_class = Class.new(DAG::Step::Base) do
+      def call(_input)
+        DAG::Success[value: {label: "real"}, context_patch: {shared: "real"}]
+      end
+    end
+    sink_class = Class.new(DAG::Step::Base) do
+      define_method(:call) do |input|
+        observed_snapshots << input.runtime_snapshot
+        observed_contexts << input.context.to_h
+        DAG::Success[value: :sink, context_patch: {}]
+      end
+    end
+    registry.register(name: :source, klass: source_class, fingerprint_payload: {v: 1})
+    registry.register(name: :sink, klass: sink_class, fingerprint_payload: {v: 1})
+    registry.freeze!
+    registry
+  end
+
+  def effect_intent(key:, payload: {value: 1})
+    DAG::Effects::Intent[type: "test", key: key, payload: payload, metadata: {source: "spec"}]
+  end
+
+  def mark_effect_succeeded_and_release(storage, effect_id, result:)
+    claimed = storage.claim_ready_effects(limit: 1, owner_id: "worker", lease_ms: 500, now_ms: 1_000)
+    assert_equal [effect_id], claimed.map(&:id)
+    storage.mark_effect_succeeded(
+      effect_id: effect_id,
+      owner_id: "worker",
+      result: result,
+      external_ref: "external-#{effect_id}",
+      now_ms: 1_100
+    )
+    storage.release_nodes_satisfied_by_effect(effect_id: effect_id, now_ms: 1_200)
+  end
+end


### PR DESCRIPTION
## Summary
- Add a scoped `DAG::RuntimeSnapshot` exposed through `StepInput` metadata.
- Scope snapshot coordinates to the current workflow, revision, node, and attempt.
- Expose deterministic predecessor outputs and current-node effect summaries without storage lease fields.
- Document the public input boundary in README and CONTRACT.md, with a runnable example.

## Implementation Notes
- Runtime snapshot data is deep-frozen at construction and fresh-copied on read.
- Effect snapshots are filtered to the current workflow/revision/node and limited to JSON-safe public metadata.
- Predecessor snapshots prefer current-revision committed projections before falling back to attempt results for the current revision.

## Verification
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/r3/scoped_step_input_test.rb TESTOPTS='--verbose'`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/r3/runtime_snapshot_example_test.rb TESTOPTS='--verbose'`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake test TEST=spec/r0/kernel_boundary_docs_test.rb TESTOPTS='--verbose'`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`
- `TMPDIR=$HOME/.tmp/ruby-dag ruby scripts/production_readiness.rb --fast`

## Review Notes
- Independent risk review completed with no blockers.
- Public artifact wording checked for internal process/persona references.

Closes #160
