### PR TITLE
chore: carve out Thread+Queue exception for effects dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### Changed
+
+- Roadmap v3.4 §2.4 / §9.1 carve out a single V1.3+ exception to the
+  no-`Thread`/no-`Queue` ban: `lib/dag/effects/dispatcher.rb` is the
+  one file in `lib/dag/**` permitted to use `Thread` and `Queue` for
+  bounded parallel dispatch inside a `Dispatcher#tick`. `Mutex`,
+  `Monitor`, `SizedQueue`, `ConditionVariable`, `Fiber`,
+  `Process.fork`/`spawn`/`daemon`, and `Ractor` remain banned in that
+  file as everywhere else. The `Dag/NoThreadOrRactor` cop encodes the
+  carve-out via `dispatcher_relaxed_file?`; tests in
+  `spec/r0/rubocop_cops_test.rb` cover both the allow-list (Thread,
+  Queue) and the still-banned types (Mutex in the dispatcher) and
+  files (Thread in the runner). Rationale: the Dispatcher is already
+  an I/O-bound boundary and already non-deterministic by design
+  (handlers complete in network/LLM/disk order), so allowing
+  intra-tick parallelism does not move the §2.1 Determinism pillar —
+  Runner, Memory adapters, and every other `lib/dag/**` file remain
+  single-threaded. The `parallelism:` kwarg itself ships with the
+  V1.3 feature release; this changelog entry documents only the
+  governance carve-out it depends on. `CONTRACT.md` gains a
+  "Dispatcher Concurrency Contract" subsection covering storage and
+  handler thread-safety responsibilities and the
+  `Memory::Storage` + `parallelism > 1` `ArgumentError` rule.
+
 ### Added
 
 - `DAG::Event::TYPES` gains `:effect_dispatch_stale_lease`, emitted by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,34 @@
 
 ### Changed
 
-- Roadmap v3.4 §2.4 / §9.1 carve out a single V1.3+ exception to the
-  no-`Thread`/no-`Queue` ban: `lib/dag/effects/dispatcher.rb` is the
-  one file in `lib/dag/**` permitted to use `Thread` and `Queue` for
-  bounded parallel dispatch inside a `Dispatcher#tick`. `Mutex`,
-  `Monitor`, `SizedQueue`, `ConditionVariable`, `Fiber`,
-  `Process.fork`/`spawn`/`daemon`, and `Ractor` remain banned in that
-  file as everywhere else. The `Dag/NoThreadOrRactor` cop encodes the
-  carve-out via `dispatcher_relaxed_file?`; tests in
-  `spec/r0/rubocop_cops_test.rb` cover both the allow-list (Thread,
-  Queue) and the still-banned types (Mutex in the dispatcher) and
-  files (Thread in the runner). Rationale: the Dispatcher is already
-  an I/O-bound boundary and already non-deterministic by design
-  (handlers complete in network/LLM/disk order), so allowing
-  intra-tick parallelism does not move the §2.1 Determinism pillar —
-  Runner, Memory adapters, and every other `lib/dag/**` file remain
-  single-threaded. The `parallelism:` kwarg itself ships with the
-  V1.3 feature release; this changelog entry documents only the
-  governance carve-out it depends on. `CONTRACT.md` gains a
-  "Dispatcher Concurrency Contract" subsection covering storage and
-  handler thread-safety responsibilities and the
-  `Memory::Storage` + `parallelism > 1` `ArgumentError` rule.
+- Roadmap v3.4 §2.4 / §9.1 carve out a single V1.3+ exception against
+  two cop gates so bounded parallel dispatch can be implemented inside
+  the kernel:
+  - `Dag/NoThreadOrRactor` lets `lib/dag/effects/dispatcher.rb` use
+    `Thread` and `Queue` for the worker pool.
+  - `Dag/NoInPlaceMutation` lets the same file use `<<`, `pop`, and
+    `[]=` for queue feed, worker drain, and slot-indexed result
+    writes.
+  Both cops use the same `dispatcher_relaxed_file?` predicate.
+  `Mutex`, `Monitor`, `SizedQueue`, `ConditionVariable`, `Fiber`,
+  `Process.fork`/`spawn`/`daemon`, `Ractor`, and the other mutating
+  ops (`merge!`, `update`, `delete`, `clear`, `shift`, `push`)
+  remain banned even in the dispatcher. Tests in
+  `spec/r0/rubocop_cops_test.rb` cover both cops' allow-lists
+  (Thread/Queue and `<<`/`pop`/`[]=` in the dispatcher) and the
+  still-banned cases (Mutex and `merge!` in the dispatcher; Thread in
+  the runner; `<<` in other `lib/dag/effects/**` files). Rationale: the
+  Dispatcher is already an I/O-bound boundary and already
+  non-deterministic by design (handlers complete in network/LLM/disk
+  order), so allowing intra-tick parallelism does not move the §2.1
+  Determinism pillar — Runner, Memory adapters, and every other
+  `lib/dag/**` file remain single-threaded and pure-value. The
+  `parallelism:` kwarg itself ships with the V1.3 feature release;
+  this changelog entry documents only the governance carve-out it
+  depends on. `CONTRACT.md` gains a "Dispatcher Concurrency Contract"
+  subsection covering storage and handler thread-safety
+  responsibilities and the `Memory::Storage` + `parallelism > 1`
+  `ArgumentError` rule.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,11 +39,20 @@ Hard rules:
   documented extension with explicit justification — see "Port extensions"
   below.
 - **Anti-patterns in §9.1 do not pass review.** No `Thread`/`Ractor`/
-  `Mutex`/`Queue` anywhere; no `Process.fork`/`spawn`/`system` in
-  `lib/dag/**`; no `attr_accessor` in `lib/dag/**`; no in-place mutation in
-  pure-kernel files; no non-stdlib `require` at runtime; no AI/LLM terms in
-  the kernel; no budget/approval inside `Runner`; no default-singleton
-  injected dependencies on `Runner.new` (all 7 keyword args are required).
+  `Mutex`/`Queue` anywhere (carve-out below); no `Process.fork`/`spawn`/
+  `system` in `lib/dag/**`; no `attr_accessor` in `lib/dag/**`; no
+  in-place mutation in pure-kernel files; no non-stdlib `require` at
+  runtime; no AI/LLM terms in the kernel; no budget/approval inside
+  `Runner`; no default-singleton injected dependencies on `Runner.new`
+  (all 7 keyword args are required).
+- **Single V1.3 carve-out.** `lib/dag/effects/dispatcher.rb` is the one
+  file allowed to use `Thread` and `Queue`, for bounded parallel
+  dispatch within a `Dispatcher#tick`. `Mutex`, `Monitor`, `SizedQueue`,
+  `ConditionVariable`, `Fiber`, `Process.fork`/`spawn`/`daemon`, and
+  `Ractor` remain banned even in this file. The `Dag/NoThreadOrRactor`
+  cop encodes the carve-out via `dispatcher_relaxed_file?`. Every other
+  file in `lib/dag/**` — including `Runner`, `Memory::Storage`, and the
+  rest of `lib/dag/effects/**` — stays single-thread.
 - **Frozen decisions (§3) are not negotiable.** Ruby ≥ 3.4. Zero runtime
   deps. Test framework Minitest. Memory adapters single-process. SQLite
   for durable concurrency in S0. No Ractor anywhere.
@@ -386,8 +395,11 @@ public surface) without paying ceremony for private scaffolding.
   registry:, clock:, id_generator:, fingerprint:, serializer:`); a
   missing or `nil` keyword raises `ArgumentError`.
 - No `Thread`, `Mutex`, `Queue`, `Ractor`, `Monitor`, or `ConditionVariable`
-  anywhere in `lib/dag/**`. The `Dag/NoThreadOrRactor` cop enforces this
-  globally.
+  anywhere in `lib/dag/**`, with the single carve-out for `Thread` + `Queue`
+  in `lib/dag/effects/dispatcher.rb` (V1.3+, see "Hard rules" above).
+  `Mutex`, `Monitor`, `SizedQueue`, `ConditionVariable`, and `Ractor`
+  remain banned even in the dispatcher. The `Dag/NoThreadOrRactor` cop
+  encodes both the global ban and the carve-out.
 - Event types are the closed set in `DAG::Event::TYPES`. The Runner
   emits `:workflow_started` once per workflow (idempotent via event log
   inspection), `:node_started` / `:node_committed` / `:node_waiting` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,13 +46,19 @@ Hard rules:
   `Runner`; no default-singleton injected dependencies on `Runner.new`
   (all 7 keyword args are required).
 - **Single V1.3 carve-out.** `lib/dag/effects/dispatcher.rb` is the one
-  file allowed to use `Thread` and `Queue`, for bounded parallel
-  dispatch within a `Dispatcher#tick`. `Mutex`, `Monitor`, `SizedQueue`,
-  `ConditionVariable`, `Fiber`, `Process.fork`/`spawn`/`daemon`, and
-  `Ractor` remain banned even in this file. The `Dag/NoThreadOrRactor`
-  cop encodes the carve-out via `dispatcher_relaxed_file?`. Every other
-  file in `lib/dag/**` — including `Runner`, `Memory::Storage`, and the
-  rest of `lib/dag/effects/**` — stays single-thread.
+  file in `lib/dag/**` allowed to use the concurrency primitives needed
+  to implement bounded parallel dispatch within a `Dispatcher#tick`:
+  `Thread` and `Queue` (cop `Dag/NoThreadOrRactor`) for the worker
+  pool, plus `<<`, `pop`, and `[]=` mutating ops (cop
+  `Dag/NoInPlaceMutation`) for queue feed, worker drain, and
+  slot-indexed result writes. Both cops encode the same
+  `dispatcher_relaxed_file?` carve-out. `Mutex`, `Monitor`,
+  `SizedQueue`, `ConditionVariable`, `Fiber`,
+  `Process.fork`/`spawn`/`daemon`, `Ractor`, and the other mutating
+  ops (`merge!`, `update`, `delete`, `clear`, `shift`, `push`) remain
+  banned even in this file. Every other file in `lib/dag/**` —
+  including `Runner`, `Memory::Storage`, and the rest of
+  `lib/dag/effects/**` — stays single-thread and pure-value.
 - **Frozen decisions (§3) are not negotiable.** Ruby ≥ 3.4. Zero runtime
   deps. Test framework Minitest. Memory adapters single-process. SQLite
   for durable concurrency in S0. No Ractor anywhere.

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -342,6 +342,68 @@ type
 Code-specific entries may add fields. `:handler_raised` adds `class` and
 `message`; `:handler_bad_return` adds `class`; `:stale_lease` adds `message`.
 
+### Dispatcher Concurrency Contract
+
+`DAG::Effects::Dispatcher` is the single file in `lib/dag/**` permitted
+to use `Thread` and `Queue` (Roadmap v3.4 §2.4 / §9.1 V1.3 carve-out).
+The default behavior is unchanged: a `Dispatcher` dispatches claimed
+records sequentially within a `tick`. This subsection documents the
+contract a consumer agrees to when opting into bounded parallel
+dispatch via the `parallelism:` kwarg introduced in V1.3. The kwarg
+itself ships with the feature release; this section is the binding
+contract that release implements against.
+
+A `Dispatcher` constructed with `parallelism: > 1` dispatches its
+claimed records concurrently with at most `parallelism` worker threads
+in flight, regardless of the batch size. Two responsibilities flow to
+the consumer:
+
+**Storage thread-safety.** When `parallelism > 1`, the storage adapter
+must be safe for concurrent invocation, from up to `parallelism`
+threads, of every method the dispatcher touches:
+
+```text
+claim_ready_effects
+mark_effect_succeeded
+mark_effect_failed
+complete_effect_succeeded
+complete_effect_failed
+release_nodes_satisfied_by_effect
+append_event
+renew_effect_lease
+```
+
+`DAG::Adapters::Memory::Storage` is single-process and **does not**
+declare this property; constructing
+`Dispatcher.new(storage: memory_storage, parallelism: > 1)` raises
+`ArgumentError`. Durable adapters that bind every dispatcher-touched
+method to a backend transaction (typically a single SQL transaction
+per call) satisfy the contract by construction. Consumer adapters
+declare the property explicitly so the dispatcher can validate it at
+construction.
+
+**Handler thread-safety.** When `parallelism > 1`, every registered
+handler must be safe for concurrent invocation. This was an implicit
+property in V1.2 single-thread tick (where handler concurrency could
+only come from running multiple `Dispatcher` instances in distinct
+processes) and is now explicit: handler `#call` may be invoked by
+distinct threads on distinct records simultaneously, and must not
+share unsynchronized mutable state across calls.
+
+The dispatcher itself does not introduce shared mutable state across
+worker threads beyond the bounded work queue: claimed records are
+pushed onto a queue once, each worker pops, dispatches, and writes its
+outcome into a pre-allocated slot. Order preservation in
+`DispatchReport` is per collection: `succeeded.map(&:id)` is a
+subsequence of `claimed.map(&:id)` in original order, but the
+collections do not promise positional alignment with `claimed`.
+
+Unexpected exceptions raised inside a worker thread re-emerge from
+`#tick`: `dispatch_record` continues to catch only
+`DAG::Effects::StaleLeaseError`, and any other exception propagates via
+`Thread#value` re-raise after `join`. The serial map's exception
+semantics are preserved.
+
 ## Storage Receipts And Failure Vocabulary
 
 Public storage methods must not require consumers to infer success from `nil`

--- a/Ruby DAG Project Roadmap v3.4.md
+++ b/Ruby DAG Project Roadmap v3.4.md
@@ -109,17 +109,26 @@ Regole operative:
 
 **Eccezione puntuale V1.3 — `lib/dag/effects/dispatcher.rb`.**
 A partire da V1.3, il singolo file `lib/dag/effects/dispatcher.rb` può
-usare `Thread` e `Queue` per parallel dispatch bounded all'interno di
-un `Dispatcher#tick(limit:)`. L'eccezione è chirurgica per file e per
-primitiva: `Mutex`, `Monitor`, `SizedQueue`, `ConditionVariable`,
-`Fiber`, `Process.fork`/`spawn`/`daemon`, `system`/backtick shell e
-`Ractor` restano universalmente banditi, anche in
-`lib/dag/effects/dispatcher.rb`. Razionale: il Dispatcher è già un
-boundary I/O-bound e già non-deterministico per design (gli handler
-completano nell'ordine in cui finiscono il network/LLM/disk, non in un
-ordine prescritto), quindi parallelizzare *dentro* un tick non muove il
-pillar §2.1 Determinismo — il Runner, gli adapter Memory, e ogni altro
-file `lib/dag/**` restano single-thread invariati. `parallelism > 1`
+usare:
+
+- `Thread` e `Queue` (cop `DAG::NoThreadOrRactor`) per orchestrare il
+  pool worker bounded;
+- `<<` (push su `Queue`), `pop` (worker drain di `Queue`), e `[]=`
+  (slot-indexed write su array pre-allocato) (cop
+  `DAG::NoInPlaceMutation`) per alimentare la coda, drenarla nei
+  worker, e raccogliere i risultati.
+
+L'eccezione è chirurgica per file e per primitiva. Restano
+universalmente banditi anche in questo file: `Mutex`, `Monitor`,
+`SizedQueue`, `ConditionVariable`, `Fiber`,
+`Process.fork`/`spawn`/`daemon`, `system`/backtick shell, `Ractor`, e
+le mutating ops `merge!`, `update`, `delete`, `clear`, `shift`,
+`push`. Razionale: il Dispatcher è già un boundary I/O-bound e già
+non-deterministico per design (gli handler completano nell'ordine in
+cui finiscono il network/LLM/disk, non in un ordine prescritto),
+quindi parallelizzare *dentro* un tick non muove il pillar §2.1
+Determinismo — il Runner, gli adapter Memory, e ogni altro file
+`lib/dag/**` restano single-thread invariati. `parallelism > 1`
 richiede uno storage adapter che dichiari thread-safety per le
 chiamate dispatcher-touched; `Memory::Storage` non lo dichiara e resta
 `parallelism = 1` only. Vedi `CONTRACT.md` "Dispatcher concurrency
@@ -156,7 +165,7 @@ DAG::Adapters::Memory::CrashableStorage
 | `lib/dag/definition_editor.rb` | vietati | vietato | vietati | vietata | kernel puro |
 | `lib/dag/adapters/memory/storage.rb` | vietati | vietato | vietati | consentita privata | single-process adapter |
 | `lib/dag/adapters/memory/event_bus.rb` | vietati | vietato | vietati | consentita privata | single-process adapter |
-| `lib/dag/effects/dispatcher.rb` | `Thread` consentito, `Ractor` vietato | vietato | `Queue` consentito; `Mutex`/`Monitor`/`SizedQueue`/`ConditionVariable` vietati | vietata | **eccezione V1.3** per parallel dispatch bounded |
+| `lib/dag/effects/dispatcher.rb` | `Thread` consentito, `Ractor` vietato | vietato | `Queue` consentito; `Mutex`/`Monitor`/`SizedQueue`/`ConditionVariable` vietati | `<<`, `pop` e `[]=` consentiti per pool feed/drain e slot writes; altre mutating ops vietate | **eccezione V1.3** per parallel dispatch bounded |
 | `test/**` core | vietati | consentito solo se dichiarato nel test | vietati | consentito nei fake | niente Ractor |
 | `test/s0/**` in `delphic` | vietati | consentito | vietati | consentito nei fixture | process concurrency SQLite |
 | `lib/delphic/**` | vietati | consentito solo in adapter/process runner espliciti | vietati | consentita negli storage applicativi | fiber-first |
@@ -1501,7 +1510,8 @@ Una PR che introduce anche solo una di queste violazioni non passa review.
 | `Queue` | tutto il repo, incluso `test/**` e adapter Memory, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3) | `DAG::NoThreadOrRactor` |
 | `Process.fork`, `Process.spawn`, `system`, backtick shell, `%x` | `lib/dag/**` | `DAG::NoThreadOrRactor`; `Process.clock_gettime` resta consentito |
 | `attr_accessor`, `attr_writer` | tutto `lib/dag/**` | `DAG::NoMutableAccessors` |
-| `push`, `<<`, `merge!`, `update`, `delete`, `clear`, `shift`, `pop`, `[]=` su stato kernel | kernel puro | `DAG::NoInPlaceMutation` |
+| `push`, `merge!`, `update`, `delete`, `clear`, `shift` su stato kernel | kernel puro | `DAG::NoInPlaceMutation` |
+| `<<`, `[]=`, `pop` su stato kernel | kernel puro, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3 per pool feed/drain e slot writes) | `DAG::NoInPlaceMutation` |
 | `add_dependency` nel gemspec `ruby-dag` | gemspec | test zero runtime deps |
 | `require` di librerie non stdlib | runtime | `DAG::NoExternalRequires` |
 | Termini AI nel kernel: `prompt`, `token`, `model`, `skill`, `conversation`, `llm` | kernel | grep test + review |
@@ -2432,7 +2442,7 @@ end
 
 #### `NoInPlaceMutation`
 
-Scope: kernel puro. Gli adapter stateful sono esclusi ma non devono esporre riferimenti mutabili.
+Scope: kernel puro. Gli adapter stateful sono esclusi ma non devono esporre riferimenti mutabili. Eccezione V1.3 chirurgica: `lib/dag/effects/dispatcher.rb` può usare `<<` (queue feed), `pop` (worker drain) e `[]=` (slot-indexed result writes) per il `parallel_map` bounded; gli altri metodi mutating restano banditi anche in questo file.
 
 Metodi minimi da intercettare:
 

--- a/Ruby DAG Project Roadmap v3.4.md
+++ b/Ruby DAG Project Roadmap v3.4.md
@@ -100,12 +100,30 @@ Ogni oggetto che attraversa il confine pubblico del kernel deve essere deep-froz
 Regole operative:
 
 - Nessun `Ractor` in nessun repo.
-- Nessun `Thread`, `Mutex`, `Monitor`, `Queue`, `SizedQueue`, `ConditionVariable` nel kernel e negli adapter Memory.
+- Nessun `Thread`, `Mutex`, `Monitor`, `Queue`, `SizedQueue`, `ConditionVariable` nel kernel e negli adapter Memory, **eccezione puntuale V1.3** documentata sotto per `lib/dag/effects/dispatcher.rb`.
 - Nessun `Process.fork`, `Process.spawn`, backtick shell o `system` in `lib/dag/**`.
 - I test possono usare processi solo dove serve verificare la concorrenza reale; per `ruby-dag` core i test restano single-process, mentre i test process-level vivono in S0 su SQLite dentro `delphic`.
 - `Memory::Storage` e `Memory::EventBus` sono adapter **single-process** per test, REPL e sviluppo. Non sono backend process-safe e non devono fingere di esserlo.
 - `Delphic::Adapters::Sqlite::Storage` è il primo backend process-safe: ogni processo apre una propria connessione SQLite e si coordina tramite transazioni.
 - `delphic` usa `Async::Task` / fiber per concorrenza applicativa. I processi sono ammessi solo per isolamento esplicito di tool esterni, worker o test di integrazione; non per rendere concorrente il kernel.
+
+**Eccezione puntuale V1.3 — `lib/dag/effects/dispatcher.rb`.**
+A partire da V1.3, il singolo file `lib/dag/effects/dispatcher.rb` può
+usare `Thread` e `Queue` per parallel dispatch bounded all'interno di
+un `Dispatcher#tick(limit:)`. L'eccezione è chirurgica per file e per
+primitiva: `Mutex`, `Monitor`, `SizedQueue`, `ConditionVariable`,
+`Fiber`, `Process.fork`/`spawn`/`daemon`, `system`/backtick shell e
+`Ractor` restano universalmente banditi, anche in
+`lib/dag/effects/dispatcher.rb`. Razionale: il Dispatcher è già un
+boundary I/O-bound e già non-deterministico per design (gli handler
+completano nell'ordine in cui finiscono il network/LLM/disk, non in un
+ordine prescritto), quindi parallelizzare *dentro* un tick non muove il
+pillar §2.1 Determinismo — il Runner, gli adapter Memory, e ogni altro
+file `lib/dag/**` restano single-thread invariati. `parallelism > 1`
+richiede uno storage adapter che dichiari thread-safety per le
+chiamate dispatcher-touched; `Memory::Storage` non lo dichiara e resta
+`parallelism = 1` only. Vedi `CONTRACT.md` "Dispatcher concurrency
+contract".
 
 Sono kernel puro:
 
@@ -138,6 +156,7 @@ DAG::Adapters::Memory::CrashableStorage
 | `lib/dag/definition_editor.rb` | vietati | vietato | vietati | vietata | kernel puro |
 | `lib/dag/adapters/memory/storage.rb` | vietati | vietato | vietati | consentita privata | single-process adapter |
 | `lib/dag/adapters/memory/event_bus.rb` | vietati | vietato | vietati | consentita privata | single-process adapter |
+| `lib/dag/effects/dispatcher.rb` | `Thread` consentito, `Ractor` vietato | vietato | `Queue` consentito; `Mutex`/`Monitor`/`SizedQueue`/`ConditionVariable` vietati | vietata | **eccezione V1.3** per parallel dispatch bounded |
 | `test/**` core | vietati | consentito solo se dichiarato nel test | vietati | consentito nei fake | niente Ractor |
 | `test/s0/**` in `delphic` | vietati | consentito | vietati | consentito nei fixture | process concurrency SQLite |
 | `lib/delphic/**` | vietati | consentito solo in adapter/process runner espliciti | vietati | consentita negli storage applicativi | fiber-first |
@@ -1477,8 +1496,9 @@ Una PR che introduce anche solo una di queste violazioni non passa review.
 | Anti-pattern | Dove è vietato | Mitigazione |
 |---|---|---|
 | `Ractor`, `Ractor.new`, `Ractor.receive`, `Ractor.yield` | tutto il repo, incluso `test/**` | `DAG::NoThreadOrRactor` |
-| `Thread.new`, `Thread.start`, `Thread.fork` | tutto il repo, incluso `test/**` | `DAG::NoThreadOrRactor` |
-| `Mutex`, `Monitor`, `Queue`, `SizedQueue`, `ConditionVariable` | tutto il repo, incluso `test/**` e adapter Memory | `DAG::NoThreadOrRactor` |
+| `Thread.new`, `Thread.start`, `Thread.fork` | tutto il repo, incluso `test/**`, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3) | `DAG::NoThreadOrRactor` |
+| `Mutex`, `Monitor`, `SizedQueue`, `ConditionVariable` | tutto il repo, incluso `test/**` e adapter Memory | `DAG::NoThreadOrRactor` |
+| `Queue` | tutto il repo, incluso `test/**` e adapter Memory, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3) | `DAG::NoThreadOrRactor` |
 | `Process.fork`, `Process.spawn`, `system`, backtick shell, `%x` | `lib/dag/**` | `DAG::NoThreadOrRactor`; `Process.clock_gettime` resta consentito |
 | `attr_accessor`, `attr_writer` | tutto `lib/dag/**` | `DAG::NoMutableAccessors` |
 | `push`, `<<`, `merge!`, `update`, `delete`, `clear`, `shift`, `pop`, `[]=` su stato kernel | kernel puro | `DAG::NoInPlaceMutation` |
@@ -2273,9 +2293,10 @@ Vincoli per `Memory::Storage`:
 
 Regole:
 
-- vieta `Thread.new`, `Thread.start`, `Thread.fork` ovunque, incluso `test/**`;
+- vieta `Thread.new`, `Thread.start`, `Thread.fork` ovunque, incluso `test/**`, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3 per parallel dispatch bounded);
 - vieta `Ractor`, `Ractor.new`, `Ractor.receive`, `Ractor.yield` ovunque, incluso `test/**`;
-- vieta `Mutex.new`, `Monitor.new`, `Queue.new`, `SizedQueue.new`, `ConditionVariable.new` ovunque, incluso `test/**` e adapter Memory;
+- vieta `Mutex.new`, `Monitor.new`, `SizedQueue.new`, `ConditionVariable.new` ovunque, incluso `test/**` e adapter Memory;
+- vieta `Queue.new` ovunque, incluso `test/**` e adapter Memory, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3);
 - vieta process spawn nel runtime `lib/dag/**`: `Process.fork`, `Process.spawn`, `Process.daemon`, `Kernel.system`, backtick shell e `%x`; `Process.clock_gettime` resta consentito;
 - i test S0 possono usare `Process.fork` perché verificano il backend SQLite, non il kernel.
 

--- a/rubocop/cop/dag/no_in_place_mutation.rb
+++ b/rubocop/cop/dag/no_in_place_mutation.rb
@@ -8,6 +8,12 @@ module RuboCop
       class NoInPlaceMutation < Base
         MSG = "Do not mutate pure kernel values in place."
         MUTATING_METHODS = %i[push << merge! update delete clear shift pop []=].freeze
+        # Methods the V1.3 dispatcher carve-out lets through in
+        # `lib/dag/effects/dispatcher.rb` because bounded `parallel_map`
+        # needs queue feed (`<<`), worker drain (`pop`), and
+        # slot-indexed result writes (`[]=`). Every other mutating method
+        # stays banned even in the dispatcher.
+        DISPATCHER_RELAXED_METHODS = %i[<< []= pop].freeze
         # Files that wrap their state in Data.define and must not mutate it
         # in place. Everything under `lib/dag/effects/` is also pure value
         # code. `immutability.rb` is intentionally NOT in this list — it is
@@ -26,7 +32,10 @@ module RuboCop
         RESTRICT_ON_SEND = MUTATING_METHODS
 
         def on_send(node)
-          add_offense(node) if pure_kernel_file?
+          return unless pure_kernel_file?
+          return if dispatcher_relaxed_file? && DISPATCHER_RELAXED_METHODS.include?(node.method_name)
+
+          add_offense(node)
         end
 
         private
@@ -36,6 +45,15 @@ module RuboCop
           PURE_KERNEL_FILES.any? { |file| path.end_with?("/lib/dag/#{file}") } ||
             path.include?("/lib/dag/effects/") ||
             path.include?("/lib/dag/ports/")
+        end
+
+        # Roadmap v3.4 §2.4 / §9.1 V1.3 carve-out: the abstract effect
+        # dispatcher can use `<<` (queue feed), `pop` (worker drain), and
+        # `[]=` (slot-indexed result writes) for bounded `parallel_map`.
+        # Other mutating methods (`merge!`, `update`, `delete`, `clear`,
+        # `shift`, `push`) stay banned even in this file.
+        def dispatcher_relaxed_file?
+          processed_source.file_path.end_with?("/lib/dag/effects/dispatcher.rb")
         end
       end
     end

--- a/rubocop/cop/dag/no_thread_or_ractor.rb
+++ b/rubocop/cop/dag/no_thread_or_ractor.rb
@@ -8,11 +8,15 @@ module RuboCop
       class NoThreadOrRactor < Base
         MSG = "Do not use thread/ractor primitives or process spawning in ruby-dag kernel code."
         FORBIDDEN_CONS = %w[Thread Ractor Mutex Monitor Queue SizedQueue ConditionVariable].freeze
+        DISPATCHER_RELAXED_CONS = %w[Thread Queue].freeze
         FORBIDDEN_THREAD_SENDS = %i[new start fork].freeze
         FORBIDDEN_PROCESS_SENDS = %i[fork spawn daemon].freeze
 
         def on_const(node)
-          add_offense(node) if FORBIDDEN_CONS.include?(node.const_name)
+          return unless FORBIDDEN_CONS.include?(node.const_name)
+          return if dispatcher_relaxed_file? && DISPATCHER_RELAXED_CONS.include?(node.const_name)
+
+          add_offense(node)
         end
 
         def on_send(node)
@@ -25,6 +29,8 @@ module RuboCop
           end
 
           if receiver&.const_type? && %w[Thread Ractor].include?(receiver.const_name)
+            return if dispatcher_relaxed_file? && receiver.const_name == "Thread"
+
             add_offense(node) if FORBIDDEN_THREAD_SENDS.include?(method_name)
             return
           end
@@ -41,6 +47,14 @@ module RuboCop
         def runtime_file?
           path = processed_source.file_path
           path.include?("/lib/dag/") || path.end_with?("/lib/dag.rb")
+        end
+
+        # Roadmap v3.4 §2.4 / §9.1 carve-out: the abstract effect dispatcher
+        # is the single file allowed to use Thread + Queue for bounded
+        # parallel dispatch from V1.3 onward. Mutex/Monitor/SizedQueue/
+        # ConditionVariable/Ractor remain banned even in this file.
+        def dispatcher_relaxed_file?
+          processed_source.file_path.end_with?("/lib/dag/effects/dispatcher.rb")
         end
       end
     end

--- a/spec/r0/rubocop_cops_test.rb
+++ b/spec/r0/rubocop_cops_test.rb
@@ -18,6 +18,46 @@ class R0RuboCopCopsTest < Minitest::Test
     refute_empty offenses
   end
 
+  def test_no_thread_or_ractor_allows_thread_in_dispatcher
+    offenses = inspect_source(
+      RuboCop::Cop::DAG::NoThreadOrRactor,
+      "Thread.new { :work }.value\n",
+      path: runtime_path("effects/dispatcher.rb")
+    )
+
+    assert_empty offenses
+  end
+
+  def test_no_thread_or_ractor_allows_queue_in_dispatcher
+    offenses = inspect_source(
+      RuboCop::Cop::DAG::NoThreadOrRactor,
+      "queue = Queue.new\nqueue << :item\n",
+      path: runtime_path("effects/dispatcher.rb")
+    )
+
+    assert_empty offenses
+  end
+
+  def test_no_thread_or_ractor_still_flags_mutex_in_dispatcher
+    offenses = inspect_source(
+      RuboCop::Cop::DAG::NoThreadOrRactor,
+      "lock = Mutex.new\nlock.synchronize { :work }\n",
+      path: runtime_path("effects/dispatcher.rb")
+    )
+
+    refute_empty offenses
+  end
+
+  def test_no_thread_or_ractor_still_flags_thread_in_runner
+    offenses = inspect_source(
+      RuboCop::Cop::DAG::NoThreadOrRactor,
+      "Thread.new { :work }\n",
+      path: runtime_path("runner.rb")
+    )
+
+    refute_empty offenses
+  end
+
   def test_no_thread_or_ractor_flags_runtime_process_spawn
     offenses = inspect_source(
       RuboCop::Cop::DAG::NoThreadOrRactor,

--- a/spec/r0/rubocop_cops_test.rb
+++ b/spec/r0/rubocop_cops_test.rb
@@ -138,6 +138,56 @@ class R0RuboCopCopsTest < Minitest::Test
     refute_empty offenses
   end
 
+  def test_no_in_place_mutation_allows_queue_push_in_dispatcher
+    offenses = inspect_source(
+      RuboCop::Cop::DAG::NoInPlaceMutation,
+      "queue = Queue.new\nitems.each_with_index { |item, idx| queue << [item, idx] }\n",
+      path: runtime_path("effects/dispatcher.rb")
+    )
+
+    assert_empty offenses
+  end
+
+  def test_no_in_place_mutation_allows_slot_write_in_dispatcher
+    offenses = inspect_source(
+      RuboCop::Cop::DAG::NoInPlaceMutation,
+      "results = Array.new(items.length)\nresults[idx] = block.call(item)\n",
+      path: runtime_path("effects/dispatcher.rb")
+    )
+
+    assert_empty offenses
+  end
+
+  def test_no_in_place_mutation_allows_queue_pop_in_dispatcher
+    offenses = inspect_source(
+      RuboCop::Cop::DAG::NoInPlaceMutation,
+      "queue = Queue.new\npair = queue.pop(true)\n",
+      path: runtime_path("effects/dispatcher.rb")
+    )
+
+    assert_empty offenses
+  end
+
+  def test_no_in_place_mutation_still_flags_merge_bang_in_dispatcher
+    offenses = inspect_source(
+      RuboCop::Cop::DAG::NoInPlaceMutation,
+      "config = {}\nconfig.merge!(extra: 1)\n",
+      path: runtime_path("effects/dispatcher.rb")
+    )
+
+    refute_empty offenses
+  end
+
+  def test_no_in_place_mutation_still_flags_push_in_other_effects_file
+    offenses = inspect_source(
+      RuboCop::Cop::DAG::NoInPlaceMutation,
+      "values = []\nvalues << :item\n",
+      path: runtime_path("effects/intent.rb")
+    )
+
+    refute_empty offenses
+  end
+
   def test_no_external_requires_flags_non_stdlib_runtime_requires
     offenses = inspect_source(
       RuboCop::Cop::DAG::NoExternalRequires,


### PR DESCRIPTION
## Summary

Roadmap v3.4 §2.4 / §9.1 carve out a single V1.3+ exception against **two cop gates** so bounded parallel dispatch can be implemented inside the kernel:

- **`Dag/NoThreadOrRactor`** lets `lib/dag/effects/dispatcher.rb` use `Thread` and `Queue` for the worker pool.
- **`Dag/NoInPlaceMutation`** lets the same file use `<<`, `pop`, and `[]=` for queue feed, worker drain, and slot-indexed result writes.

Both cops use the same `dispatcher_relaxed_file?` predicate.

`Mutex`, `Monitor`, `SizedQueue`, `ConditionVariable`, `Fiber`, `Process.fork/spawn/daemon`, `Ractor`, and the other mutating ops (`merge!`, `update`, `delete`, `clear`, `shift`, `push`) remain banned even in the dispatcher. Other files in `lib/dag/effects/**` (`intent.rb`, `record.rb`, etc.) stay under the global ban.

`CONTRACT.md` gains a "Dispatcher Concurrency Contract" subsection covering storage thread-safety, handler thread-safety, and the `Memory::Storage` + `parallelism > 1` `ArgumentError` rule.

## Rationale

`DAG::Effects::Dispatcher#tick` claims up to `limit` effects then dispatches them sequentially via `claimed.map { |record| dispatch_record(record) }`. For workflows with fan-out on N co-eligible effects, wall time degenerates to `N × per_record` instead of `max_i(per_record_i)`.

The Dispatcher is already an I/O-bound boundary and already non-deterministic by design — handlers complete when the network/LLM/disk finishes, not in a prescribed order. Allowing intra-tick parallelism does not move the §2.1 Determinism pillar. Runner, Memory adapters, and every other `lib/dag/**` file remain single-threaded and pure-value.

## Why two cops

The bounded `parallel_map` pattern needs primitives gated by **both** custom cops:

```ruby
queue = Queue.new                                   # NoThreadOrRactor
items.each_with_index { |i, n| queue << [i, n] }    # NoInPlaceMutation: <<
Thread.new do                                       # NoThreadOrRactor
  pair = queue.pop(true)                            # NoInPlaceMutation: pop
  results[idx] = block.call(...)                    # NoInPlaceMutation: []=
end
```

Without the `NoInPlaceMutation` extension the carve-out is only decorative: the cop gate still rejects the implementation. The first commit relaxed `NoThreadOrRactor` only; the second commit closes that gap and verifies the full pattern passes the production `bundle exec rubocop` against the real config.

## Scope

This PR ships **only** the governance carve-out:

- Roadmap §2.4 (carve-out paragraph + concurrency table row), §9.1 (split rows for `NoInPlaceMutation` and `NoThreadOrRactor`), Appendix F (both cop descriptions)
- Cop changes (`dispatcher_relaxed_file?` helper in both cops + relaxed `on_const`/`on_send`)
- 8 new cop tests in `spec/r0/rubocop_cops_test.rb`
- `CONTRACT.md` Dispatcher Concurrency Contract subsection
- `CLAUDE.md` updated bullets
- `CHANGELOG.md` Unreleased entry

The `parallelism:` kwarg itself ships separately as the V1.3 feature release, in a follow-up PR that implements the contract documented here.

## What is NOT in this PR

- `Dispatcher.new(parallelism:)` kwarg
- `parallel_map` implementation
- `Memory::Storage` thread-safety declaration
- Version bump (V1.2 → V1.3 lands with the feature)

## Test plan

- [x] `bundle exec rake` — 607 runs, 40629 assertions, 0 failures
- [x] `bundle exec rubocop` — 151 files, no offenses
- [x] `bundle exec yard doc --no-output --no-progress --fail-on-warning` passes
- [x] Sanity check: full `parallel_map` pattern (Thread.new + Queue.new + queue << + queue.pop + Array.new + results[]= + Thread#join) added to dispatcher.rb temporarily, run through `bundle exec rubocop` against production config — no offenses; reverted before commit
- [x] New cop tests cover both cops' allow-lists (Thread/Queue and `<<`/`pop`/`[]=` in the dispatcher) and the still-banned cases (Mutex and `merge!` in the dispatcher; Thread in the runner; `<<` in other `lib/dag/effects/**` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)