### PR TITLE
chore: strengthen V1.2 idempotency test and dedupe release-gate helper

### DIFF
--- a/lib/dag/testing/storage_contract/effects.rb
+++ b/lib/dag/testing/storage_contract/effects.rb
@@ -222,7 +222,7 @@ module DAG::Testing::StorageContract
       storage = build_contract_storage
       workflow_id = contract_create_workflow(storage)
       effect = commit_waiting_effect(storage, workflow_id, :a)
-      storage.claim_ready_effects(limit: 1, owner_id: "worker-a", lease_ms: 500, now_ms: 1_000)
+      claimed = storage.claim_ready_effects(limit: 1, owner_id: "worker-a", lease_ms: 500, now_ms: 1_000).first
 
       renewed = storage.renew_effect_lease(
         effect_id: effect.id,
@@ -232,6 +232,9 @@ module DAG::Testing::StorageContract
       )
 
       assert_equal 1_500, renewed.lease_until_ms
+      assert_equal "worker-a", renewed.lease_owner
+      assert_equal :dispatching, renewed.status
+      assert_equal claimed.updated_at_ms, renewed.updated_at_ms
     end
 
     def test_contract_renew_effect_lease_rejects_wrong_owner

--- a/spec/r0/v1_1_release_gate_test.rb
+++ b/spec/r0/v1_1_release_gate_test.rb
@@ -5,10 +5,6 @@ require_relative "../test_helper"
 class R0V11ReleaseGateTest < Minitest::Test
   ROOT = File.expand_path("../..", __dir__)
 
-  def normalized(path)
-    File.read(File.join(ROOT, path)).split.join(" ")
-  end
-
   def normalized_section(path, start_marker, end_marker)
     text = File.read(File.join(ROOT, path))
     text.fetch_after(start_marker).fetch_before(end_marker).split.join(" ")

--- a/spec/r0/v1_2_release_gate_test.rb
+++ b/spec/r0/v1_2_release_gate_test.rb
@@ -5,10 +5,6 @@ require_relative "../test_helper"
 class R0V12ReleaseGateTest < Minitest::Test
   ROOT = File.expand_path("../..", __dir__)
 
-  def normalized(path)
-    File.read(File.join(ROOT, path)).split.join(" ")
-  end
-
   def test_version_is_bumped_to_contract_release
     assert_equal "1.2.0", DAG::VERSION
   end
@@ -34,7 +30,7 @@ class R0V12ReleaseGateTest < Minitest::Test
     port = File.read(File.join(ROOT, "lib/dag/ports/storage.rb"))
 
     assert_includes port, "def renew_effect_lease(effect_id:, owner_id:, until_ms:, now_ms:)"
-    assert_includes port.downcase, "cooperatively extend the lease"
+    assert_includes port, "cooperatively extend the lease"
   end
 
   def test_contract_documents_renew_effect_lease

--- a/spec/support/release_gate_helpers.rb
+++ b/spec/support/release_gate_helpers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ReleaseGateHelpers
+  def normalized(path)
+    File.read(File.join(self.class::ROOT, path)).split.join(" ")
+  end
+end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -26,6 +26,7 @@ require_relative "support/runner_factory"
 require_relative "support/workflow_builders"
 require_relative "support/step_helpers"
 require_relative "support/event_helpers"
+require_relative "support/release_gate_helpers"
 
 TEST_TMPDIR = File.expand_path(ENV.fetch("TMPDIR", "~/.tmp/ruby-dag-tests"))
 FileUtils.mkdir_p(TEST_TMPDIR)
@@ -37,5 +38,6 @@ module Minitest
     include WorkflowBuilders
     include StepHelpers
     include EventHelpers
+    include ReleaseGateHelpers
   end
 end


### PR DESCRIPTION
## Summary

Three follow-up fixes surfaced by a `/simplify` review of #176 / #177.

- **Strengthen the renewal idempotency contract test.** `test_contract_renew_effect_lease_is_idempotent_when_until_ms_unchanged` previously only checked `lease_until_ms`. The port docstring promises the no-op case returns an *unchanged* record, so the test now also asserts `lease_owner`, `status`, and `updated_at_ms` are invariant. This is what would have caught a regression that quietly applied `record.with(...)` in the no-op branch.
- **Drop a no-op `.downcase` in the V1.2 release-gate test.** The docstring fragment `\"cooperatively extend the lease\"` is already lowercase in `lib/dag/ports/storage.rb`, so the call only masked an inconsistency with the case-sensitive signature assertion right above it.
- **Dedupe the `normalized(path)` helper.** It was identical in both `spec/r0/v1_1_release_gate_test.rb` and `spec/r0/v1_2_release_gate_test.rb`. Moves it into `spec/support/release_gate_helpers.rb` and auto-includes it on `Minitest::Test`, matching the convention used by `RunnerFactory`, `WorkflowBuilders`, `StepHelpers`, and `EventHelpers`.

## Test plan

- [x] `bundle exec rake` green: 597 runs, 40598 assertions (+3 from the strengthened idempotency test), 0 failures, 0 offenses.
- [x] The strengthened idempotency test fails as expected if the no-op early-return in `StorageState#renew_effect_lease` is removed (verified by reasoning, not destructive change).

## Out of scope

`/simplify` surfaced several findings that we deliberately skipped:

- Setup duplication across the eight `renew_effect_lease` contract tests — by design, the contract suite values stand-alone readability over DRY.
- The `# Implements Ports::Storage#X` doc comments — uniform across `storage_state.rb`, more navigation than narration.
- The `record.with(...) → state[:effects][id] = updated` pattern — transparent enough not to merit extraction.
- Repeated `File.read` in release-gate tests — full suite runs in ~0.7s, not worth caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)