### PR TITLE
feat: durably emit :effect_dispatch_stale_lease diagnostic event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,27 @@
 
 ## Unreleased
 
-- No changes yet.
+### Added
+
+- `DAG::Event::TYPES` gains `:effect_dispatch_stale_lease`, emitted by
+  `DAG::Effects::Dispatcher` when a handler returns but the storage lease
+  has already expired and the completion mark cannot be applied. The
+  dispatcher appends the event durably via `storage.append_event` before
+  recording the in-memory `DispatchReport#errors` entry, so the failure
+  mode is visible in the workflow event log instead of having to be
+  reconstructed from process-local state. Payload carries
+  `code: :stale_lease`, `effect_id`, `ref`, `type`, `lease_owner`,
+  `lease_until_ms`, and `message`.
+- `DAG::TraceRecord::STATUSES` gains `:effect_dispatch_stale_lease` and
+  the matching entry in `EVENT_STATUS`, mirroring the
+  `mutation_applied` 1:1 mapping pattern so trace consumers can render
+  the diagnostic without confusing it with a node-level failure.
+
+### Changed
+
+- `DAG::Effects::Dispatcher` now requires the storage adapter to
+  implement `append_event`. The Memory adapter already does;
+  `validate_storage!` is updated to reject adapters that don't.
 
 ## 1.2.0 — 2026-05-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,13 @@ methods:
   DAG::Effects::HandlerResult`**. Handler exceptions and invalid return values
   become retriable failures; unknown effect types default to terminal failure
   unless `unknown_handler_policy: :raise` is selected.
+- When the dispatcher catches `DAG::Effects::StaleLeaseError` after a
+  handler returns (the handler ran longer than `lease_ms`, so the mark
+  cannot be applied), it appends a durable
+  `:effect_dispatch_stale_lease` event via `storage.append_event` before
+  recording the error in `DispatchReport#errors`. This makes the failure
+  mode visible in the workflow event log instead of only in the in-memory
+  `DispatchReport`.
 
 This keeps concrete external integrations in Delphi while `ruby-dag` supplies
 the lease-aware, deterministic coordination contract.

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -321,8 +321,9 @@ After a successful handler result or terminal failure, waiting nodes are
 released only when every blocking effect linked to the waiting attempt is
 terminal. Retriable failures do not release waiting nodes.
 `DAG::Effects::StaleLeaseError` from a completion or mark operation is
-recorded in `errors` and the tick continues with the remaining claimed
-records.
+recorded in `errors`, durably appended to the workflow event log as a
+`:effect_dispatch_stale_lease` event, and the tick continues with the
+remaining claimed records.
 
 Handler exceptions and invalid handler return values become retriable effect
 failures with JSON-safe error payloads. Unknown effect types default to terminal
@@ -834,11 +835,27 @@ EVENT_TYPES = %i[
   workflow_completed
   workflow_failed
   mutation_applied
+  effect_dispatch_stale_lease
 ].freeze
 ```
 
 Events are durably appended by storage operations, then published live through
 `EventBus#publish` after commit.
+
+`:effect_dispatch_stale_lease` is the only event emitted by
+`DAG::Effects::Dispatcher` rather than by `DAG::Runner`. It records that a
+handler returned but the storage lease had already expired, so the
+completion mark could not be applied. The payload is JSON-safe and shaped:
+
+```text
+code            # always :stale_lease
+effect_id
+ref
+type            # the effect type (not the event type)
+lease_owner
+lease_until_ms
+message         # storage-supplied diagnostic
+```
 
 ## Runtime Profile
 

--- a/lib/dag/effects/dispatcher.rb
+++ b/lib/dag/effects/dispatcher.rb
@@ -164,7 +164,29 @@ module DAG
         outcome = handler_outcome_for(record)
         apply_handler_result(record, outcome.result, @clock.now_ms, outcome.error)
       rescue DAG::Effects::StaleLeaseError => stale
+        emit_stale_lease_event(record, stale)
         DispatchOutcome.claimed_not_marked(error: stale_lease_error(record, stale))
+      end
+
+      def emit_stale_lease_event(record, stale)
+        event = DAG::Event[
+          type: :effect_dispatch_stale_lease,
+          workflow_id: record.workflow_id,
+          revision: record.revision,
+          node_id: record.node_id,
+          attempt_id: record.attempt_id,
+          at_ms: @clock.now_ms,
+          payload: {
+            code: :stale_lease,
+            effect_id: record.id,
+            ref: record.ref,
+            type: record.type,
+            lease_owner: record.lease_owner,
+            lease_until_ms: record.lease_until_ms,
+            message: stale.message
+          }
+        ]
+        @storage.append_event(workflow_id: record.workflow_id, event: event)
       end
 
       def handler_outcome_for(record)
@@ -322,6 +344,7 @@ module DAG
           mark_effect_succeeded
           mark_effect_failed
           release_nodes_satisfied_by_effect
+          append_event
         ].each do |method_name|
           DAG::Validation.dependency!(value, method_name, "storage")
         end

--- a/lib/dag/event.rb
+++ b/lib/dag/event.rb
@@ -69,5 +69,6 @@ module DAG
     workflow_completed
     workflow_failed
     mutation_applied
+    effect_dispatch_stale_lease
   ].freeze
 end

--- a/lib/dag/trace_record.rb
+++ b/lib/dag/trace_record.rb
@@ -114,7 +114,7 @@ module DAG
   end
 
   # Closed normalized status vocabulary used by TraceRecord.
-  TraceRecord::STATUSES = %i[started success waiting failed paused completed mutation_applied].freeze
+  TraceRecord::STATUSES = %i[started success waiting failed paused completed mutation_applied effect_dispatch_stale_lease].freeze
 
   # Mapping from durable event types to normalized trace statuses.
   TraceRecord::EVENT_STATUS = {
@@ -127,6 +127,7 @@ module DAG
     workflow_waiting: :waiting,
     workflow_completed: :completed,
     workflow_failed: :failed,
-    mutation_applied: :mutation_applied
+    mutation_applied: :mutation_applied,
+    effect_dispatch_stale_lease: :effect_dispatch_stale_lease
   }.freeze
 end

--- a/spec/r2/effects_dispatcher_test.rb
+++ b/spec/r2/effects_dispatcher_test.rb
@@ -172,7 +172,7 @@ class EffectsDispatcherTest < Minitest::Test
     dispatcher = DAG::Effects::Dispatcher.new(
       storage: storage,
       handlers: {"success" => ->(_record) { DAG::Effects::HandlerResult.succeeded(result: {ok: true}) }},
-      clock: SequenceClock.new(1_000, 1_501),
+      clock: SequenceClock.new(1_000, 1_501, 1_502),
       owner_id: "worker",
       lease_ms: 500
     )
@@ -183,6 +183,38 @@ class EffectsDispatcherTest < Minitest::Test
     assert_empty report.succeeded
     assert_equal :stale_lease, report.errors.first[:code]
     assert_equal :dispatching, storage.list_effects_for_attempt(attempt_id: effect.attempt_id).first.status
+  end
+
+  def test_stale_lease_emits_durable_diagnostic_event
+    storage = DAG::Adapters::Memory::Storage.new
+    effect = commit_waiting_effect(storage, node_id: :a, effect_type: "success")
+    seq_before = storage.read_events(workflow_id: effect.workflow_id).last.seq
+    dispatcher = DAG::Effects::Dispatcher.new(
+      storage: storage,
+      handlers: {"success" => ->(_record) { DAG::Effects::HandlerResult.succeeded(result: {ok: true}) }},
+      clock: SequenceClock.new(1_000, 1_501, 1_502),
+      owner_id: "worker",
+      lease_ms: 500
+    )
+
+    dispatcher.tick(limit: 1)
+
+    new_events = storage.read_events(workflow_id: effect.workflow_id, after_seq: seq_before)
+    stale_event = new_events.find { |e| e.type == :effect_dispatch_stale_lease }
+    refute_nil stale_event, "expected an :effect_dispatch_stale_lease event in the durable log"
+    assert_equal effect.workflow_id, stale_event.workflow_id
+    assert_equal 1, stale_event.revision
+    assert_equal :a, stale_event.node_id
+    assert_equal effect.attempt_id, stale_event.attempt_id
+    assert_equal 1_502, stale_event.at_ms
+    payload = stale_event.payload
+    assert_equal :stale_lease, payload[:code]
+    assert_equal effect.id, payload[:effect_id]
+    assert_equal effect.ref, payload[:ref]
+    assert_equal "success", payload[:type]
+    assert_equal "worker", payload[:lease_owner]
+    assert_equal 1_500, payload[:lease_until_ms]
+    assert_kind_of String, payload[:message]
   end
 
   private
@@ -275,5 +307,12 @@ class EffectsDispatcherTest < Minitest::Test
     def release_nodes_satisfied_by_effect(effect_id:, now_ms:)
       []
     end
+
+    def append_event(workflow_id:, event:)
+      (@events ||= []) << event
+      event
+    end
+
+    attr_reader :events
   end
 end


### PR DESCRIPTION
## Summary

Closes the V1.2 follow-up promised in the `renew_effect_lease` discussion. When `DAG::Effects::Dispatcher` catches `StaleLeaseError` after a handler returns (the handler ran longer than `lease_ms`, so the completion mark is refused), the dispatcher now appends a durable `:effect_dispatch_stale_lease` event via `storage.append_event` before recording the `DispatchReport#errors` entry.

Before this change the only trace of the failure mode was the in-memory `DispatchReport.errors` array; once the tick returned, the signal was gone. The original retry-storm Delphi trace took ~6 hours to diagnose; with the durable event it would have shown up in the event log on the first occurrence.

## Design

- **`storage.append_event`, not `event_bus.publish`.** The dispatcher does not currently inject `event_bus`. Going purely through `storage.append_event` is additive (the port already exposes it), avoids changing `Dispatcher.new`'s signature, and is enough to satisfy the \"visible in the durable log\" requirement. Live notification is the consumer's responsibility — they can subscribe via `storage.read_events` or wire `event_bus` themselves around the dispatcher.
- **Event type added to the closed vocabulary.** `:effect_dispatch_stale_lease` is now in `DAG::Event::TYPES`. `TraceRecord::STATUSES` and `EVENT_STATUS` get a matching 1:1 entry, mirroring the `mutation_applied` pattern, so trace consumers don't accidentally fold this into a node-level failure.
- **Validate `append_event` on the storage port.** `Effects::Dispatcher#validate_storage!` now requires `append_event` alongside the existing four. Both the Memory adapter and the public port already provide it.

## Payload shape

```ruby
{
  code: :stale_lease,
  effect_id: record.id,
  ref: record.ref,
  type: record.type,        # the effect type, not the event type
  lease_owner: record.lease_owner,
  lease_until_ms: record.lease_until_ms,
  message: stale.message
}
```

This matches the shape from the original Delphi proposal, with `message` added for storage-supplied diagnostic context.

## Test plan

- [x] `bundle exec rake` green: 598 runs, 40611 assertions, 0 failures, 0 offenses.
- [x] New `test_stale_lease_emits_durable_diagnostic_event` confirms the event appears in `storage.read_events`, with the right `workflow_id`, `revision`, `node_id`, `attempt_id`, `at_ms` from the post-handler clock tick, and the full payload shape.
- [x] Existing `test_stale_lease_errors_are_reported_and_tick_continues` still passes (the `StaleSuccessStorage` mock now stubs `append_event` as a no-op).
- [x] Existing `test_mark_uses_fresh_time_after_handler` still passes (its `SequenceClock` was extended with the third `now_ms` value the dispatcher now consumes when emitting the event).

## Out of scope

- Consumer-side heartbeat / `LeaseRenewer` helper still lives in Delphi.
- No `event_bus` injection in `Effects::Dispatcher` — kept additive on the storage path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)