### PR TITLE
fix: align dispatcher parallelism implementation with its V1.3 contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,17 @@ opt-in is a single additive kwarg; the default is identical to V1.2.
   `claimed.map(&:id)` in original order. Unexpected exceptions raised
   inside a worker thread propagate out of `#tick` *only after every
   worker has joined*: each worker rescues every exception, parks it
-  in a shared error list, *drains the work queue* so peer workers see
+  in its own slot of a per-pool error array (slot-indexed writes
+  with no contention), *drains the work queue* so peer workers see
   `ThreadError` on their next `pop` and exit (peers still finish
   whatever record they were already processing), and exits its loop
   normally. After `workers.each(&:join)` returns, `#tick` raises the
   first captured exception. Synchronization rides on `Queue`'s
-  built-in thread-safety rather than on cross-thread visibility of
-  custom flags. This guarantees no worker is still mutating storage
-  when `#tick` raises and preserves the V1.2 serial-map exception
-  semantics where the caller observes a stable post-tick state.
+  built-in thread-safety plus per-worker error slots; no contended
+  shared mutable state. This guarantees no worker is still mutating
+  storage when `#tick` raises and preserves the V1.2 serial-map
+  exception semantics where the caller observes a stable post-tick
+  state.
 - `parallelism > 1` requires the storage adapter to declare
   thread-safety by implementing `#thread_safe_for_dispatch?` returning
   truthy. Adapters that do not declare it cause

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -393,19 +393,31 @@ processes) and is now explicit: handler `#call` may be invoked by
 distinct threads on distinct records simultaneously, and must not
 share unsynchronized mutable state across calls.
 
-The dispatcher itself does not introduce shared mutable state across
-worker threads beyond the bounded work queue: claimed records are
-pushed onto a queue once, each worker pops, dispatches, and writes its
-outcome into a pre-allocated slot. Order preservation in
-`DispatchReport` is per collection: `succeeded.map(&:id)` is a
-subsequence of `claimed.map(&:id)` in original order, but the
-collections do not promise positional alignment with `claimed`.
+The dispatcher introduces three pieces of shared mutable state across
+worker threads, all bounded and contention-isolated: the work queue
+(an `Stdlib::Queue` whose own synchronization protects pushes and
+pops), the result Array (each worker writes only to its own
+pre-allocated slot, so writes do not contend), and a per-pool error
+slot Array (each worker writes only to its own slot on failure).
+Claimed records are pushed onto the queue once; each worker pops,
+dispatches, and writes its outcome into the matching pre-allocated
+result slot. Order preservation in `DispatchReport` is per
+collection: `succeeded.map(&:id)` is a subsequence of
+`claimed.map(&:id)` in original order, but the collections do not
+promise positional alignment with `claimed`.
 
-Unexpected exceptions raised inside a worker thread re-emerge from
-`#tick`: `dispatch_record` continues to catch only
-`DAG::Effects::StaleLeaseError`, and any other exception propagates via
-`Thread#value` re-raise after `join`. The serial map's exception
-semantics are preserved.
+`dispatch_record` continues to catch only
+`DAG::Effects::StaleLeaseError`. Any other exception raised inside a
+worker thread is captured by the worker (so the thread terminates
+normally, which prevents `Thread#join` from short-circuiting the join
+loop and re-raising before peer workers have finished), parked in
+the per-worker error slot, and the worker drains the remaining work
+queue so peer workers see `ThreadError` on their next `pop` and
+exit. After every worker has joined, `#tick` raises the first
+captured exception. This guarantees no worker is still mutating
+storage when `#tick` raises, preserving the V1.2 serial-map
+exception semantics: the caller observes a stable post-tick state
+on both success and failure paths.
 
 ## Storage Receipts And Failure Vocabulary
 

--- a/lib/dag/effects/dispatcher.rb
+++ b/lib/dag/effects/dispatcher.rb
@@ -182,23 +182,24 @@ module DAG
       # worker: `Thread#join` re-raises any exception that escaped a
       # worker thread, which would short-circuit the join loop and let
       # peer workers keep mutating storage past `tick`'s return. So each
-      # worker rescues every exception, parks it in `errors`, *drains
-      # the work queue* (so peer workers see `ThreadError` on their next
-      # `pop` and exit instead of pulling more records), and breaks out
-      # of the loop normally. Once every worker has joined we raise the
-      # first captured exception. Draining uses the queue itself as the
-      # abort signal, so synchronization rides on `Queue`'s built-in
-      # thread-safety rather than on Ruby's array-mutation visibility
-      # across threads.
+      # worker rescues every exception, parks it in its own slot of the
+      # `worker_errors` array (no contention: each worker writes a
+      # different index), *drains the work queue* (so peer workers see
+      # `ThreadError` on their next `pop` and exit instead of pulling
+      # more records), and breaks out of the loop normally. Once every
+      # worker has joined we raise the first captured exception.
+      # Draining uses the queue itself as the abort signal, so
+      # synchronization rides on `Queue`'s built-in thread-safety rather
+      # than on Ruby's array-mutation visibility across threads.
       def parallel_map(items)
         return items.map { |item| yield item } if @parallelism <= 1 || items.length <= 1
 
+        pool_size = (@parallelism < items.length) ? @parallelism : items.length
         results = Array.new(items.length)
-        errors = []
+        worker_errors = Array.new(pool_size)
         queue = Queue.new
         items.each_with_index { |item, idx| queue << [item, idx] }
-        pool_size = (@parallelism < items.length) ? @parallelism : items.length
-        workers = Array.new(pool_size) do
+        workers = Array.new(pool_size) do |worker_idx|
           Thread.new do
             loop do
               pair = begin
@@ -210,7 +211,7 @@ module DAG
               begin
                 results[idx] = yield item
               rescue Exception => exception # standard:disable Lint/RescueException
-                errors << exception
+                worker_errors[worker_idx] = exception
                 drain_queue(queue)
                 break
               end
@@ -218,7 +219,8 @@ module DAG
           end
         end
         workers.each(&:join)
-        raise errors.first unless errors.empty?
+        first_error = worker_errors.compact.first
+        raise first_error if first_error
 
         results
       end


### PR DESCRIPTION
## Summary

Codex stop-time review on #182 flagged: \"dispatcher parallelism violates its own V1.3 carve-out\". The implementation used a shared mutable \`errors\` Array (contended on `<<`) that neither §2.4/§9.1 nor `CONTRACT.md` disclosed. The contract still claimed exception propagation went \"via `Thread#value` re-raise after `join`\" — wording from the first iteration that was already replaced when join-before-raise landed.

## Two changes

1. **Implementation**: replace the shared `errors << exception` Array with a per-pool `worker_errors = Array.new(pool_size)` indexed by `worker_idx`. Each worker writes only to its own slot on failure. Main thread reads `worker_errors.compact.first` after `join` — read-only, no synchronization. Slot-indexed `[]=` is already in the V1.3 `NoInPlaceMutation` carve-out.

2. **Contract**: update the \"Dispatcher Concurrency Contract\" section in `CONTRACT.md` to (a) enumerate all three pieces of shared state the dispatcher introduces (work queue, results Array, per-worker error slot Array), (b) describe each as bounded and contention-isolated, and (c) replace the stale \"via `Thread#value` re-raise after `join`\" wording with the actual capture-and-drain protocol that ships in V1.3.

## Behavior

Unchanged on the success path. On the failure path the caller still observes V1.2 serial-map exception semantics: the first worker exception propagates out of `#tick` after every worker has joined, with no worker still mutating storage when `#tick` raises.

## Test plan

- [x] `bundle exec rake` — 620 runs, 40680 assertions, 0 failures
- [x] All 7 V1.3 dispatcher tests still green (including `joins_all_workers_before_raising`)
- [x] RuboCop + standardrb + YARD clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)