### PR TITLE
test: align storage receipt contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@
   suite around G1-G13 behavior: lifecycle, state transitions, attempts,
   canonical predecessor selection, effect ledger atomicity, leases,
   waiting-node release, workflow retry, revision CAS, event ordering,
-  immutable reads, standard errors, and consumer-neutrality.
+  immutable reads, standard receipts/errors, and consumer-neutrality.
+- Storage receipt contract tests now assert the documented return shapes for
+  workflow/node transitions, revision append, workflow retry, and atomic
+  effect completion, and the port docs require every public storage method to
+  document its return value.
 
 ## 1.0.1 — 2026-05-01
 

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -280,6 +280,41 @@ type
 Code-specific entries may add fields. `:handler_raised` adds `class` and
 `message`; `:handler_bad_return` adds `class`; `:stale_lease` adds `message`.
 
+## Storage Receipts And Failure Vocabulary
+
+Public storage methods must not require consumers to infer success from `nil`
+or adapter-specific side effects. Every mutating operation returns the
+shape documented in `DAG::Ports::Storage`:
+
+- `create_workflow` -> `{id:, current_revision:}`.
+- `transition_workflow_state` -> `{id:, state:, event:}` where `event` is the
+  stamped event or `nil`.
+- `transition_node_state` -> `{workflow_id:, revision:, node_id:, state:}`.
+- `append_revision` and `append_revision_if_workflow_state` ->
+  `{id:, revision:, event:}`.
+- `begin_attempt` -> the durable attempt id string.
+- `commit_attempt` -> the stamped durable `DAG::Event`.
+- `claim_ready_effects` -> claimed `DAG::Effects::Record` snapshots.
+- `mark_effect_succeeded` and `mark_effect_failed` -> the updated
+  `DAG::Effects::Record`.
+- `complete_effect_succeeded` and `complete_effect_failed` ->
+  `{record:, released:}`.
+- `release_nodes_satisfied_by_effect` -> release receipts shaped as
+  `{workflow_id:, revision:, node_id:, attempt_id:, released_at_ms:}`.
+- `abort_running_attempts` -> aborted attempt ids.
+- `append_event` -> stamped `DAG::Event` with monotonic `seq`.
+- `prepare_workflow_retry` ->
+  `{id:, state:, reset:, workflow_retry_count:, event:}`.
+
+Storage adapters use the shared public error vocabulary for control flow:
+`DAG::UnknownWorkflowError`, `DAG::StaleStateError`,
+`DAG::StaleRevisionError`, `DAG::ConcurrentMutationError`,
+`DAG::WorkflowRetryExhaustedError`, `DAG::Effects::UnknownEffectError`,
+`DAG::Effects::IdempotencyConflictError`, and
+`DAG::Effects::StaleLeaseError`. Exception messages are diagnostics only;
+Runner and consumers must branch on classes and structured receipts rather than
+parsing adapter-specific text.
+
 ## Effect Storage Contract
 
 Effect reservation is part of the attempt commit atomic boundary:
@@ -377,7 +412,7 @@ covers these groups:
 - **G9** revision append CAS plus workflow-state guard.
 - **G10** durable event ordering and filtering.
 - **G11** immutable/fresh returned values.
-- **G12** standard error/failure vocabulary.
+- **G12** standard receipt and error/failure vocabulary.
 - **G13** no consumer-specific semantics in the storage contract.
 
 `DAG::Adapters::Memory::Storage` runs the suite in this repository. Consumer or

--- a/README.md
+++ b/README.md
@@ -248,7 +248,10 @@ taxonomy used by Delphi.
 `DAG::Testing::StorageContract::All`, a reusable G1-G13 behavioral suite for
 adapters that implement `DAG::Ports::Storage`. This repository runs it against
 `DAG::Adapters::Memory::Storage`; production adapters can include the same
-suite without depending on memory-adapter internals.
+suite without depending on memory-adapter internals. The suite asserts
+receipt shapes for mutating storage operations and the public failure
+vocabulary, so consumers branch on structured values and exception classes
+instead of adapter-specific messages.
 
 See `CONTRACT.md` for the closed event types, allowed transitions, and
 boundary contract; `docs/plans/2026-04-26-r1-deterministic-kernel.md`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ Tracked phases:
 | Effects PR3 (runner integration) | —    | Done (#153) |
 | Effects PR4 (abstract dispatcher)| —    | Done (#154) |
 | Effects PR5 (docs + release gate)| #149 | In progress (#155) |
-| V1.1 kernel hardening          | #157 | In progress (#166, #167, #168, #161) |
+| V1.1 kernel hardening          | #157 | In progress (#166, #167, #168, #169; current #162) |
 | S0 (SQLite adapter, in Delphi)   | TBD  | Next |
 | Release v1.0                     | #74  | Backlog |
 

--- a/lib/dag/ports/storage.rb
+++ b/lib/dag/ports/storage.rb
@@ -58,7 +58,7 @@ module DAG
       # @param invalidated_node_ids [Array<Symbol>] nodes whose committed
       #   results should be discarded in the new revision
       # @param event [DAG::Event, nil] optional `mutation_applied` event
-      # @return [Hash] {id:, revision:, event: stamped_event}
+      # @return [Hash] {id:, revision:, event: stamped_event_or_nil}
       # @raise [DAG::StaleRevisionError] when `parent_revision` no longer matches
       def append_revision(id:, parent_revision:, definition:, invalidated_node_ids:, event:)
         raise PortNotImplementedError
@@ -74,7 +74,7 @@ module DAG
       # @param definition [DAG::Workflow::Definition] new revision graph
       # @param invalidated_node_ids [Array<Symbol>]
       # @param event [DAG::Event, nil]
-      # @return [Hash] {id:, revision:, event: stamped_event}
+      # @return [Hash] {id:, revision:, event: stamped_event_or_nil}
       # @raise [DAG::ConcurrentMutationError] when current state is :running
       # @raise [DAG::StaleStateError] when current state is not allowed
       # @raise [DAG::StaleRevisionError] when `parent_revision` no longer matches
@@ -185,7 +185,8 @@ module DAG
       # @param result [Object] JSON-safe result
       # @param external_ref [Object, nil] JSON-safe external reference
       # @param now_ms [Integer]
-      # @return [DAG::Effects::Record]
+      # @return [DAG::Effects::Record] updated terminal record
+      # @raise [DAG::Effects::UnknownEffectError] when `effect_id` is unknown
       # @raise [DAG::Effects::StaleLeaseError] when the lease is missing, expired, or owned by another dispatcher
       def mark_effect_succeeded(effect_id:, owner_id:, result:, external_ref:, now_ms:)
         raise PortNotImplementedError
@@ -199,7 +200,8 @@ module DAG
       # @param retriable [Boolean]
       # @param not_before_ms [Integer, nil] retry delay hint for retriable failures
       # @param now_ms [Integer]
-      # @return [DAG::Effects::Record]
+      # @return [DAG::Effects::Record] updated failed record
+      # @raise [DAG::Effects::UnknownEffectError] when `effect_id` is unknown
       # @raise [DAG::Effects::StaleLeaseError] when the lease is missing, expired, or owned by another dispatcher
       def mark_effect_failed(effect_id:, owner_id:, error:, retriable:, not_before_ms:, now_ms:)
         raise PortNotImplementedError
@@ -215,7 +217,10 @@ module DAG
       # @param result [Object] JSON-safe result
       # @param external_ref [Object, nil] JSON-safe external reference
       # @param now_ms [Integer]
-      # @return [Hash] {record:, released:}
+      # @return [Hash] {record: DAG::Effects::Record, released: Array<Hash>}
+      #   Each release receipt is shaped as
+      #   {workflow_id:, revision:, node_id:, attempt_id:, released_at_ms:}.
+      # @raise [DAG::Effects::UnknownEffectError] when `effect_id` is unknown
       # @raise [DAG::Effects::StaleLeaseError] when the lease is missing, expired, or owned by another dispatcher
       def complete_effect_succeeded(effect_id:, owner_id:, result:, external_ref:, now_ms:)
         raise PortNotImplementedError
@@ -230,7 +235,10 @@ module DAG
       # @param retriable [Boolean]
       # @param not_before_ms [Integer, nil] retry delay hint for retriable failures
       # @param now_ms [Integer]
-      # @return [Hash] {record:, released:}
+      # @return [Hash] {record: DAG::Effects::Record, released: Array<Hash>}
+      #   Each release receipt is shaped as
+      #   {workflow_id:, revision:, node_id:, attempt_id:, released_at_ms:}.
+      # @raise [DAG::Effects::UnknownEffectError] when `effect_id` is unknown
       # @raise [DAG::Effects::StaleLeaseError] when the lease is missing, expired, or owned by another dispatcher
       def complete_effect_failed(effect_id:, owner_id:, error:, retriable:, not_before_ms:, now_ms:)
         raise PortNotImplementedError
@@ -242,7 +250,9 @@ module DAG
       #
       # @param effect_id [String]
       # @param now_ms [Integer]
-      # @return [Array<Hash>] released workflow/node coordinates
+      # @return [Array<Hash>] release receipts shaped as
+      #   {workflow_id:, revision:, node_id:, attempt_id:, released_at_ms:}
+      # @raise [DAG::Effects::UnknownEffectError] when `effect_id` is unknown
       def release_nodes_satisfied_by_effect(effect_id:, now_ms:)
         raise PortNotImplementedError
       end

--- a/lib/dag/testing/storage_contract.rb
+++ b/lib/dag/testing/storage_contract.rb
@@ -22,7 +22,7 @@ module DAG::Testing::StorageContract
     G9: "revision append CAS plus workflow-state guard",
     G10: "durable event ordering and filtering",
     G11: "immutable/fresh returned values",
-    G12: "standard error/failure vocabulary",
+    G12: "standard receipt and error/failure vocabulary",
     G13: "no consumer-specific semantics in storage contract"
   }.freeze
 
@@ -75,6 +75,50 @@ module DAG::Testing::StorageContract
         attempt_number: attempt_number
       )
     end
+
+    def contract_prepared_effect(
+      workflow_id:,
+      attempt_id:,
+      node_id: :a,
+      effect_type: "contract",
+      effect_key: "effect",
+      payload: {value: 1},
+      payload_fingerprint: "fp-1",
+      blocking: true,
+      created_at_ms: 1_700_000_000_000,
+      revision: 1
+    )
+      DAG::Effects::PreparedIntent[
+        workflow_id: workflow_id,
+        revision: revision,
+        node_id: node_id,
+        attempt_id: attempt_id,
+        type: effect_type,
+        key: effect_key,
+        payload: payload,
+        payload_fingerprint: payload_fingerprint,
+        blocking: blocking,
+        created_at_ms: created_at_ms
+      ]
+    end
+
+    def contract_commit_waiting_effect(storage, workflow_id, node_id, effect_key: "effect")
+      attempt_id = contract_begin_attempt(storage, workflow_id, node_id)
+      effect = contract_prepared_effect(
+        workflow_id: workflow_id,
+        attempt_id: attempt_id,
+        node_id: node_id,
+        effect_key: effect_key
+      )
+      storage.commit_attempt(
+        attempt_id: attempt_id,
+        result: DAG::Waiting[reason: :effect_pending],
+        node_state: :waiting,
+        event: contract_event(type: :node_waiting, workflow_id: workflow_id, node_id: node_id, attempt_id: attempt_id),
+        effects: [effect]
+      )
+      storage.list_effects_for_attempt(attempt_id: attempt_id).first
+    end
   end
 end
 
@@ -84,6 +128,7 @@ require_relative "storage_contract/attempt_atomicity"
 require_relative "storage_contract/event_log"
 require_relative "storage_contract/effects"
 require_relative "storage_contract/retry"
+require_relative "storage_contract/receipts"
 require_relative "storage_contract/error_vocabulary"
 require_relative "storage_contract/consumer_boundary"
 
@@ -95,6 +140,7 @@ module DAG::Testing::StorageContract
     include EventLog
     include Effects
     include Retry
+    include Receipts
     include ErrorVocabulary
     include ConsumerBoundary
   end

--- a/lib/dag/testing/storage_contract/error_vocabulary.rb
+++ b/lib/dag/testing/storage_contract/error_vocabulary.rb
@@ -4,18 +4,18 @@ module DAG::Testing::StorageContract
   module ErrorVocabulary
     include Helpers
 
-    def test_contract_uses_standard_storage_error_classes
+    def test_contract_uses_standard_workflow_storage_error_classes
       storage = build_contract_storage
 
-      assert_raises(DAG::UnknownWorkflowError) { storage.load_workflow(id: "missing") }
+      assert_contract_error(DAG::UnknownWorkflowError) { storage.load_workflow(id: "missing") }
 
       workflow_id = contract_create_workflow(storage)
-      assert_raises(DAG::StaleStateError) do
+      assert_contract_error(DAG::StaleStateError) do
         storage.transition_workflow_state(id: workflow_id, from: :running, to: :completed)
       end
 
       next_definition = contract_definition.add_node(:c, type: :passthrough).add_edge(:b, :c)
-      assert_raises(DAG::StaleRevisionError) do
+      assert_contract_error(DAG::StaleRevisionError) do
         storage.append_revision(
           id: workflow_id,
           parent_revision: 99,
@@ -26,7 +26,7 @@ module DAG::Testing::StorageContract
       end
 
       storage.transition_workflow_state(id: workflow_id, from: :pending, to: :running)
-      assert_raises(DAG::ConcurrentMutationError) do
+      assert_contract_error(DAG::ConcurrentMutationError) do
         storage.append_revision_if_workflow_state(
           id: workflow_id,
           allowed_states: %i[paused waiting],
@@ -36,6 +36,112 @@ module DAG::Testing::StorageContract
           event: contract_event(type: :mutation_applied, workflow_id: workflow_id)
         )
       end
+    end
+
+    def test_contract_uses_standard_retry_and_effect_error_classes
+      storage = build_contract_storage
+      retry_workflow_id = contract_create_workflow(
+        storage,
+        runtime_profile: contract_runtime_profile(max_workflow_retries: 0)
+      )
+      attempt_id = contract_begin_attempt(storage, retry_workflow_id, :a)
+      storage.commit_attempt(
+        attempt_id: attempt_id,
+        result: DAG::Failure[error: {code: :boom}, retriable: false],
+        node_state: :failed,
+        event: contract_event(
+          type: :node_failed,
+          workflow_id: retry_workflow_id,
+          node_id: :a,
+          attempt_id: attempt_id
+        )
+      )
+      storage.transition_workflow_state(id: retry_workflow_id, from: :pending, to: :failed)
+
+      assert_contract_error(DAG::WorkflowRetryExhaustedError) do
+        storage.prepare_workflow_retry(id: retry_workflow_id, from: :failed, to: :pending)
+      end
+
+      assert_contract_error(DAG::Effects::UnknownEffectError) do
+        storage.mark_effect_succeeded(
+          effect_id: "missing",
+          owner_id: "worker-a",
+          result: {ok: true},
+          external_ref: nil,
+          now_ms: 1_000
+        )
+      end
+
+      lease_workflow_id = contract_create_workflow(storage)
+      leased = contract_commit_waiting_effect(storage, lease_workflow_id, :a, effect_key: "leased")
+      storage.claim_ready_effects(limit: 1, owner_id: "worker-a", lease_ms: 500, now_ms: 1_000)
+
+      assert_contract_error(DAG::Effects::StaleLeaseError) do
+        storage.mark_effect_succeeded(
+          effect_id: leased.id,
+          owner_id: "worker-b",
+          result: {ok: true},
+          external_ref: nil,
+          now_ms: 1_100
+        )
+      end
+    end
+
+    def test_contract_uses_standard_idempotency_conflict_error_class
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      first_attempt_id = contract_begin_attempt(storage, workflow_id, :a)
+      first_effect = contract_prepared_effect(
+        workflow_id: workflow_id,
+        attempt_id: first_attempt_id,
+        effect_key: "same-ref"
+      )
+      storage.commit_attempt(
+        attempt_id: first_attempt_id,
+        result: DAG::Waiting[reason: :effect_pending],
+        node_state: :waiting,
+        event: contract_event(type: :node_waiting, workflow_id: workflow_id, node_id: :a, attempt_id: first_attempt_id),
+        effects: [first_effect]
+      )
+      first_record = storage.list_effects_for_attempt(attempt_id: first_attempt_id).first
+      storage.claim_ready_effects(limit: 1, owner_id: "worker-a", lease_ms: 500, now_ms: 1_000)
+      storage.complete_effect_succeeded(
+        effect_id: first_record.id,
+        owner_id: "worker-a",
+        result: {ok: true},
+        external_ref: nil,
+        now_ms: 1_100
+      )
+
+      second_attempt_id = contract_begin_attempt(storage, workflow_id, :a, attempt_number: 2)
+      conflicting_effect = contract_prepared_effect(
+        workflow_id: workflow_id,
+        attempt_id: second_attempt_id,
+        effect_key: "same-ref",
+        payload_fingerprint: "different"
+      )
+
+      assert_contract_error(DAG::Effects::IdempotencyConflictError) do
+        storage.commit_attempt(
+          attempt_id: second_attempt_id,
+          result: DAG::Waiting[reason: :effect_pending],
+          node_state: :waiting,
+          event: contract_event(
+            type: :node_waiting,
+            workflow_id: workflow_id,
+            node_id: :a,
+            attempt_id: second_attempt_id
+          ),
+          effects: [conflicting_effect]
+        )
+      end
+    end
+
+    private
+
+    def assert_contract_error(error_class)
+      error = assert_raises(error_class) { yield }
+      assert_kind_of DAG::Error, error
     end
   end
 end

--- a/lib/dag/testing/storage_contract/receipts.rb
+++ b/lib/dag/testing/storage_contract/receipts.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+module DAG::Testing::StorageContract
+  module Receipts
+    include Helpers
+
+    def test_contract_workflow_and_node_transitions_return_documented_receipts
+      storage = build_contract_storage
+      workflow_id = SecureRandom.uuid
+      create_receipt = storage.create_workflow(
+        id: workflow_id,
+        initial_definition: contract_definition,
+        initial_context: {seed: 1},
+        runtime_profile: contract_runtime_profile
+      )
+
+      assert_receipt_keys %i[id current_revision], create_receipt
+      assert_equal workflow_id, create_receipt.fetch(:id)
+      assert_equal 1, create_receipt.fetch(:current_revision)
+
+      transition_receipt = storage.transition_workflow_state(
+        id: workflow_id,
+        from: :pending,
+        to: :running,
+        event: contract_event(type: :workflow_started, workflow_id: workflow_id)
+      )
+
+      assert_receipt_keys %i[id state event], transition_receipt
+      assert_equal workflow_id, transition_receipt.fetch(:id)
+      assert_equal :running, transition_receipt.fetch(:state)
+      assert_equal transition_receipt.fetch(:event), storage.read_events(workflow_id: workflow_id).last
+
+      eventless_workflow_id = contract_create_workflow(storage)
+      eventless_transition_receipt = storage.transition_workflow_state(
+        id: eventless_workflow_id,
+        from: :pending,
+        to: :running
+      )
+      assert_receipt_keys %i[id state event], eventless_transition_receipt
+      assert_nil eventless_transition_receipt.fetch(:event)
+
+      node_receipt = storage.transition_node_state(
+        workflow_id: workflow_id,
+        revision: 1,
+        node_id: :a,
+        from: :pending,
+        to: :running
+      )
+
+      assert_receipt_keys %i[workflow_id revision node_id state], node_receipt
+      assert_equal workflow_id, node_receipt.fetch(:workflow_id)
+      assert_equal 1, node_receipt.fetch(:revision)
+      assert_equal :a, node_receipt.fetch(:node_id)
+      assert_equal :running, node_receipt.fetch(:state)
+    end
+
+    def test_contract_revision_append_operations_return_documented_receipts
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      next_definition = contract_definition.add_node(:c, type: :passthrough).add_edge(:b, :c)
+
+      append_receipt = storage.append_revision(
+        id: workflow_id,
+        parent_revision: 1,
+        definition: next_definition,
+        invalidated_node_ids: [:b],
+        event: contract_event(type: :mutation_applied, workflow_id: workflow_id)
+      )
+
+      assert_receipt_keys %i[id revision event], append_receipt
+      assert_equal workflow_id, append_receipt.fetch(:id)
+      assert_equal 2, append_receipt.fetch(:revision)
+      assert_equal :mutation_applied, append_receipt.fetch(:event).type
+
+      eventless_workflow_id = contract_create_workflow(storage)
+      eventless_receipt = storage.append_revision(
+        id: eventless_workflow_id,
+        parent_revision: 1,
+        definition: next_definition,
+        invalidated_node_ids: [],
+        event: nil
+      )
+      assert_receipt_keys %i[id revision event], eventless_receipt
+      assert_nil eventless_receipt.fetch(:event)
+
+      guarded_workflow_id = contract_create_workflow(storage)
+      guarded_receipt = storage.append_revision_if_workflow_state(
+        id: guarded_workflow_id,
+        allowed_states: [:pending],
+        parent_revision: 1,
+        definition: next_definition,
+        invalidated_node_ids: [:b],
+        event: contract_event(type: :mutation_applied, workflow_id: guarded_workflow_id)
+      )
+
+      assert_receipt_keys %i[id revision event], guarded_receipt
+      assert_equal guarded_workflow_id, guarded_receipt.fetch(:id)
+      assert_equal 2, guarded_receipt.fetch(:revision)
+      assert_equal :mutation_applied, guarded_receipt.fetch(:event).type
+    end
+
+    def test_contract_workflow_retry_returns_documented_receipt
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(
+        storage,
+        runtime_profile: contract_runtime_profile(max_workflow_retries: 1)
+      )
+      attempt_id = contract_begin_attempt(storage, workflow_id, :a)
+      storage.commit_attempt(
+        attempt_id: attempt_id,
+        result: DAG::Failure[error: {code: :boom}, retriable: false],
+        node_state: :failed,
+        event: contract_event(type: :node_failed, workflow_id: workflow_id, node_id: :a, attempt_id: attempt_id)
+      )
+      storage.transition_workflow_state(id: workflow_id, from: :pending, to: :failed)
+
+      retry_receipt = storage.prepare_workflow_retry(
+        id: workflow_id,
+        from: :failed,
+        to: :pending,
+        event: contract_event(type: :workflow_started, workflow_id: workflow_id)
+      )
+
+      assert_receipt_keys %i[id state reset workflow_retry_count event], retry_receipt
+      assert_equal workflow_id, retry_receipt.fetch(:id)
+      assert_equal :pending, retry_receipt.fetch(:state)
+      assert_equal [:a], retry_receipt.fetch(:reset)
+      assert_equal 1, retry_receipt.fetch(:workflow_retry_count)
+      assert_equal retry_receipt.fetch(:event), storage.read_events(workflow_id: workflow_id).last
+    end
+
+    def test_contract_effect_completion_returns_documented_receipts
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      succeeded = contract_commit_waiting_effect(storage, workflow_id, :a, effect_key: "succeeded")
+      storage.claim_ready_effects(limit: 1, owner_id: "worker-a", lease_ms: 500, now_ms: 1_000)
+
+      success_receipt = storage.complete_effect_succeeded(
+        effect_id: succeeded.id,
+        owner_id: "worker-a",
+        result: {ok: true},
+        external_ref: "external-1",
+        now_ms: 1_100
+      )
+
+      assert_receipt_keys %i[record released], success_receipt
+      assert_equal :succeeded, success_receipt.fetch(:record).status
+      assert_equal 1, success_receipt.fetch(:released).size
+      assert_receipt_keys(
+        %i[workflow_id revision node_id attempt_id released_at_ms],
+        success_receipt.fetch(:released).first
+      )
+
+      failed = contract_commit_waiting_effect(storage, workflow_id, :b, effect_key: "failed")
+      storage.claim_ready_effects(limit: 1, owner_id: "worker-b", lease_ms: 500, now_ms: 2_000)
+      failure_receipt = storage.complete_effect_failed(
+        effect_id: failed.id,
+        owner_id: "worker-b",
+        error: {code: :terminal},
+        retriable: false,
+        not_before_ms: nil,
+        now_ms: 2_100
+      )
+
+      assert_receipt_keys %i[record released], failure_receipt
+      assert_equal :failed_terminal, failure_receipt.fetch(:record).status
+      assert_equal 1, failure_receipt.fetch(:released).size
+      assert_receipt_keys(
+        %i[workflow_id revision node_id attempt_id released_at_ms],
+        failure_receipt.fetch(:released).first
+      )
+    end
+
+    private
+
+    def assert_receipt_keys(expected, receipt)
+      assert_equal expected.sort, receipt.keys.sort
+    end
+  end
+end

--- a/spec/r0/kernel_boundary_docs_test.rb
+++ b/spec/r0/kernel_boundary_docs_test.rb
@@ -63,6 +63,18 @@ class R0KernelBoundaryDocsTest < Minitest::Test
     assert_includes normalized_contract, "does not expose lease owners, lease deadlines, storage timestamps, unrelated node attempts, or consumer runtime objects"
   end
 
+  def test_contract_documents_storage_receipts_and_error_vocabulary
+    contract = File.read(File.join(ROOT, "CONTRACT.md"))
+    normalized_contract = normalized(contract)
+
+    assert_includes normalized_contract, "## Storage Receipts And Failure Vocabulary"
+    assert_includes normalized_contract, "`transition_node_state` -> `{workflow_id:, revision:, node_id:, state:}`"
+    assert_includes normalized_contract, "`complete_effect_succeeded` and `complete_effect_failed` -> `{record:, released:}`"
+    assert_includes normalized_contract, "`prepare_workflow_retry` -> `{id:, state:, reset:, workflow_retry_count:, event:}`"
+    assert_includes normalized_contract, "Exception messages are diagnostics only"
+    assert_includes normalized_contract, "Runner and consumers must branch on classes and structured receipts"
+  end
+
   def test_readme_explains_production_ports_and_consumer_adapters
     readme = File.read(File.join(ROOT, "README.md"))
     normalized_readme = normalized(readme)

--- a/spec/r0/ports_test.rb
+++ b/spec/r0/ports_test.rb
@@ -8,19 +8,59 @@ class R0PortsTest < Minitest::Test
     load_workflow: {id: "x"},
     transition_workflow_state: {id: "x", from: :pending, to: :running},
     append_revision: {id: "x", parent_revision: 1, definition: nil, invalidated_node_ids: [], event: nil},
+    append_revision_if_workflow_state: {
+      id: "x",
+      allowed_states: [:pending],
+      parent_revision: 1,
+      definition: nil,
+      invalidated_node_ids: [],
+      event: nil
+    },
     load_revision: {id: "x", revision: 1},
     load_current_definition: {id: "x"},
     load_node_states: {workflow_id: "x", revision: 1},
     transition_node_state: {workflow_id: "x", revision: 1, node_id: :a, from: :pending, to: :running},
     begin_attempt: {workflow_id: "x", revision: 1, node_id: :a, expected_node_state: :pending, attempt_number: 1},
     commit_attempt: {attempt_id: "x", result: nil, node_state: :committed, event: nil},
+    list_effects_for_node: {workflow_id: "x", revision: 1, node_id: :a},
+    list_effects_for_attempt: {attempt_id: "x"},
+    claim_ready_effects: {limit: 1, owner_id: "worker", lease_ms: 1, now_ms: 1},
+    mark_effect_succeeded: {effect_id: "x", owner_id: "worker", result: {}, external_ref: nil, now_ms: 1},
+    mark_effect_failed: {effect_id: "x", owner_id: "worker", error: {}, retriable: true, not_before_ms: nil, now_ms: 1},
+    complete_effect_succeeded: {effect_id: "x", owner_id: "worker", result: {}, external_ref: nil, now_ms: 1},
+    complete_effect_failed: {effect_id: "x", owner_id: "worker", error: {}, retriable: false, not_before_ms: nil, now_ms: 1},
+    release_nodes_satisfied_by_effect: {effect_id: "x", now_ms: 1},
     abort_running_attempts: {workflow_id: "x"},
     list_attempts: {workflow_id: "x"},
+    list_committed_results_for_predecessors: {workflow_id: "x", revision: 1, predecessors: []},
     count_attempts: {workflow_id: "x", revision: 1, node_id: :a},
     append_event: {workflow_id: "x", event: nil},
     read_events: {workflow_id: "x"},
     prepare_workflow_retry: {id: "x"}
   }.freeze
+
+  ROOT = File.expand_path("../..", __dir__)
+
+  def test_storage_port_method_list_matches_documented_contract
+    assert_equal STORAGE_METHODS.keys.sort, DAG::Ports::Storage.public_instance_methods(false).sort
+  end
+
+  def test_storage_port_public_methods_document_return_shapes
+    source = File.read(File.join(ROOT, "lib/dag/ports/storage.rb"))
+
+    STORAGE_METHODS.each_key do |method_name|
+      method_documentation = source.match(/((?:\s*#.*\n)+)\s*def #{method_name}\(/)
+      refute_nil method_documentation, "#{method_name} should have a documentation block"
+      assert_includes method_documentation[1], "@return", "#{method_name} should document its return shape"
+    end
+  end
+
+  def test_runner_does_not_parse_storage_error_messages
+    runner = File.read(File.join(ROOT, "lib/dag/runner.rb"))
+    storage_error_rescue = /rescue\s+(?:DAG::)?(?:StaleStateError|StaleRevisionError|ConcurrentMutationError|WorkflowRetryExhaustedError)[^\n]*=>\s*(\w+)(?:.|\n){0,200}\1\.message/
+
+    refute_match storage_error_rescue, runner
+  end
 
   def test_storage_port_every_method_raises_port_not_implemented
     adapter = Class.new { include DAG::Ports::Storage }.new


### PR DESCRIPTION
## Summary
- Adds reusable storage contract coverage for documented receipt shapes across workflow/node transitions, revision appends, workflow retry, and effect completion.
- Extends the shared storage contract failure-vocabulary tests for stale state, stale revision, concurrent mutation, retry exhaustion, stale lease, unknown effects, and idempotency conflict.
- Tightens `DAG::Ports::Storage` documentation so every public storage method has an explicit return shape, and documents that exception messages are diagnostics rather than control-flow inputs.
- Updates README, CONTRACT, CHANGELOG, and ROADMAP notes for the V1.1 storage contract closeout.

## Verification
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec ruby -Itest -Ilib spec/r2/memory_storage_contract_test.rb spec/r0/ports_test.rb spec/r0/kernel_boundary_docs_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`
- `TMPDIR=$HOME/.tmp/ruby-dag ruby scripts/production_readiness.rb --fast`

Closes #162
