### PR TITLE
release: gate v1.2 lease renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,45 @@
 
 ## Unreleased
 
-- Hardened runtime profile, memory storage, and event values against mutable
-  workflow, attempt, and event-bus-kind inputs without changing public API
-  signatures.
-- Clarified effect key examples to avoid `:` inside consumer-owned `type` and
-  `key` parts, preserving the unambiguous `type:key` record identity, and
-  refreshed stale execution-plan wording as historical reference.
-- Added API-stability guard tests for release documentation, runtime profile
-  compatibility, and legacy mutation storage adapters.
+- No changes yet.
+
+## 1.2.0 — 2026-05-07
+
+V1.2 extends the effect-aware storage contract with cooperative lease renewal
+so dispatchers can keep their default `lease_ms` short (fast worker-death
+recovery) while still letting legitimately long-running handlers extend
+their own claim. Originated from a Delphi-side retry-storm trace
+(workflows `7134e4d6` and `b540702c`, 2026-05-06) where a 30s default
+`lease_ms` was shorter than legitimate LLM handler runtime (~110s),
+causing repeated re-claims and duplicate paid external work.
+
+### Added
+
 - `DAG::Ports::Storage#renew_effect_lease(effect_id:, owner_id:, until_ms:,
   now_ms:)` cooperatively extends the lease of an effect currently held by
-  `owner_id`, separating admission control (worker-death detection via
-  expired lease) from handler execution time. Applies the same lease CAS as
-  `mark_effect_*` (status `:dispatching`, owner match, non-expired lease)
-  and updates `lease_until_ms` and `updated_at_ms` atomically. Renewal is
-  monotonic: `until_ms` must exceed `now_ms` and not shrink the current
+  `owner_id`. Applies the same lease CAS as `mark_effect_*` (status
+  `:dispatching`, owner match, non-expired lease) and updates
+  `lease_until_ms` and `updated_at_ms` atomically. Renewal is monotonic:
+  `until_ms` must exceed `now_ms` and not shrink the current
   `lease_until_ms` (`ArgumentError` otherwise); `until_ms == lease_until_ms`
   is a no-op success. A stale, foreign, or non-`:dispatching` lease raises
-  `DAG::Effects::StaleLeaseError`. Motivated by a Delphi retry-storm trace
-  (workflows `7134e4d6` and `b540702c`, 2026-05-06) where a 30s default
-  `lease_ms` was shorter than legitimate LLM handler runtime (~110s),
-  causing repeated re-claims and duplicate paid external work.
-- `DAG::Adapters::Memory::Storage` implements the new method.
-- `DAG::Testing::StorageContract::Effects` extends G6 with renewal
-  coverage: success, idempotency on equal `until_ms`, wrong owner, expired
-  lease, unclaimed effect, unknown effect, and rejection of both
-  `until_ms <= now_ms` and shrinking `until_ms`.
+  `DAG::Effects::StaleLeaseError`.
+- `DAG::Adapters::Memory::Storage` implements `renew_effect_lease`.
+- `DAG::Testing::StorageContract::Effects` extends G6 with renewal coverage:
+  success, idempotency on equal `until_ms`, wrong owner, expired lease,
+  unclaimed effect, unknown effect, and rejection of both `until_ms <= now_ms`
+  and shrinking `until_ms`.
+- API-stability guard tests for release documentation, runtime profile
+  compatibility, and legacy mutation storage adapters.
+
+### Changed
+
+- Runtime profile, memory storage, and event values are hardened against
+  mutable workflow, attempt, and event-bus-kind inputs without changing
+  public API signatures.
+- Effect key examples avoid `:` inside consumer-owned `type` and `key`
+  parts so the `type:key` record identity stays unambiguous, and stale
+  execution-plan wording is preserved as historical reference.
 
 ## 1.1.0 — 2026-05-03
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-dag (1.1.0)
+    ruby-dag (1.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,8 @@ Tracked phases:
 | Effects PR5 (docs + release gate)| #149 | Done (#155) |
 | V1.1 kernel hardening          | #157 | Done (#158-#164 via #166, #167, #168, #169, #170, #171, #172) |
 | Release v1.1                   | #165 | Done |
+| V1.2 cooperative lease renewal | —    | Done (#175, #176) |
+| Release v1.2                   | —    | Done |
 | S0 (SQLite adapter, in Delphi)   | TBD  | Next |
 | Release v1.0                     | #74  | Done (#126, #156) |
 

--- a/lib/dag/version.rb
+++ b/lib/dag/version.rb
@@ -2,5 +2,5 @@
 
 module DAG
   # Library version. Bumped per release; see `CHANGELOG.md`.
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/spec/r0/v1_1_release_gate_test.rb
+++ b/spec/r0/v1_1_release_gate_test.rb
@@ -20,10 +20,6 @@ class R0V11ReleaseGateTest < Minitest::Test
     text[start_index...end_index]
   end
 
-  def test_version_is_bumped_to_contract_release
-    assert_equal "1.1.0", DAG::VERSION
-  end
-
   def test_changelog_contains_v1_1_contract_release_notes
     changelog = normalized("CHANGELOG.md")
 

--- a/spec/r0/v1_2_release_gate_test.rb
+++ b/spec/r0/v1_2_release_gate_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class R0V12ReleaseGateTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def normalized(path)
+    File.read(File.join(ROOT, path)).split.join(" ")
+  end
+
+  def test_version_is_bumped_to_contract_release
+    assert_equal "1.2.0", DAG::VERSION
+  end
+
+  def test_changelog_contains_v1_2_release_notes
+    changelog = normalized("CHANGELOG.md")
+
+    assert_includes changelog, "## 1.2.0 — 2026-05-07"
+    assert_includes changelog, "cooperative lease renewal"
+    assert_includes changelog, "renew_effect_lease"
+    assert_includes changelog, "7134e4d6"
+    assert_includes changelog, "b540702c"
+  end
+
+  def test_roadmap_marks_v1_2_release_done
+    roadmap = normalized("ROADMAP.md")
+
+    assert_includes roadmap, "V1.2 cooperative lease renewal"
+    assert_includes roadmap, "Release v1.2"
+  end
+
+  def test_storage_port_documents_renew_effect_lease
+    port = File.read(File.join(ROOT, "lib/dag/ports/storage.rb"))
+
+    assert_includes port, "def renew_effect_lease(effect_id:, owner_id:, until_ms:, now_ms:)"
+    assert_includes port.downcase, "cooperatively extend the lease"
+  end
+
+  def test_contract_documents_renew_effect_lease
+    contract = normalized("CONTRACT.md")
+
+    assert_includes contract, "renew_effect_lease(effect_id:, owner_id:, until_ms:, now_ms:)"
+    assert_includes contract, "cooperatively extends the lease"
+  end
+end


### PR DESCRIPTION
## Summary

- Bumps `DAG::VERSION` to `1.2.0` and `Gemfile.lock` self-spec accordingly.
- Promotes the `## Unreleased` section to `## 1.2.0 — 2026-05-07` with a release-summary paragraph and Added/Changed split.
- Adds the V1.2 entry to `ROADMAP.md`.
- Moves the version-bump assertion from `spec/r0/v1_1_release_gate_test.rb` (job done) into a new `spec/r0/v1_2_release_gate_test.rb` that asserts the V1.2 release notes, ROADMAP entry, and contract documentation are in place.

## Highlights

V1.2 is a feature release on top of the V1.1 hardening: the new `storage.renew_effect_lease` primitive (#176) lets dispatchers keep their default `lease_ms` short for fast worker-death recovery while letting legitimately long-running handlers extend their own claim cooperatively. Originated from the Delphi retry-storm trace `7134e4d6` / `b540702c` (2026-05-06).

V1.2 also carries forward the V1.1 hardening polish merged in #175 (mutable-input defenses on runtime profile / memory storage / event values, colon-free effect key examples, API-stability guard tests).

## Test plan

- [x] `bundle exec rake` green: 597 runs, 40595 assertions, 0 failures, 0 offenses.
- [x] `bundle exec yard doc --no-output --no-progress --fail-on-warning` clean.
- [x] V1.2 release-gate test asserts version, changelog notes, ROADMAP entry, and contract documentation.

## Post-merge

- Tag `v1.2.0` on the squash-merge commit.
- Create GitHub release with the V1.2 changelog body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)