### PR TITLE
chore: tighten dispatcher carve-out to Thread.new only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
   two cop gates so bounded parallel dispatch can be implemented inside
   the kernel:
   - `Dag/NoThreadOrRactor` lets `lib/dag/effects/dispatcher.rb` use
-    `Thread` and `Queue` for the worker pool.
+    `Thread.new` and `Queue` for the worker pool. `Thread.start` and
+    `Thread.fork` stay banned even in this file: bounded
+    `parallel_map` does not need them, and keeping them blocked closes
+    the gap between the documented carve-out and the cop allow-list.
   - `Dag/NoInPlaceMutation` lets the same file use `<<`, `pop`, and
     `[]=` for queue feed, worker drain, and slot-indexed result
     writes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,9 @@ Hard rules:
 - **Single V1.3 carve-out.** `lib/dag/effects/dispatcher.rb` is the one
   file in `lib/dag/**` allowed to use the concurrency primitives needed
   to implement bounded parallel dispatch within a `Dispatcher#tick`:
-  `Thread` and `Queue` (cop `Dag/NoThreadOrRactor`) for the worker
-  pool, plus `<<`, `pop`, and `[]=` mutating ops (cop
+  `Thread.new` and `Queue` (cop `Dag/NoThreadOrRactor`) for the worker
+  pool — `Thread.start` and `Thread.fork` stay banned even here —
+  plus `<<`, `pop`, and `[]=` mutating ops (cop
   `Dag/NoInPlaceMutation`) for queue feed, worker drain, and
   slot-indexed result writes. Both cops encode the same
   `dispatcher_relaxed_file?` carve-out. `Mutex`, `Monitor`,

--- a/Ruby DAG Project Roadmap v3.4.md
+++ b/Ruby DAG Project Roadmap v3.4.md
@@ -111,8 +111,9 @@ Regole operative:
 A partire da V1.3, il singolo file `lib/dag/effects/dispatcher.rb` può
 usare:
 
-- `Thread` e `Queue` (cop `DAG::NoThreadOrRactor`) per orchestrare il
-  pool worker bounded;
+- `Thread.new` e `Queue` (cop `DAG::NoThreadOrRactor`) per orchestrare
+  il pool worker bounded; `Thread.start` e `Thread.fork` restano
+  bandite anche in questo file;
 - `<<` (push su `Queue`), `pop` (worker drain di `Queue`), e `[]=`
   (slot-indexed write su array pre-allocato) (cop
   `DAG::NoInPlaceMutation`) per alimentare la coda, drenarla nei
@@ -1505,7 +1506,8 @@ Una PR che introduce anche solo una di queste violazioni non passa review.
 | Anti-pattern | Dove è vietato | Mitigazione |
 |---|---|---|
 | `Ractor`, `Ractor.new`, `Ractor.receive`, `Ractor.yield` | tutto il repo, incluso `test/**` | `DAG::NoThreadOrRactor` |
-| `Thread.new`, `Thread.start`, `Thread.fork` | tutto il repo, incluso `test/**`, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3) | `DAG::NoThreadOrRactor` |
+| `Thread.start`, `Thread.fork` | tutto il repo, incluso `test/**` e `lib/dag/effects/dispatcher.rb` | `DAG::NoThreadOrRactor` |
+| `Thread.new` | tutto il repo, incluso `test/**`, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3 per worker pool) | `DAG::NoThreadOrRactor` |
 | `Mutex`, `Monitor`, `SizedQueue`, `ConditionVariable` | tutto il repo, incluso `test/**` e adapter Memory | `DAG::NoThreadOrRactor` |
 | `Queue` | tutto il repo, incluso `test/**` e adapter Memory, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3) | `DAG::NoThreadOrRactor` |
 | `Process.fork`, `Process.spawn`, `system`, backtick shell, `%x` | `lib/dag/**` | `DAG::NoThreadOrRactor`; `Process.clock_gettime` resta consentito |
@@ -2303,7 +2305,8 @@ Vincoli per `Memory::Storage`:
 
 Regole:
 
-- vieta `Thread.new`, `Thread.start`, `Thread.fork` ovunque, incluso `test/**`, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3 per parallel dispatch bounded);
+- vieta `Thread.start`, `Thread.fork` ovunque, incluso `test/**` e `lib/dag/effects/dispatcher.rb`;
+- vieta `Thread.new` ovunque, incluso `test/**`, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3 per worker pool);
 - vieta `Ractor`, `Ractor.new`, `Ractor.receive`, `Ractor.yield` ovunque, incluso `test/**`;
 - vieta `Mutex.new`, `Monitor.new`, `SizedQueue.new`, `ConditionVariable.new` ovunque, incluso `test/**` e adapter Memory;
 - vieta `Queue.new` ovunque, incluso `test/**` e adapter Memory, **tranne `lib/dag/effects/dispatcher.rb`** (eccezione V1.3);

--- a/rubocop/cop/dag/no_thread_or_ractor.rb
+++ b/rubocop/cop/dag/no_thread_or_ractor.rb
@@ -10,6 +10,12 @@ module RuboCop
         FORBIDDEN_CONS = %w[Thread Ractor Mutex Monitor Queue SizedQueue ConditionVariable].freeze
         DISPATCHER_RELAXED_CONS = %w[Thread Queue].freeze
         FORBIDDEN_THREAD_SENDS = %i[new start fork].freeze
+        # The carve-out documented in Roadmap §2.4 / §9.1 is "Thread for the
+        # worker pool", which structurally means `Thread.new`. `Thread.start`
+        # and `Thread.fork` stay banned even in the dispatcher: bounded
+        # parallel_map does not need them, and keeping them blocked closes
+        # the gap between the documented exception and the cop allow-list.
+        DISPATCHER_RELAXED_THREAD_SENDS = %i[new].freeze
         FORBIDDEN_PROCESS_SENDS = %i[fork spawn daemon].freeze
 
         def on_const(node)
@@ -29,7 +35,10 @@ module RuboCop
           end
 
           if receiver&.const_type? && %w[Thread Ractor].include?(receiver.const_name)
-            return if dispatcher_relaxed_file? && receiver.const_name == "Thread"
+            if dispatcher_relaxed_file? && receiver.const_name == "Thread" &&
+                DISPATCHER_RELAXED_THREAD_SENDS.include?(method_name)
+              return
+            end
 
             add_offense(node) if FORBIDDEN_THREAD_SENDS.include?(method_name)
             return

--- a/spec/r0/rubocop_cops_test.rb
+++ b/spec/r0/rubocop_cops_test.rb
@@ -28,6 +28,26 @@ class R0RuboCopCopsTest < Minitest::Test
     assert_empty offenses
   end
 
+  def test_no_thread_or_ractor_still_flags_thread_start_in_dispatcher
+    offenses = inspect_source(
+      RuboCop::Cop::DAG::NoThreadOrRactor,
+      "Thread.start { :work }\n",
+      path: runtime_path("effects/dispatcher.rb")
+    )
+
+    refute_empty offenses
+  end
+
+  def test_no_thread_or_ractor_still_flags_thread_fork_in_dispatcher
+    offenses = inspect_source(
+      RuboCop::Cop::DAG::NoThreadOrRactor,
+      "Thread.fork { :work }\n",
+      path: runtime_path("effects/dispatcher.rb")
+    )
+
+    refute_empty offenses
+  end
+
   def test_no_thread_or_ractor_allows_queue_in_dispatcher
     offenses = inspect_source(
       RuboCop::Cop::DAG::NoThreadOrRactor,


### PR DESCRIPTION
## Summary

Tightening follow-up to #180. The first PR carved out `Thread` for `lib/dag/effects/dispatcher.rb` by short-circuiting **all** of `FORBIDDEN_THREAD_SENDS = %i[new start fork]` whenever the file matched. That was broader than the documented exception, which says \"Thread.new for the worker pool\" — `Thread.start` and `Thread.fork` were silently allowed.

This PR closes the gap between the documented carve-out and the cop allow-list.

## What changes

- New `DISPATCHER_RELAXED_THREAD_SENDS = %i[new]` constant.
- `on_send` only skips the offense when the method matches that list.
- `Thread.start` and `Thread.fork` stay flagged everywhere, including the dispatcher.
- Two new tests in `spec/r0/rubocop_cops_test.rb` pin the chirurgical scope: `Thread.start` and `Thread.fork` flagged in `lib/dag/effects/dispatcher.rb`.
- Roadmap §2.4 / §9.1 / Appendix F, CLAUDE.md, and CHANGELOG updated to spell out the precise surface.

## Why

Bounded `parallel_map` (the V1.3 feature pattern) needs `Thread.new` only. `Thread.start` (suspended-on-create) and `Thread.fork` (alias for `start`) are not used by the pattern, and leaving them globally banned removes a vector for the carve-out to drift in subtle ways later.

## Test plan

- [x] `bundle exec rake` — 609 runs, 40633 assertions, 0 failures
- [x] `bundle exec rubocop` clean
- [x] New cop tests cover: `Thread.start` flagged in dispatcher.rb; `Thread.fork` flagged in dispatcher.rb; existing `Thread.new` allowed test still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)