### PR TITLE
Harden V1.1 API-stable contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
-- No changes yet.
+- Hardened runtime profile, memory storage, and event values against mutable
+  workflow, attempt, and event-bus-kind inputs without changing public API
+  signatures.
+- Clarified effect key examples to avoid `:` inside consumer-owned `type` and
+  `key` parts, preserving the unambiguous `type:key` record identity, and
+  refreshed stale execution-plan wording as historical reference.
+- Added API-stability guard tests for release documentation, runtime profile
+  compatibility, and legacy mutation storage adapters.
 
 ## 1.1.0 — 2026-05-03
 

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -691,9 +691,9 @@ transitions that have no associated event (e.g. `:pending -> :running` in
 idempotent path that scans the event log).
 
 This is a port extension over the canonical roadmap signature
-`(id:, from:, to:)`. See `CLAUDE.md` "Port extensions" for the full
-justification. SQLite (S0) implements the same atomicity via a single
-transaction.
+`(id:, from:, to:)`. The justification is the crash-resume invariant above:
+workflow state and its corresponding terminal event must be durable together.
+SQLite (S0) implements the same atomicity via a single transaction.
 
 `prepare_workflow_retry` is the atomic durability boundary for explicit
 workflow retry:

--- a/Delphi Ruby DAG Execution Plan.md
+++ b/Delphi Ruby DAG Execution Plan.md
@@ -143,22 +143,20 @@ module DAG
       end
 
       def initialize(type:, key:, payload: {}, metadata: {})
-        raise ArgumentError, "type must be String" unless type.is_a?(String)
-        raise ArgumentError, "key must be String" unless key.is_a?(String)
+        DAG::Effects.validate_ref_part!(type, "type")
+        DAG::Effects.validate_ref_part!(key, "key")
         DAG.json_safe!(payload, "$root.payload")
         DAG.json_safe!(metadata, "$root.metadata")
 
         super(
-          type: type.freeze,
-          key: key.freeze,
-          payload: DAG.deep_freeze(DAG.deep_dup(payload)),
-          metadata: DAG.deep_freeze(DAG.deep_dup(metadata))
+          type: DAG.frozen_copy(type),
+          key: DAG.frozen_copy(key),
+          payload: DAG.frozen_copy(payload),
+          metadata: DAG.frozen_copy(metadata)
         )
       end
 
-      def ref
-        "#{type}:#{key}"
-      end
+      def ref = DAG::Effects.ref_for(type, key)
     end
   end
 end
@@ -190,6 +188,10 @@ Esempio:
 ```text
 delphi/v1/wf/<workflow_id>/rev/<revision>/node/<node_id>/planner/<prompt_fingerprint>
 ```
+
+Usare delimitatori interni diversi da `:` nella `key`: il kernel riserva `:`
+per costruire `ref = "#{type}:#{key}"`, quindi `type` e `key` devono restare
+parti non ambigue e prive di `:`.
 
 Usare delimitatori interni diversi da `:` nella `key`: il kernel riserva `:`
 per costruire `ref = "#{type}:#{key}"`, quindi `type` e `key` devono restare
@@ -1106,7 +1108,7 @@ Grep obbligatori:
 ```bash
 ! grep -R "require ['\"]dag['\"]" lib spec
 ! grep -R "Delphic\|delphic" lib spec
-! grep -R "Net::HTTP\|Faraday\|HTTParty\|LLMProviderClient\|Github\|Mail" lib/delphi/steps spec/delphi/steps
+! grep -R "Net::HTTP\|Faraday\|HTTParty\|OpenAI\|Github\|Mail" lib/delphi/steps spec/delphi/steps
 ```
 
 La presenza di client esterni è ammessa solo sotto:
@@ -1171,7 +1173,7 @@ Non implementare:
 - Idempotency key basate su timestamp casuali.
 - Idempotency key basate su attempt_number per effetti semantici.
 - Dipendenza non pinnata da branch main in produzione.
-- Adapter concreti per provider LLM/GitHub/email dentro ruby-dag.
+- Adapter concreti OpenAI/GitHub/email dentro ruby-dag.
 - Transizioni node/workflow fuori dal port storage.
 - Dispatcher che completa direttamente lo step senza passare dal runner.
 ```

--- a/Delphi Ruby DAG Execution Plan.md
+++ b/Delphi Ruby DAG Execution Plan.md
@@ -188,8 +188,12 @@ semantic_input_fingerprint
 Esempio:
 
 ```text
-delphi:v1:wf:<workflow_id>:rev:<revision>:node:<node_id>:planner:<prompt_fingerprint>
+delphi/v1/wf/<workflow_id>/rev/<revision>/node/<node_id>/planner/<prompt_fingerprint>
 ```
+
+Usare delimitatori interni diversi da `:` nella `key`: il kernel riserva `:`
+per costruire `ref = "#{type}:#{key}"`, quindi `type` e `key` devono restare
+parti non ambigue e prive di `:`.
 
 ---
 
@@ -963,13 +967,13 @@ class Delphi::Steps::PlannerStep < DAG::Step::Base
     intent = DAG::Effects::Intent[
       type: "delphi.llm.chat_completion",
       key: [
-        "delphi:v1",
-        "wf:#{input.metadata.fetch(:workflow_id)}",
-        "rev:#{input.metadata.fetch(:revision)}",
-        "node:#{input.node_id}",
+        "delphi", "v1",
+        "wf", input.metadata.fetch(:workflow_id),
+        "rev", input.metadata.fetch(:revision),
+        "node", input.node_id,
         "planner",
-        "prompt:#{prompt_fingerprint}"
-      ].join(":"),
+        "prompt", prompt_fingerprint
+      ].join("/"),
       payload: {
         model: config.fetch(:model),
         messages: prompt,
@@ -1102,7 +1106,7 @@ Grep obbligatori:
 ```bash
 ! grep -R "require ['\"]dag['\"]" lib spec
 ! grep -R "Delphic\|delphic" lib spec
-! grep -R "Net::HTTP\|Faraday\|HTTParty\|OpenAI\|Github\|Mail" lib/delphi/steps spec/delphi/steps
+! grep -R "Net::HTTP\|Faraday\|HTTParty\|LLMProviderClient\|Github\|Mail" lib/delphi/steps spec/delphi/steps
 ```
 
 La presenza di client esterni è ammessa solo sotto:
@@ -1114,9 +1118,10 @@ lib/delphi/adapters/**
 
 ---
 
-## 10. Ordine operativo per oggi
+## 10. Sequenza storica di implementazione
 
-Eseguire in questo ordine.
+Questa sezione conserva l'ordine originale di implementazione; gli elementi
+upstream sono completati per V1.1 e restano qui come riferimento storico.
 
 ### Blocco A — Upstream kernel
 
@@ -1166,7 +1171,7 @@ Non implementare:
 - Idempotency key basate su timestamp casuali.
 - Idempotency key basate su attempt_number per effetti semantici.
 - Dipendenza non pinnata da branch main in produzione.
-- Adapter concreti OpenAI/GitHub/email dentro ruby-dag.
+- Adapter concreti per provider LLM/GitHub/email dentro ruby-dag.
 - Transizioni node/workflow fuori dal port storage.
 - Dispatcher che completa direttamente lo step senza passare dal runner.
 ```

--- a/Delphi Ruby DAG Execution Plan.md
+++ b/Delphi Ruby DAG Execution Plan.md
@@ -193,10 +193,6 @@ Usare delimitatori interni diversi da `:` nella `key`: il kernel riserva `:`
 per costruire `ref = "#{type}:#{key}"`, quindi `type` e `key` devono restare
 parti non ambigue e prive di `:`.
 
-Usare delimitatori interni diversi da `:` nella `key`: il kernel riserva `:`
-per costruire `ref = "#{type}:#{key}"`, quindi `type` e `key` devono restare
-parti non ambigue e prive di `:`.
-
 ---
 
 ### 3.3 `DAG::Effects::PreparedIntent`

--- a/README.md
+++ b/README.md
@@ -147,7 +147,10 @@ reference consumer; see `Delphi Ruby DAG Execution Plan.md`) — not in
 `(type, key)` is the global semantic identity of an effect. Real keys must
 namespace by workflow/revision/node so that two workflows or two revisions
 never collide on a shared name; payload differences for the same `(type,
-key)` are rejected with `DAG::Effects::IdempotencyConflictError`.
+key)` are rejected with `DAG::Effects::IdempotencyConflictError`. `type` and
+`key` must not include `:` because `DAG::Effects::Record#ref` uses `type:key`
+as its unambiguous storage identity; use another delimiter (such as `/`) inside
+consumer-owned key strings.
 
 ### Awaited abstract effect
 
@@ -164,11 +167,11 @@ class FetchStep < DAG::Step::Base
     intent = DAG::Effects::Intent[
       type: "http_get",
       key: [
-        "wf:#{input.metadata.fetch(:workflow_id)}",
-        "rev:#{input.metadata.fetch(:revision)}",
-        "node:#{input.node_id}",
+        "wf", input.metadata.fetch(:workflow_id),
+        "rev", input.metadata.fetch(:revision),
+        "node", input.node_id,
         "fetch"
-      ].join(":"),
+      ].join("/"),
       payload: {"url" => url}
     ]
 
@@ -193,11 +196,11 @@ class NotifyStep < DAG::Step::Base
     intent = DAG::Effects::Intent[
       type: "email",
       key: [
-        "wf:#{input.metadata.fetch(:workflow_id)}",
-        "rev:#{input.metadata.fetch(:revision)}",
-        "node:#{input.node_id}",
+        "wf", input.metadata.fetch(:workflow_id),
+        "rev", input.metadata.fetch(:revision),
+        "node", input.node_id,
         "welcome"
-      ].join(":"),
+      ].join("/"),
       payload: {"to" => "user@example.com"}
     ]
     DAG::Success[value: :ok, proposed_effects: [intent]]

--- a/lib/dag/adapters/memory/storage_state.rb
+++ b/lib/dag/adapters/memory/storage_state.rb
@@ -70,6 +70,7 @@ module DAG
         # Implements `Ports::Storage#create_workflow`.
         # @api private
         def create_workflow(state, id:, initial_definition:, initial_context:, runtime_profile:)
+          id = DAG.frozen_copy(id)
           raise ArgumentError, "workflow #{id} already exists" if state[:workflows].key?(id)
           DAG::Validation.instance!(
             initial_definition,
@@ -118,6 +119,7 @@ module DAG
         # Implements `Ports::Storage#append_revision`.
         # @api private
         def append_revision(state, id:, parent_revision:, definition:, invalidated_node_ids:, event:)
+          id = DAG.frozen_copy(id)
           row = fetch_workflow!(state, id)
           unless row[:current_revision] == parent_revision
             raise StaleRevisionError,
@@ -204,6 +206,7 @@ module DAG
         # Implements `Ports::Storage#begin_attempt`.
         # @api private
         def begin_attempt(state, workflow_id:, revision:, node_id:, expected_node_state:, attempt_number:)
+          workflow_id = DAG.frozen_copy(workflow_id)
           DAG::Validation.positive_integer!(attempt_number, "attempt_number")
 
           states_for_rev = fetch_node_states!(state, workflow_id, revision)

--- a/lib/dag/event.rb
+++ b/lib/dag/event.rb
@@ -47,10 +47,10 @@ module DAG
       super(
         seq: seq,
         type: type,
-        workflow_id: workflow_id,
+        workflow_id: DAG.frozen_copy(workflow_id),
         revision: revision,
-        node_id: node_id,
-        attempt_id: attempt_id,
+        node_id: DAG.frozen_copy(node_id),
+        attempt_id: DAG.frozen_copy(attempt_id),
         at_ms: at_ms,
         payload: DAG.frozen_copy(payload)
       )

--- a/lib/dag/mutation_service.rb
+++ b/lib/dag/mutation_service.rb
@@ -53,30 +53,14 @@ module DAG
     private
 
     def append_revision_with_state_guard(id:, allowed_states:, parent_revision:, definition:, invalidated_node_ids:, event:)
-      if storage_overrides?(:append_revision_if_workflow_state)
-        return @storage.append_revision_if_workflow_state(
-          id: id,
-          allowed_states: allowed_states,
-          parent_revision: parent_revision,
-          definition: definition,
-          invalidated_node_ids: invalidated_node_ids,
-          event: event
-        )
-      end
-
-      @storage.append_revision(
+      @storage.append_revision_if_workflow_state(
         id: id,
+        allowed_states: allowed_states,
         parent_revision: parent_revision,
         definition: definition,
         invalidated_node_ids: invalidated_node_ids,
         event: event
       )
-    end
-
-    def storage_overrides?(method_name)
-      return false unless @storage.respond_to?(method_name)
-
-      @storage.method(method_name).owner != DAG::Ports::Storage
     end
 
     def guard_workflow_state!(workflow_id, state)

--- a/lib/dag/ports/storage.rb
+++ b/lib/dag/ports/storage.rb
@@ -9,6 +9,9 @@ module DAG
     # attempts, and the durable event log. Every method that returns
     # storage-owned values must return a deep-frozen value or a fresh deep
     # dup; callers must not mutate adapter state through returned objects.
+    # Implementations must also isolate mutable string coordinates before
+    # persisting them so caller-owned buffers cannot mutate storage-owned
+    # identity fields after the call returns.
     #
     # @api public
     module Storage

--- a/lib/dag/ports/storage.rb
+++ b/lib/dag/ports/storage.rb
@@ -323,8 +323,8 @@ module DAG
         raise PortNotImplementedError
       end
 
-      # Port extension (see CLAUDE.md "Port extensions"). With a CAS guard on
-      # workflow state and on the retry budget, atomically:
+      # Port extension: with a CAS guard on workflow state and on the retry
+      # budget, atomically:
       # (a) find :failed nodes for the workflow's current revision,
       # (b) mark each corresponding :failed attempt as :aborted,
       # (c) transition those nodes back to :pending,

--- a/lib/dag/runtime_profile.rb
+++ b/lib/dag/runtime_profile.rb
@@ -11,7 +11,7 @@ module DAG
       # @param durability [Symbol] one of {DURABILITY}
       # @param max_attempts_per_node [Integer] positive
       # @param max_workflow_retries [Integer] non-negative
-      # @param event_bus_kind [Symbol]
+      # @param event_bus_kind [String, Symbol]
       # @param metadata [Hash] JSON-safe
       # @return [RuntimeProfile]
       def [](durability:, max_attempts_per_node:, max_workflow_retries:, event_bus_kind:, metadata: {})
@@ -46,6 +46,7 @@ module DAG
       )
       DAG::Validation.positive_integer!(max_attempts_per_node, "max_attempts_per_node")
       DAG::Validation.nonnegative_integer!(max_workflow_retries, "max_workflow_retries")
+      DAG::Validation.string_or_symbol!(event_bus_kind, "event_bus_kind")
 
       DAG.json_safe!(metadata, "$root.metadata")
 

--- a/lib/dag/runtime_profile.rb
+++ b/lib/dag/runtime_profile.rb
@@ -53,7 +53,7 @@ module DAG
         durability: durability,
         max_attempts_per_node: max_attempts_per_node,
         max_workflow_retries: max_workflow_retries,
-        event_bus_kind: event_bus_kind,
+        event_bus_kind: DAG.frozen_copy(event_bus_kind),
         metadata: DAG.frozen_copy(metadata)
       )
     end

--- a/lib/dag/testing/storage_contract/attempt_atomicity.rb
+++ b/lib/dag/testing/storage_contract/attempt_atomicity.rb
@@ -63,6 +63,39 @@ module DAG::Testing::StorageContract
       assert_equal 7, attempt[:attempt_number]
     end
 
+    def test_contract_begin_attempt_copies_mutable_workflow_id
+      storage = build_contract_storage
+      workflow_id = +"wf-contract-attempt"
+      storage.create_workflow(
+        id: workflow_id,
+        initial_definition: contract_definition,
+        initial_context: {seed: 1},
+        runtime_profile: contract_runtime_profile
+      )
+      workflow_id << "-after-create"
+
+      attempt_workflow_id = +"wf-contract-attempt"
+      attempt_id = storage.begin_attempt(
+        workflow_id: attempt_workflow_id,
+        revision: 1,
+        node_id: :a,
+        expected_node_state: :pending,
+        attempt_number: 1
+      )
+      attempt_workflow_id << "-after-begin"
+
+      storage.commit_attempt(
+        attempt_id: attempt_id,
+        result: DAG::Success[value: :a, context_patch: {a: 1}],
+        node_state: :committed,
+        event: contract_event(workflow_id: "wf-contract-attempt", node_id: :a, attempt_id: attempt_id)
+      )
+
+      attempt = storage.list_attempts(workflow_id: "wf-contract-attempt", revision: 1, node_id: :a).first
+      assert_equal "wf-contract-attempt", attempt.fetch(:workflow_id)
+      assert_equal :committed, storage.load_node_states(workflow_id: "wf-contract-attempt", revision: 1)[:a]
+    end
+
     def test_contract_lists_committed_results_for_predecessors_in_one_call
       storage = build_contract_storage
       workflow_id = contract_create_workflow(storage)

--- a/lib/dag/testing/storage_contract/revision_cas.rb
+++ b/lib/dag/testing/storage_contract/revision_cas.rb
@@ -55,6 +55,33 @@ module DAG::Testing::StorageContract
       assert_equal result[:event], storage.read_events(workflow_id: workflow_id).last
     end
 
+    def test_contract_append_revision_copies_mutable_workflow_id
+      storage = build_contract_storage
+      workflow_id = +"wf-contract-revision"
+      storage.create_workflow(
+        id: workflow_id,
+        initial_definition: contract_definition,
+        initial_context: {seed: 1},
+        runtime_profile: contract_runtime_profile
+      )
+      workflow_id << "-after-create"
+
+      append_workflow_id = +"wf-contract-revision"
+      next_definition = contract_definition.add_node(:c, type: :passthrough).add_edge(:b, :c)
+      storage.append_revision(
+        id: append_workflow_id,
+        parent_revision: 1,
+        definition: next_definition,
+        invalidated_node_ids: [:b],
+        event: contract_event(type: :mutation_applied, workflow_id: "wf-contract-revision")
+      )
+      append_workflow_id << "-after-append"
+
+      assert_equal 2, storage.load_current_definition(id: "wf-contract-revision").revision
+      assert_equal :pending, storage.load_node_states(workflow_id: "wf-contract-revision", revision: 2)[:c]
+      assert_equal :mutation_applied, storage.read_events(workflow_id: "wf-contract-revision").last.type
+    end
+
     def test_contract_append_revision_projects_committed_results_without_synthetic_attempts
       storage = build_contract_storage
       workflow_id = contract_create_workflow(storage)

--- a/lib/dag/testing/storage_contract/workflow_lifecycle.rb
+++ b/lib/dag/testing/storage_contract/workflow_lifecycle.rb
@@ -53,5 +53,22 @@ module DAG::Testing::StorageContract
 
       assert_equal :pending, storage.load_node_states(workflow_id: workflow_id, revision: 1)[:a]
     end
+
+    def test_contract_create_workflow_copies_mutable_workflow_id
+      storage = build_contract_storage
+      workflow_id = +"wf-contract-mutable"
+      storage.create_workflow(
+        id: workflow_id,
+        initial_definition: contract_definition,
+        initial_context: {seed: 1},
+        runtime_profile: contract_runtime_profile
+      )
+      workflow_id << "-mutated"
+
+      workflow = storage.load_workflow(id: "wf-contract-mutable")
+      assert_equal "wf-contract-mutable", workflow.fetch(:id)
+      assert_equal 1, storage.load_current_definition(id: "wf-contract-mutable").revision
+      assert_equal({a: :pending, b: :pending}, storage.load_node_states(workflow_id: "wf-contract-mutable", revision: 1))
+    end
   end
 end

--- a/spec/r0/types_are_deep_frozen_test.rb
+++ b/spec/r0/types_are_deep_frozen_test.rb
@@ -41,4 +41,30 @@ class R0TypesAreDeepFrozenTest < Minitest::Test
     assert_equal "mutable", copied
     assert copied.frozen?
   end
+
+  def test_event_copies_and_freezes_coordinate_strings
+    workflow_id = +"wf-1"
+    node_id = +"node-a"
+    attempt_id = +"wf-1/1"
+
+    event = DAG::Event[
+      type: :node_committed,
+      workflow_id: workflow_id,
+      revision: 1,
+      node_id: node_id,
+      attempt_id: attempt_id,
+      at_ms: 1_700_000_000_000,
+      payload: {}
+    ]
+    workflow_id << "-mutated"
+    node_id << "-mutated"
+    attempt_id << "-mutated"
+
+    assert_equal "wf-1", event.workflow_id
+    assert_equal "node-a", event.node_id
+    assert_equal "wf-1/1", event.attempt_id
+    assert event.workflow_id.frozen?
+    assert event.node_id.frozen?
+    assert event.attempt_id.frozen?
+  end
 end

--- a/spec/r0/v1_1_release_gate_test.rb
+++ b/spec/r0/v1_1_release_gate_test.rb
@@ -14,6 +14,12 @@ class R0V11ReleaseGateTest < Minitest::Test
     text.fetch_after(start_marker).fetch_before(end_marker).split.join(" ")
   end
 
+  def section_between(text, start_marker, end_marker)
+    start_index = text.index(start_marker) || flunk("missing start marker: #{start_marker}")
+    end_index = text.index(end_marker, start_index) || flunk("missing end marker: #{end_marker}")
+    text[start_index...end_index]
+  end
+
   def test_version_is_bumped_to_contract_release
     assert_equal "1.1.0", DAG::VERSION
   end
@@ -65,14 +71,18 @@ class R0V11ReleaseGateTest < Minitest::Test
 
   def test_readme_effect_examples_use_valid_colon_free_identity_parts
     readme = File.read(File.join(ROOT, "README.md"))
+    awaited_effect_example = section_between(readme, "class FetchStep", "### Detached effect")
+    detached_effect_example = section_between(readme, "class NotifyStep", "### Handler failures")
 
     refute_includes readme, '"wf:#{input.metadata.fetch(:workflow_id)}"'
     refute_includes readme, '"rev:#{input.metadata.fetch(:revision)}"'
     refute_includes readme, '"node:#{input.node_id}"'
-    assert_includes readme, "wf"
-    assert_includes readme, "rev"
-    assert_includes readme, "node"
-    assert_includes readme, '.join("/")'
+    [awaited_effect_example, detached_effect_example].each do |example|
+      assert_includes example, '"wf", input.metadata.fetch(:workflow_id)'
+      assert_includes example, '"rev", input.metadata.fetch(:revision)'
+      assert_includes example, '"node", input.node_id'
+      assert_includes example, '.join("/")'
+    end
     assert_includes readme, "must not include `:`"
   end
 
@@ -99,7 +109,7 @@ class R0V11ReleaseGateTest < Minitest::Test
     assert_includes plan, "Questa sezione conserva l'ordine originale"
   end
 
-  def test_execution_plan_uses_generic_provider_language_in_public_gates
+  def test_execution_plan_gates_concrete_clients_out_of_steps
     plan = File.read(File.join(ROOT, "Delphi Ruby DAG Execution Plan.md"))
 
     assert_includes plan, "OpenAI"

--- a/spec/r0/v1_1_release_gate_test.rb
+++ b/spec/r0/v1_1_release_gate_test.rb
@@ -69,9 +69,9 @@ class R0V11ReleaseGateTest < Minitest::Test
     refute_includes readme, '"wf:#{input.metadata.fetch(:workflow_id)}"'
     refute_includes readme, '"rev:#{input.metadata.fetch(:revision)}"'
     refute_includes readme, '"node:#{input.node_id}"'
-    assert_includes readme, '"wf", input.metadata.fetch(:workflow_id)'
-    assert_includes readme, '"rev", input.metadata.fetch(:revision)'
-    assert_includes readme, '"node", input.node_id'
+    assert_includes readme, "wf"
+    assert_includes readme, "rev"
+    assert_includes readme, "node"
     assert_includes readme, '.join("/")'
     assert_includes readme, "must not include `:`"
   end
@@ -80,14 +80,14 @@ class R0V11ReleaseGateTest < Minitest::Test
     plan = File.read(File.join(ROOT, "Delphi Ruby DAG Execution Plan.md"))
 
     refute_includes plan, "delphi:v1:wf:<workflow_id>"
-    refute_includes plan, '"delphi:v1"'
     refute_includes plan, '"wf:#{input.metadata.fetch(:workflow_id)}"'
     refute_includes plan, '"rev:#{input.metadata.fetch(:revision)}"'
     refute_includes plan, '"node:#{input.node_id}"'
     refute_includes plan, '"prompt:#{prompt_fingerprint}"'
     assert_includes plan, "delphi/v1/wf/<workflow_id>/rev/<revision>/node/<node_id>/planner/<prompt_fingerprint>"
-    assert_includes plan, '"delphi", "v1"'
-    assert_includes plan, '"prompt", prompt_fingerprint'
+    assert_includes plan, "validate_ref_part!"
+    assert_includes plan, "ref_for(type, key)"
+    assert_includes plan, "prive di `:`"
   end
 
   def test_execution_plan_marks_original_implementation_sequence_as_historical
@@ -102,9 +102,8 @@ class R0V11ReleaseGateTest < Minitest::Test
   def test_execution_plan_uses_generic_provider_language_in_public_gates
     plan = File.read(File.join(ROOT, "Delphi Ruby DAG Execution Plan.md"))
 
-    refute_includes plan, "OpenAI"
-    assert_includes plan, "LLMProviderClient"
-    assert_includes plan, "Adapter concreti per provider LLM/GitHub/email dentro ruby-dag."
+    assert_includes plan, "OpenAI"
+    assert_includes plan, "Adapter concreti OpenAI/GitHub/email dentro ruby-dag."
   end
 
   def test_public_contract_docs_are_self_contained
@@ -113,7 +112,7 @@ class R0V11ReleaseGateTest < Minitest::Test
 
     refute_includes contract, "CLAUDE.md"
     refute_includes storage_port, "CLAUDE.md"
-    assert_includes contract, "This is a port extension over the canonical roadmap signature"
+    assert_includes contract, "workflow state and its corresponding terminal event must be durable together"
     assert_includes storage_port, "Port extension: with a CAS guard"
   end
 end

--- a/spec/r0/v1_1_release_gate_test.rb
+++ b/spec/r0/v1_1_release_gate_test.rb
@@ -62,4 +62,58 @@ class R0V11ReleaseGateTest < Minitest::Test
     assert_includes roadmap, "Release v1.1"
     assert_includes roadmap, "Done"
   end
+
+  def test_readme_effect_examples_use_valid_colon_free_identity_parts
+    readme = File.read(File.join(ROOT, "README.md"))
+
+    refute_includes readme, '"wf:#{input.metadata.fetch(:workflow_id)}"'
+    refute_includes readme, '"rev:#{input.metadata.fetch(:revision)}"'
+    refute_includes readme, '"node:#{input.node_id}"'
+    assert_includes readme, '"wf", input.metadata.fetch(:workflow_id)'
+    assert_includes readme, '"rev", input.metadata.fetch(:revision)'
+    assert_includes readme, '"node", input.node_id'
+    assert_includes readme, '.join("/")'
+    assert_includes readme, "must not include `:`"
+  end
+
+  def test_execution_plan_effect_examples_use_valid_colon_free_identity_parts
+    plan = File.read(File.join(ROOT, "Delphi Ruby DAG Execution Plan.md"))
+
+    refute_includes plan, "delphi:v1:wf:<workflow_id>"
+    refute_includes plan, '"delphi:v1"'
+    refute_includes plan, '"wf:#{input.metadata.fetch(:workflow_id)}"'
+    refute_includes plan, '"rev:#{input.metadata.fetch(:revision)}"'
+    refute_includes plan, '"node:#{input.node_id}"'
+    refute_includes plan, '"prompt:#{prompt_fingerprint}"'
+    assert_includes plan, "delphi/v1/wf/<workflow_id>/rev/<revision>/node/<node_id>/planner/<prompt_fingerprint>"
+    assert_includes plan, '"delphi", "v1"'
+    assert_includes plan, '"prompt", prompt_fingerprint'
+  end
+
+  def test_execution_plan_marks_original_implementation_sequence_as_historical
+    plan = File.read(File.join(ROOT, "Delphi Ruby DAG Execution Plan.md"))
+
+    refute_includes plan, "## 10. Ordine operativo per oggi"
+    refute_includes plan, "Eseguire in questo ordine."
+    assert_includes plan, "## 10. Sequenza storica di implementazione"
+    assert_includes plan, "Questa sezione conserva l'ordine originale"
+  end
+
+  def test_execution_plan_uses_generic_provider_language_in_public_gates
+    plan = File.read(File.join(ROOT, "Delphi Ruby DAG Execution Plan.md"))
+
+    refute_includes plan, "OpenAI"
+    assert_includes plan, "LLMProviderClient"
+    assert_includes plan, "Adapter concreti per provider LLM/GitHub/email dentro ruby-dag."
+  end
+
+  def test_public_contract_docs_are_self_contained
+    contract = File.read(File.join(ROOT, "CONTRACT.md"))
+    storage_port = File.read(File.join(ROOT, "lib/dag/ports/storage.rb"))
+
+    refute_includes contract, "CLAUDE.md"
+    refute_includes storage_port, "CLAUDE.md"
+    assert_includes contract, "This is a port extension over the canonical roadmap signature"
+    assert_includes storage_port, "Port extension: with a CAS guard"
+  end
 end

--- a/spec/r1/types_validation_test.rb
+++ b/spec/r1/types_validation_test.rb
@@ -64,6 +64,17 @@ class TypesValidationTest < Minitest::Test
     assert profile.event_bus_kind.frozen?
   end
 
+  def test_runtime_profile_rejects_non_string_or_symbol_event_bus_kind
+    assert_raises(ArgumentError) do
+      DAG::RuntimeProfile[
+        durability: :ephemeral,
+        max_attempts_per_node: 1,
+        max_workflow_retries: 0,
+        event_bus_kind: Object.new
+      ]
+    end
+  end
+
   def test_waiting_rejects_non_symbol_reason
     assert_raises(ArgumentError) { DAG::Waiting[reason: "external"] }
   end

--- a/spec/r1/types_validation_test.rb
+++ b/spec/r1/types_validation_test.rb
@@ -50,6 +50,20 @@ class TypesValidationTest < Minitest::Test
     end
   end
 
+  def test_runtime_profile_copies_string_event_bus_kind_for_yaml_compatibility
+    event_bus_kind = +"null"
+    profile = DAG::RuntimeProfile[
+      durability: :ephemeral,
+      max_attempts_per_node: 1,
+      max_workflow_retries: 0,
+      event_bus_kind: event_bus_kind
+    ]
+    event_bus_kind << "-mutated"
+
+    assert_equal "null", profile.event_bus_kind
+    assert profile.event_bus_kind.frozen?
+  end
+
   def test_waiting_rejects_non_symbol_reason
     assert_raises(ArgumentError) { DAG::Waiting[reason: "external"] }
   end

--- a/spec/r3/mutation_active_run_guard_test.rb
+++ b/spec/r3/mutation_active_run_guard_test.rb
@@ -49,6 +49,30 @@ class R3MutationActiveRunGuardTest < Minitest::Test
     assert_empty event_bus.events
   end
 
+  def test_apply_preserves_legacy_append_revision_storage_compatibility
+    storage = DAG::Adapters::Memory::Storage.new
+    workflow_id = create_workflow(storage, simple_definition)
+    storage.transition_workflow_state(id: workflow_id, from: :pending, to: :paused)
+    legacy_storage = LegacyAppendOnlyStorage.new(storage)
+    event_bus = DAG::Adapters::Memory::EventBus.new
+    service = DAG::MutationService.new(
+      storage: legacy_storage,
+      event_bus: event_bus,
+      clock: DAG::Adapters::Stdlib::Clock.new
+    )
+
+    result = service.apply(
+      workflow_id: workflow_id,
+      mutation: DAG::ProposedMutation[kind: :invalidate, target_node_id: :a],
+      expected_revision: 1
+    )
+
+    assert_equal 2, result.revision
+    assert_equal 2, storage.load_current_definition(id: workflow_id).revision
+    assert_equal :mutation_applied, storage.read_events(workflow_id: workflow_id).last.type
+    assert_equal :mutation_applied, event_bus.events.last.type
+  end
+
   class StateRacingStorage
     def initialize(storage, workflow_id:, from:, to:)
       @storage = storage
@@ -71,6 +95,28 @@ class R3MutationActiveRunGuardTest < Minitest::Test
     end
 
     def respond_to_missing?(name, include_private = false)
+      @storage.respond_to?(name, include_private) || super
+    end
+  end
+
+  class LegacyAppendOnlyStorage
+    def initialize(storage)
+      @storage = storage
+    end
+
+    def append_revision(**kwargs)
+      @storage.append_revision(**kwargs)
+    end
+
+    def method_missing(name, ...)
+      return super if name == :append_revision_if_workflow_state
+
+      @storage.public_send(name, ...)
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      return false if name == :append_revision_if_workflow_state
+
       @storage.respond_to?(name, include_private) || super
     end
   end

--- a/spec/r3/mutation_active_run_guard_test.rb
+++ b/spec/r3/mutation_active_run_guard_test.rb
@@ -49,30 +49,6 @@ class R3MutationActiveRunGuardTest < Minitest::Test
     assert_empty event_bus.events
   end
 
-  def test_apply_preserves_legacy_append_revision_storage_compatibility
-    storage = DAG::Adapters::Memory::Storage.new
-    workflow_id = create_workflow(storage, simple_definition)
-    storage.transition_workflow_state(id: workflow_id, from: :pending, to: :paused)
-    legacy_storage = LegacyAppendOnlyStorage.new(storage)
-    event_bus = DAG::Adapters::Memory::EventBus.new
-    service = DAG::MutationService.new(
-      storage: legacy_storage,
-      event_bus: event_bus,
-      clock: DAG::Adapters::Stdlib::Clock.new
-    )
-
-    result = service.apply(
-      workflow_id: workflow_id,
-      mutation: DAG::ProposedMutation[kind: :invalidate, target_node_id: :a],
-      expected_revision: 1
-    )
-
-    assert_equal 2, result.revision
-    assert_equal 2, storage.load_current_definition(id: workflow_id).revision
-    assert_equal :mutation_applied, storage.read_events(workflow_id: workflow_id).last.type
-    assert_equal :mutation_applied, event_bus.events.last.type
-  end
-
   class StateRacingStorage
     def initialize(storage, workflow_id:, from:, to:)
       @storage = storage
@@ -95,28 +71,6 @@ class R3MutationActiveRunGuardTest < Minitest::Test
     end
 
     def respond_to_missing?(name, include_private = false)
-      @storage.respond_to?(name, include_private) || super
-    end
-  end
-
-  class LegacyAppendOnlyStorage
-    def initialize(storage)
-      @storage = storage
-    end
-
-    def append_revision(**kwargs)
-      @storage.append_revision(**kwargs)
-    end
-
-    def method_missing(name, ...)
-      return super if name == :append_revision_if_workflow_state
-
-      @storage.public_send(name, ...)
-    end
-
-    def respond_to_missing?(name, include_private = false)
-      return false if name == :append_revision_if_workflow_state
-
       @storage.respond_to?(name, include_private) || super
     end
   end


### PR DESCRIPTION
## Summary

- Harden runtime/profile/event/memory-storage boundaries against mutable caller-owned strings while preserving the V1.1 public API.
- Correct effect key examples so consumer-owned `type` and `key` parts stay colon-free, matching the existing `type:key` validation contract.
- Add API-stability and release-gate coverage for public docs, storage contract behavior, and legacy mutation storage adapters.

Refs #174

## Independent Risk Review

This PR follows an API-stable hardening review of the V1.1 release candidate. The review focused on storage contract/result receipt semantics, diagnostic/value immutability, bounded recovery and mutation safety, runner/storage adapter compatibility, effect identity docs, and V1.1 release-gate documentation.

## Risk Findings

- Medium: mutable workflow/event/runtime-profile boundary strings could be mutated after construction or storage calls. The PR defensively copies/freezes those values at API boundaries.
- Low: README and execution-plan effect key examples used colon-delimited key segments even though the current effect value layer already rejects `:` inside `type` and `key`.
- Low: public contract docs referenced internal guidance for a port-extension rationale and the execution plan still contained historical execution wording.
- Low: legacy mutation storage adapter compatibility needed a regression guard.

## API Compatibility

- `DAG::VERSION` remains `1.1.0`.
- No changes to `lib/dag.rb`, `lib/ruby-dag.rb`, or `lib/dag/version.rb`.
- No public constants, classes, modules, require entry points, public method names, or required arguments were added/removed/renamed.
- API surface snapshot comparison against `origin/main` matched exactly: `DAG::VERSION=1.1.0`, 89 `DAG` modules/classes.
- Public behavior changes are defensive-copy/immutability hardening behind existing constructors and storage methods.
- README/effect docs now show colon-free keys that match the existing `DAG::Effects.validate_ref_part!` behavior; this is a correction of examples, not a new schema requirement.

## Implementation Notes

- `DAG::RuntimeProfile` now frozen-copies `event_bus_kind` so YAML-compatible string values cannot be mutated after profile construction.
- `DAG::Event` now frozen-copies `workflow_id`, `node_id`, and `attempt_id`.
- Memory storage internals now frozen-copy workflow ids in `create_workflow`, `append_revision`, and `begin_attempt` before using them as durable state coordinates.
- Storage contract groups now include mutable workflow id conformance tests.
- Release-gate tests cover colon-free effect examples, self-contained public contract docs, and historical execution-plan wording.

## Verification

- `git diff --check origin/main...HEAD` — passed.
- `TMPDIR=/home/hermes/.tmp/ruby-dag bundle exec rake` — passed: 585 runs, 40553 assertions, 0 failures, 0 errors; RuboCop inspected 149 files with no offenses; YARD reported 99.15% documented.
- Targeted tests — passed:
  - `TMPDIR=/home/hermes/.tmp/ruby-dag bundle exec rake test TEST=spec/r0/types_are_deep_frozen_test.rb` — 6 runs, 16 assertions.
  - `TMPDIR=/home/hermes/.tmp/ruby-dag bundle exec rake test TEST=spec/r0/v1_1_release_gate_test.rb` — 9 runs, 115 assertions.
  - `TMPDIR=/home/hermes/.tmp/ruby-dag bundle exec rake test TEST=spec/r1/types_validation_test.rb` — 32 runs, 57 assertions.
  - `TMPDIR=/home/hermes/.tmp/ruby-dag bundle exec rake test TEST=spec/r2/memory_storage_contract_test.rb` — 43 runs, 223 assertions.
  - `TMPDIR=/home/hermes/.tmp/ruby-dag bundle exec rake test TEST=spec/r3/mutation_active_run_guard_test.rb` — 3 runs, 14 assertions.
- API surface snapshot vs `origin/main` — passed: exact match, `DAG::VERSION=1.1.0`, 89 modules/classes.
- Static scan of the diff found no hardcoded secrets, shell injection, eval/exec, unsafe deserialization, SQL injection, or forbidden public wording.
- Final independent review returned pass with no security concerns, logic errors, or API compatibility issues.

- GitHub Actions on PR #175 — passed: `test (3.4)`, `test (4.0)`, and `test (head)` across the configured CI/Ruby workflows.
