### PR TITLE
[V1.1] Release gate and consumer compatibility matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,39 @@
 
 ## Unreleased
 
+- No changes yet.
+
+## 1.1.0 — 2026-05-03
+
+V1.1 is a contract hardening release for durable consumers. RD-01 through RD-08
+are complete, and this release contains no Delphi-specific implementation:
+consumer repositories own concrete storage adapters, handlers, planning policy,
+escalation policy, and product semantics.
+
 ### Added
 
-- `DAG::Testing::StorageContract::All` now groups the reusable storage adapter conformance
-  suite around G1-G13 behavior: lifecycle, state transitions, attempts,
-  canonical predecessor selection, effect ledger atomicity, leases,
-  waiting-node release, workflow retry, revision CAS, event ordering,
-  immutable reads, standard receipts/errors, and consumer-neutrality.
-- Storage receipt contract tests now assert the documented return shapes for
-  workflow/node transitions, revision append, workflow retry, and atomic
-  effect completion, and the port docs require every public storage method to
-  document its return value.
+- `DAG::RuntimeSnapshot` exposes immutable, JSON-safe workflow/revision/node
+  coordinates plus scoped predecessor and effect snapshots for custom steps.
 - `DAG::TraceRecord`, `DAG::NodeDiagnostic`, and `DAG::Diagnostics` now expose
   immutable, JSON-safe trace/node diagnostic values derived from durable events,
   attempts, node state, and effect records.
+- `DAG::Testing::StorageContract::All` now groups the reusable storage adapter
+  conformance suite around G1-G13 behavior: lifecycle, state transitions,
+  attempts, canonical predecessor selection, effect ledger atomicity, leases,
+  waiting-node release, workflow retry, revision CAS, event ordering,
+  immutable reads, standard receipts/errors, and consumer-neutrality.
+- A V1.1 consumer compatibility matrix documents stable kernel APIs and the
+  required/recommended/optional durable adapter extension checklist.
+
+### Changed
+
+- Storage receipt contract tests now assert the documented return shapes for
+  workflow/node transitions, revision append, workflow retry, and atomic effect
+  completion, and the port docs require every public storage method to document
+  its return value.
+- Bounded recovery controls are explicitly documented and covered: retry
+  exhaustion, waiting, and paused states are bounded kernel outcomes; consumers
+  own escalation, alerting, approval, backoff, and replacement workflows.
 
 ## 1.0.1 — 2026-05-01
 

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -480,6 +480,80 @@ covers these groups:
 production adapters can reuse the same module to prove conformance without
 copying memory-adapter implementation details into their own tests.
 
+## V1.1 Consumer Compatibility Matrix
+
+V1.1 is a contract release. Stable consumer APIs are the public kernel boundary
+that durable hosts can adopt without depending on memory-adapter internals:
+
+- `DAG::Runner#call`, `DAG::Runner#resume`, and
+  `DAG::Runner#retry_workflow` for pending, recovery, and explicit retry
+  entry points.
+- `DAG::Workflow::Definition`, `DAG::PlanVersion`, `DAG::RuntimeProfile`,
+  `DAG::Success`, `DAG::Waiting`, `DAG::Failure`, and `DAG::StepInput` for
+  immutable workflow data and result transport.
+- `DAG::RuntimeSnapshot` for step-visible workflow/revision/node coordinates,
+  canonical predecessor values, and scoped effect snapshots.
+- `DAG::Effects::{Intent, PreparedIntent, Record, HandlerResult,
+  DispatchReport}` and `DAG::Effects::Dispatcher` for abstract effect
+  reservation and dispatch coordination.
+- `DAG::TraceRecord`, `DAG::NodeDiagnostic`, and `DAG::Diagnostics` for
+  consumer-facing trace and node state projection.
+- `DAG::DefinitionEditor` and `DAG::MutationService` for immutable structural
+  planning and guarded mutation application.
+- `DAG::Testing::StorageContract::All` for reusable storage conformance.
+
+Durable adapter adoption checklist:
+
+### Required for durable adapters
+
+- Persist workflows, definition revisions, node states, attempts, effect
+  records, attempt-effect links, and event logs durably and atomically at the
+  documented boundaries.
+- Implement the full `DAG::Ports::Storage` method set and return the documented
+  receipt shapes for every mutating operation.
+- Preserve the public failure vocabulary: `UnknownWorkflowError`,
+  `StaleStateError`, `StaleRevisionError`, `ConcurrentMutationError`,
+  `WorkflowRetryExhaustedError`, `Effects::UnknownEffectError`,
+  `Effects::IdempotencyConflictError`, and `Effects::StaleLeaseError`.
+- Bind workflow terminal state transitions and their durable events in one
+  storage boundary through `transition_workflow_state(..., event:)`.
+- Bind retry state CAS, retry-budget enforcement, failed-node reset, aborted
+  failed attempts, workflow state transition, and optional event append inside
+  `prepare_workflow_retry`.
+- Bind mutation workflow-state guard and revision CAS inside
+  `append_revision_if_workflow_state`.
+- Make `commit_attempt` one-shot and persist attempt result, node state, event,
+  and effect reservations in one logical transaction.
+- Implement effect claim/lease/completion semantics, including atomic terminal
+  completion with waiting-node release through `complete_effect_succeeded` and
+  `complete_effect_failed`.
+- Return immutable or fresh values from all read methods so consumers cannot
+  mutate adapter state through returned objects.
+- Run `DAG::Testing::StorageContract::All` against the adapter and keep all
+  G1-G13 groups passing.
+
+### Recommended for durable adapters
+
+- Implement `list_committed_results_for_predecessors` so runners can load
+  canonical predecessor results and carried-forward committed projections in a
+  single adapter-owned query.
+- Namespace effect keys by workflow, revision, and node at the consumer edge so
+  global `(type, key)` effect identity cannot collide across workflow runs.
+- Store enough indexed event, attempt, node, and effect data for
+  `DAG::Diagnostics.trace_records` and `DAG::Diagnostics.node_diagnostics` to
+  remain cheap and deterministic.
+- Treat retry exhaustion, waiting, and paused workflows as bounded kernel
+  outcomes and expose consumer-owned alerting, approval, backoff, and
+  replacement-workflow policy outside the adapter.
+
+### Optional for simple consumers
+
+- Use `DAG::Toolkit.in_memory_kit` and `DAG::Adapters::Memory::Storage` for
+  single-process examples, tests, or ephemeral scripts.
+- Omit concrete effect handlers when workflows do not use `proposed_effects`.
+- Skip live event-bus publication by injecting `DAG::Adapters::Null::EventBus`
+  when durable event-log reads are sufficient.
+
 ## Execution Context
 
 Execution context is a copy-on-write dictionary managed by the kernel. Keys and

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-dag (1.0.1)
+    ruby-dag (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -279,12 +279,31 @@ See `CONTRACT.md` for the closed event types, allowed transitions, and
 boundary contract; `docs/plans/2026-04-26-r1-deterministic-kernel.md`
 for the R1 implementation notes.
 
+## Compatibility matrix
+
+The V1.1 contract release hardens the kernel boundary for durable consumers.
+`CONTRACT.md` now lists stable consumer APIs plus the
+required/recommended/optional port extension checklist for durable adapters.
+Use it as the adoption checklist for Delphi's SQLite adapter and for any other
+consumer-owned storage implementation.
+
+Stable V1.1 surfaces include:
+
+- `DAG::Runner#call`, `#resume`, and `#retry_workflow`.
+- Immutable workflow/result values such as `DAG::Workflow::Definition`,
+  `DAG::PlanVersion`, `DAG::RuntimeProfile`, `DAG::Success`, `DAG::Waiting`,
+  `DAG::Failure`, and `DAG::StepInput`.
+- `DAG::RuntimeSnapshot`, `DAG::TraceRecord`, `DAG::NodeDiagnostic`, and
+  `DAG::Diagnostics` for runtime input and diagnostics projection.
+- `DAG::Testing::StorageContract::All` for adapter conformance against G1-G13.
+
 ## Status
 
-R0-R3 and the effect-aware kernel work have landed. The `1.0.0` release
-gate is tracked in #74. S0 is the first SQLite storage adapter, but it
-lives in the Delphi consumer (`nexus`, branch `delphi-v1`) and implements
-this repo's public `DAG::Ports::Storage` contract.
+V1.1 kernel hardening is complete. R0-R3, the effect-aware kernel work, and
+RD-01 through RD-08 of #157 have landed as a contract release with no
+consumer-specific implementation in this repository. S0 remains the first
+SQLite storage adapter, but it lives in the Delphi consumer and implements this
+repo's public `DAG::Ports::Storage` contract.
 
 Roadmap board: <https://github.com/users/duncanita/projects/2>.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,10 +39,11 @@ Tracked phases:
 | Effects PR2 (storage ledger)     | —    | Done (#152) |
 | Effects PR3 (runner integration) | —    | Done (#153) |
 | Effects PR4 (abstract dispatcher)| —    | Done (#154) |
-| Effects PR5 (docs + release gate)| #149 | In progress (#155) |
-| V1.1 kernel hardening          | #157 | In progress (#166, #167, #168, #169, #170; current #163) |
+| Effects PR5 (docs + release gate)| #149 | Done (#155) |
+| V1.1 kernel hardening          | #157 | Done (#158-#164 via #166, #167, #168, #169, #170, #171, #172) |
+| Release v1.1                   | #165 | Done |
 | S0 (SQLite adapter, in Delphi)   | TBD  | Next |
-| Release v1.0                     | #74  | Backlog |
+| Release v1.0                     | #74  | Done (#126, #156) |
 
 S0 is no longer a phase of `ruby-dag` itself: per execution-plan §5, the
 first durable storage adapter lives in the `Delphi` consumer (in repo

--- a/lib/dag/version.rb
+++ b/lib/dag/version.rb
@@ -2,5 +2,5 @@
 
 module DAG
   # Library version. Bumped per release; see `CHANGELOG.md`.
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 end

--- a/spec/r0/v1_1_release_gate_test.rb
+++ b/spec/r0/v1_1_release_gate_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class R0V11ReleaseGateTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def normalized(path)
+    File.read(File.join(ROOT, path)).split.join(" ")
+  end
+
+  def normalized_section(path, start_marker, end_marker)
+    text = File.read(File.join(ROOT, path))
+    text.fetch_after(start_marker).fetch_before(end_marker).split.join(" ")
+  end
+
+  def test_version_is_bumped_to_contract_release
+    assert_equal "1.1.0", DAG::VERSION
+  end
+
+  def test_changelog_contains_v1_1_contract_release_notes
+    changelog = normalized("CHANGELOG.md")
+
+    assert_includes changelog, "## 1.1.0 — 2026-05-03"
+    assert_includes changelog, "V1.1 is a contract hardening release"
+    assert_includes changelog, "contains no Delphi-specific implementation"
+    assert_includes changelog, "RD-01 through RD-08 are complete"
+    assert_includes changelog, "DAG::RuntimeSnapshot"
+    assert_includes changelog, "DAG::TraceRecord"
+    assert_includes changelog, "DAG::NodeDiagnostic"
+    assert_includes changelog, "DAG::Testing::StorageContract::All"
+    assert_includes changelog, "Bounded recovery controls"
+  end
+
+  def test_contract_lists_stable_consumer_apis_and_port_extension_checklist
+    contract = normalized("CONTRACT.md")
+
+    assert_includes contract, "## V1.1 Consumer Compatibility Matrix"
+    assert_includes contract, "Stable consumer APIs"
+    assert_includes contract, "DAG::Runner#call"
+    assert_includes contract, "DAG::Runner#resume"
+    assert_includes contract, "DAG::Runner#retry_workflow"
+    assert_includes contract, "DAG::RuntimeSnapshot"
+    assert_includes contract, "DAG::TraceRecord"
+    assert_includes contract, "DAG::NodeDiagnostic"
+    assert_includes contract, "DAG::Testing::StorageContract::All"
+    assert_includes contract, "Required for durable adapters"
+    assert_includes contract, "Recommended for durable adapters"
+    assert_includes contract, "Optional for simple consumers"
+    assert_includes contract, "Durable adapter adoption checklist"
+  end
+
+  def test_readme_and_roadmap_reflect_v1_1_release_state
+    readme = normalized("README.md")
+    roadmap = normalized("ROADMAP.md")
+
+    assert_includes readme, "V1.1 contract release"
+    assert_includes readme, "Compatibility matrix"
+    assert_includes readme, "Delphi's SQLite adapter"
+    assert_includes roadmap, "V1.1 kernel hardening"
+    assert_includes roadmap, "Done (#158-#164 via #166, #167, #168, #169, #170, #171, #172)"
+    assert_includes roadmap, "Release v1.1"
+    assert_includes roadmap, "Done"
+  end
+end


### PR DESCRIPTION
## Summary

- bump the gem release metadata to `1.1.0`
- add V1.1 release notes that state this is a contract hardening release with no Delphi-specific implementation
- document the stable V1.1 consumer API surface and durable adapter checklist in `CONTRACT.md`
- update README/ROADMAP status for the completed V1.1 kernel hardening sequence
- add a release-gate regression spec for version, release notes, compatibility matrix, README, and roadmap coverage

Closes #165.
Part of #157.

## Verification

- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec ruby -Ilib -Ispec spec/r0/v1_1_release_gate_test.rb`
- `TMPDIR=$HOME/.tmp/ruby-dag bundle exec rake`
- `TMPDIR=$HOME/.tmp/ruby-dag ruby scripts/production_readiness.rb --fast`

## Independent risk review

- Completed before opening the PR.
- Result: no blockers.
- Follow-up applied: ROADMAP now lists the closed V1.1 sub-issues `#158-#164` as well as the merged PR sequence `#166-#172` for auditability.
