### PR TITLE
feat: add storage.renew_effect_lease for cooperative lease extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@
   monotonic: `until_ms` must exceed `now_ms` and not shrink the current
   `lease_until_ms` (`ArgumentError` otherwise); `until_ms == lease_until_ms`
   is a no-op success. A stale, foreign, or non-`:dispatching` lease raises
-  `DAG::Effects::StaleLeaseError`.
+  `DAG::Effects::StaleLeaseError`. Motivated by a Delphi retry-storm trace
+  (workflows `7134e4d6` and `b540702c`, 2026-05-06) where a 30s default
+  `lease_ms` was shorter than legitimate LLM handler runtime (~110s),
+  causing repeated re-claims and duplicate paid external work.
 - `DAG::Adapters::Memory::Storage` implements the new method.
 - `DAG::Testing::StorageContract::Effects` extends G6 with renewal
   coverage: success, idempotency on equal `until_ms`, wrong owner, expired

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@
   refreshed stale execution-plan wording as historical reference.
 - Added API-stability guard tests for release documentation, runtime profile
   compatibility, and legacy mutation storage adapters.
+- `DAG::Ports::Storage#renew_effect_lease(effect_id:, owner_id:, until_ms:,
+  now_ms:)` cooperatively extends the lease of an effect currently held by
+  `owner_id`, separating admission control (worker-death detection via
+  expired lease) from handler execution time. Applies the same lease CAS as
+  `mark_effect_*` (status `:dispatching`, owner match, non-expired lease)
+  and updates `lease_until_ms` and `updated_at_ms` atomically. Renewal is
+  monotonic: `until_ms` must exceed `now_ms` and not shrink the current
+  `lease_until_ms` (`ArgumentError` otherwise); `until_ms == lease_until_ms`
+  is a no-op success. A stale, foreign, or non-`:dispatching` lease raises
+  `DAG::Effects::StaleLeaseError`.
+- `DAG::Adapters::Memory::Storage` implements the new method.
+- `DAG::Testing::StorageContract::Effects` extends G6 with renewal
+  coverage: success, idempotency on equal `until_ms`, wrong owner, expired
+  lease, unclaimed effect, unknown effect, and rejection of both
+  `until_ms <= now_ms` and shrinking `until_ms`.
 
 ## 1.1.0 — 2026-05-03
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,26 @@ plan: `ruby-dag` must durably reserve abstract effect intents and enforce
 idempotency on `(type, key)` plus `payload_fingerprint`, while concrete
 handlers and exactly-once external-system guarantees remain in consumers.
 
+V1.2 adds cooperative lease renewal so the dispatcher's default `lease_ms`
+no longer has to absorb worst-case handler runtime:
+
+- **`renew_effect_lease(effect_id:, owner_id:, until_ms:, now_ms:)`**
+  applies the same lease CAS as `mark_effect_*` (status `:dispatching`,
+  owner match, non-expired lease) and updates `lease_until_ms` plus
+  `updated_at_ms` atomically. Renewal is monotonic: `until_ms` must exceed
+  `now_ms` and must not shrink the existing `lease_until_ms`
+  (`ArgumentError` otherwise). `until_ms == lease_until_ms` is a no-op
+  success. A stale, foreign, or non-`:dispatching` lease raises
+  `DAG::Effects::StaleLeaseError`.
+
+This is justified by the effect safety invariant: without renewal,
+admission control (worker-death detection) and handler execution time are
+conflated into the same `lease_ms` knob, so consumers either accept retry
+storms on legitimately long handlers or pay a longer worker-death MTTR.
+The dispatcher does not yet emit a durable event when it observes a stale
+lease; that diagnostic and the consumer-side heartbeat helper remain
+out-of-scope for V1.2 and require their own design pass.
+
 Effect PR4 adds the abstract dispatcher boundary on top of those storage
 methods:
 

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -414,6 +414,7 @@ storage.list_effects_for_attempt(attempt_id:)
 storage.claim_ready_effects(limit:, owner_id:, lease_ms:, now_ms:)
 storage.mark_effect_succeeded(effect_id:, owner_id:, result:, external_ref:, now_ms:)
 storage.mark_effect_failed(effect_id:, owner_id:, error:, retriable:, not_before_ms:, now_ms:)
+storage.renew_effect_lease(effect_id:, owner_id:, until_ms:, now_ms:)
 storage.complete_effect_succeeded(effect_id:, owner_id:, result:, external_ref:, now_ms:)
 storage.complete_effect_failed(effect_id:, owner_id:, error:, retriable:, not_before_ms:, now_ms:)
 storage.release_nodes_satisfied_by_effect(effect_id:, now_ms:)
@@ -431,6 +432,18 @@ owner and a non-expired lease; otherwise they raise
 the JSON-safe result and external reference. Retriable failure sets
 `status: :failed_retriable`, stores the JSON-safe error, and may set
 `not_before_ms`. Terminal failure sets `status: :failed_terminal`.
+
+`renew_effect_lease` cooperatively extends the lease of an effect still
+held by `owner_id`, separating admission control (worker-death detection
+via expired lease) from the time a legitimately long-running handler needs
+to finish. It applies the same lease CAS as `mark_effect_*` (status
+`:dispatching`, owner match, non-expired lease) and updates `lease_until_ms`
+and `updated_at_ms` atomically. `until_ms` must be strictly greater than
+`now_ms` and not less than the current `lease_until_ms`; violating either
+constraint raises `ArgumentError`. `until_ms == lease_until_ms` is a no-op
+success that returns the unchanged record so heartbeat callers can ignore
+order-of-arrival. A stale, foreign, or non-`:dispatching` lease raises
+`DAG::Effects::StaleLeaseError`.
 
 `:succeeded` and `:failed_terminal` are terminal effect states.
 `release_nodes_satisfied_by_effect` resets linked nodes from `:waiting` to

--- a/lib/dag/adapters/memory/storage.rb
+++ b/lib/dag/adapters/memory/storage.rb
@@ -136,6 +136,17 @@ module DAG
           )
         end
 
+        # (see Ports::Storage#renew_effect_lease)
+        def renew_effect_lease(effect_id:, owner_id:, until_ms:, now_ms:)
+          frozen StorageState.renew_effect_lease(
+            @state,
+            effect_id: effect_id,
+            owner_id: owner_id,
+            until_ms: until_ms,
+            now_ms: now_ms
+          )
+        end
+
         # (see Ports::Storage#complete_effect_succeeded)
         def complete_effect_succeeded(effect_id:, owner_id:, result:, external_ref:, now_ms:)
           frozen StorageState.complete_effect_succeeded(

--- a/lib/dag/adapters/memory/storage_state.rb
+++ b/lib/dag/adapters/memory/storage_state.rb
@@ -348,6 +348,31 @@ module DAG
           state[:effects][effect_id] = updated
         end
 
+        # Implements `Ports::Storage#renew_effect_lease`.
+        # @api private
+        def renew_effect_lease(state, effect_id:, owner_id:, until_ms:, now_ms:)
+          ensure_effect_state!(state)
+          DAG::Validation.string!(owner_id, "owner_id")
+          DAG::Validation.integer!(until_ms, "until_ms")
+          DAG::Validation.integer!(now_ms, "now_ms")
+          unless until_ms > now_ms
+            raise ArgumentError, "until_ms (#{until_ms}) must be greater than now_ms (#{now_ms})"
+          end
+
+          record = fetch_effect!(state, effect_id)
+          validate_effect_lease!(record, owner_id: owner_id, now_ms: now_ms)
+
+          current_until = record.lease_until_ms
+          if until_ms < current_until
+            raise ArgumentError,
+              "until_ms (#{until_ms}) must not shrink lease_until_ms (#{current_until})"
+          end
+          return record if until_ms == current_until
+
+          updated = record.with(lease_until_ms: until_ms, updated_at_ms: now_ms)
+          state[:effects][effect_id] = updated
+        end
+
         # Implements `Ports::Storage#complete_effect_succeeded`.
         # @api private
         def complete_effect_succeeded(state, effect_id:, owner_id:, result:, external_ref:, now_ms:)

--- a/lib/dag/ports/storage.rb
+++ b/lib/dag/ports/storage.rb
@@ -210,6 +210,32 @@ module DAG
         raise PortNotImplementedError
       end
 
+      # Port extension: cooperatively extend the lease of an effect currently
+      # held by `owner_id`. This separates admission control (worker-death
+      # detection via expired lease) from handler execution time, so the
+      # dispatcher's default `lease_ms` can stay tight without forcing
+      # legitimately long-running handlers to lose their claim mid-run.
+      #
+      # The CAS guard is identical to `mark_effect_*`: status `:dispatching`,
+      # `lease_owner == owner_id`, and `lease_until_ms >= now_ms`. Adapters
+      # update `lease_until_ms` and `updated_at_ms` atomically. Renewal is
+      # monotonic: `until_ms` must be strictly greater than `now_ms` and not
+      # less than the current `lease_until_ms`. `until_ms == lease_until_ms`
+      # is a no-op success that returns the unchanged record.
+      #
+      # @param effect_id [String]
+      # @param owner_id [String] current lease owner
+      # @param until_ms [Integer] new lease deadline in wall-clock milliseconds
+      # @param now_ms [Integer]
+      # @return [DAG::Effects::Record] updated record with the extended lease
+      # @raise [DAG::Effects::UnknownEffectError] when `effect_id` is unknown
+      # @raise [DAG::Effects::StaleLeaseError] when the lease is missing, expired, or owned by another dispatcher
+      # @raise [ArgumentError] when `until_ms` is not greater than `now_ms`,
+      #   or would shrink the existing `lease_until_ms`
+      def renew_effect_lease(effect_id:, owner_id:, until_ms:, now_ms:)
+        raise PortNotImplementedError
+      end
+
       # Port extension: atomically mark a claimed effect as succeeded and
       # release any waiting nodes that become satisfied by that terminal
       # effect state. This closes the crash window between a terminal mark and

--- a/lib/dag/testing/storage_contract/effects.rb
+++ b/lib/dag/testing/storage_contract/effects.rb
@@ -196,6 +196,137 @@ module DAG::Testing::StorageContract
       assert_nil updated.lease_until_ms
     end
 
+    def test_contract_renew_effect_lease_extends_active_lease
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      effect = commit_waiting_effect(storage, workflow_id, :a)
+      storage.claim_ready_effects(limit: 1, owner_id: "worker-a", lease_ms: 500, now_ms: 1_000)
+
+      renewed = storage.renew_effect_lease(
+        effect_id: effect.id,
+        owner_id: "worker-a",
+        until_ms: 5_000,
+        now_ms: 1_100
+      )
+
+      assert_equal :dispatching, renewed.status
+      assert_equal "worker-a", renewed.lease_owner
+      assert_equal 5_000, renewed.lease_until_ms
+
+      assert_empty storage.claim_ready_effects(limit: 1, owner_id: "worker-b", lease_ms: 500, now_ms: 4_999)
+      reclaimed = storage.claim_ready_effects(limit: 1, owner_id: "worker-b", lease_ms: 500, now_ms: 5_001)
+      assert_equal [effect.id], reclaimed.map(&:id)
+    end
+
+    def test_contract_renew_effect_lease_is_idempotent_when_until_ms_unchanged
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      effect = commit_waiting_effect(storage, workflow_id, :a)
+      storage.claim_ready_effects(limit: 1, owner_id: "worker-a", lease_ms: 500, now_ms: 1_000)
+
+      renewed = storage.renew_effect_lease(
+        effect_id: effect.id,
+        owner_id: "worker-a",
+        until_ms: 1_500,
+        now_ms: 1_100
+      )
+
+      assert_equal 1_500, renewed.lease_until_ms
+    end
+
+    def test_contract_renew_effect_lease_rejects_wrong_owner
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      effect = commit_waiting_effect(storage, workflow_id, :a)
+      storage.claim_ready_effects(limit: 1, owner_id: "worker-a", lease_ms: 500, now_ms: 1_000)
+
+      assert_raises(DAG::Effects::StaleLeaseError) do
+        storage.renew_effect_lease(
+          effect_id: effect.id,
+          owner_id: "worker-b",
+          until_ms: 5_000,
+          now_ms: 1_100
+        )
+      end
+    end
+
+    def test_contract_renew_effect_lease_rejects_expired_lease
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      effect = commit_waiting_effect(storage, workflow_id, :a)
+      storage.claim_ready_effects(limit: 1, owner_id: "worker-a", lease_ms: 500, now_ms: 1_000)
+
+      assert_raises(DAG::Effects::StaleLeaseError) do
+        storage.renew_effect_lease(
+          effect_id: effect.id,
+          owner_id: "worker-a",
+          until_ms: 5_000,
+          now_ms: 1_501
+        )
+      end
+    end
+
+    def test_contract_renew_effect_lease_rejects_unclaimed_effect
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      effect = commit_waiting_effect(storage, workflow_id, :a)
+
+      assert_raises(DAG::Effects::StaleLeaseError) do
+        storage.renew_effect_lease(
+          effect_id: effect.id,
+          owner_id: "worker-a",
+          until_ms: 5_000,
+          now_ms: 1_100
+        )
+      end
+    end
+
+    def test_contract_renew_effect_lease_rejects_unknown_effect
+      storage = build_contract_storage
+      contract_create_workflow(storage)
+
+      assert_raises(DAG::Effects::UnknownEffectError) do
+        storage.renew_effect_lease(
+          effect_id: "effect/unknown",
+          owner_id: "worker-a",
+          until_ms: 5_000,
+          now_ms: 1_100
+        )
+      end
+    end
+
+    def test_contract_renew_effect_lease_rejects_until_ms_not_in_future
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      effect = commit_waiting_effect(storage, workflow_id, :a)
+      storage.claim_ready_effects(limit: 1, owner_id: "worker-a", lease_ms: 500, now_ms: 1_000)
+
+      assert_raises(ArgumentError) do
+        storage.renew_effect_lease(
+          effect_id: effect.id,
+          owner_id: "worker-a",
+          until_ms: 1_100,
+          now_ms: 1_100
+        )
+      end
+    end
+
+    def test_contract_renew_effect_lease_rejects_shrink
+      storage = build_contract_storage
+      workflow_id = contract_create_workflow(storage)
+      effect = commit_waiting_effect(storage, workflow_id, :a)
+      storage.claim_ready_effects(limit: 1, owner_id: "worker-a", lease_ms: 500, now_ms: 1_000)
+
+      assert_raises(ArgumentError) do
+        storage.renew_effect_lease(
+          effect_id: effect.id,
+          owner_id: "worker-a",
+          until_ms: 1_200,
+          now_ms: 1_100
+        )
+      end
+    end
+
     def test_contract_complete_effect_succeeded_releases_waiting_node_atomically
       storage = build_contract_storage
       workflow_id = contract_create_workflow(storage)

--- a/spec/r0/ports_test.rb
+++ b/spec/r0/ports_test.rb
@@ -27,6 +27,7 @@ class R0PortsTest < Minitest::Test
     claim_ready_effects: {limit: 1, owner_id: "worker", lease_ms: 1, now_ms: 1},
     mark_effect_succeeded: {effect_id: "x", owner_id: "worker", result: {}, external_ref: nil, now_ms: 1},
     mark_effect_failed: {effect_id: "x", owner_id: "worker", error: {}, retriable: true, not_before_ms: nil, now_ms: 1},
+    renew_effect_lease: {effect_id: "x", owner_id: "worker", until_ms: 2, now_ms: 1},
     complete_effect_succeeded: {effect_id: "x", owner_id: "worker", result: {}, external_ref: nil, now_ms: 1},
     complete_effect_failed: {effect_id: "x", owner_id: "worker", error: {}, retriable: false, not_before_ms: nil, now_ms: 1},
     release_nodes_satisfied_by_effect: {effect_id: "x", now_ms: 1},


### PR DESCRIPTION
## Summary

- Adds `DAG::Ports::Storage#renew_effect_lease(effect_id:, owner_id:, until_ms:, now_ms:)` so dispatchers can keep their default `lease_ms` short (fast worker-death recovery) while letting legitimately long-running handlers extend their own claim cooperatively.
- CAS guard mirrors `mark_effect_*` (status `:dispatching`, owner match, non-expired lease); raises `StaleLeaseError`/`UnknownEffectError`/`ArgumentError`. Renewal is monotonic and `until_ms == lease_until_ms` is a no-op success so heartbeat callers can ignore order-of-arrival.
- Memory adapter reuses the existing `validate_effect_lease!` helper. Contract suite extends G6 with eight new behavior groups covering every row of the error/success matrix.

## Motivation

Originated from a Delphi-side retry storm (workflows `7134e4d6` and `b540702c`, 2026-05-06): a 30s default `lease_ms` was shorter than legitimate LLM handler runtime (~110s), so `mark_effect_succeeded` raised `StaleLeaseError` after each successful handler call, the dispatcher re-claimed the same record on the next tick, and the same payload was paid for repeatedly until `effect_max_lifetime_ms` killed the workflow. Raising the default `lease_ms` works around the symptom but conflates two concerns: admission control (worker-death detection) and handler execution time. This primitive separates them.

## API

```ruby
storage.renew_effect_lease(
  effect_id: \"effect/42\",
  owner_id: \"worker-a\",
  until_ms: now_ms + 30_000,
  now_ms: clock.now_ms
)
```

| condition | result |
| --- | --- |
| `until_ms <= now_ms` | `ArgumentError` |
| `until_ms < lease_until_ms` | `ArgumentError` |
| `until_ms == lease_until_ms` | no-op success (record unchanged, no `updated_at_ms` mutation) |
| `until_ms > lease_until_ms` with valid lease | success, lease extended |
| stale / wrong-owner / non-`:dispatching` | `StaleLeaseError` |
| unknown `effect_id` | `UnknownEffectError` |

## Out of scope

- A consumer-side heartbeat helper (`HandlerContext` / `LeaseRenewer`) stays in the consumer host. We want to see how Delphi consumes the primitive directly before deciding whether kernel-side sugar is worth a handler-signature change.
- Diagnostic event `:effect_dispatch_stale_lease` deferred to a separate PR. The dispatcher does not currently inject an `event_bus`, so emitting a durable event needs its own design pass before extending `Event::TYPES`.
- `VERSION` bump deferred to the V1.2 cut-release commit, matching the convention from `1a199b3 release: gate v1.1 contract`.

## Test plan

- [x] `bundle exec rake` (test + standardrb + custom DAG cops) green: 582 runs, 40494 assertions, 0 failures.
- [x] `bundle exec yard doc --no-output --no-progress --fail-on-warning` clean.
- [x] G6 contract behavior groups cover: success extending lease, idempotency on equal `until_ms`, wrong owner, expired lease, unclaimed (status `:reserved`) effect, unknown `effect_id`, `until_ms <= now_ms`, and shrinking `until_ms`.
- [x] Smoke: after `renew_effect_lease`, `claim_ready_effects` does not re-claim the record until the new `lease_until_ms` is past.

🤖 Generated with [Claude Code](https://claude.com/claude-code)