### PR TITLE
[codex] Fix audit findings

### DIFF
--- a/lib/dag/adapters/memory/storage_state.rb
+++ b/lib/dag/adapters/memory/storage_state.rb
@@ -113,6 +113,15 @@ module DAG
           unless row[:state] == from
             raise StaleStateError, "workflow #{id} state is #{row[:state].inspect}, expected #{from.inspect}"
           end
+          if event
+            validate_event_coordinates!(
+              event,
+              workflow_id: row.fetch(:id),
+              revision: row[:current_revision],
+              node_id: nil,
+              attempt_id: nil
+            )
+          end
           row[:state] = to
           stamped = event ? append_event_internal(state, id, event, revision: row[:current_revision]) : nil
           {id: id, state: to, event: stamped}
@@ -131,6 +140,15 @@ module DAG
 
           new_revision = parent_revision + 1
           stored_definition = (definition.revision == new_revision) ? definition : definition.with_revision(new_revision)
+          if event
+            validate_event_coordinates!(
+              event,
+              workflow_id: id,
+              revision: [parent_revision, new_revision],
+              node_id: nil,
+              attempt_id: nil
+            )
+          end
           state[:definitions][[id, new_revision]] = stored_definition
 
           previous_states = state[:node_states][[id, parent_revision]] || {}
@@ -582,6 +600,15 @@ module DAG
           revision = row[:current_revision]
           states_for_rev = fetch_node_states!(state, id, revision)
           failed_node_ids = states_for_rev.select { |_, s| s == :failed }.keys
+          if event
+            validate_event_coordinates!(
+              event,
+              workflow_id: row.fetch(:id),
+              revision: revision,
+              node_id: nil,
+              attempt_id: nil
+            )
+          end
 
           failed_set = failed_node_ids.to_set
           state[:attempts_index].fetch(id, []).each do |aid|

--- a/lib/dag/adapters/memory/storage_state.rb
+++ b/lib/dag/adapters/memory/storage_state.rb
@@ -114,7 +114,7 @@ module DAG
             raise StaleStateError, "workflow #{id} state is #{row[:state].inspect}, expected #{from.inspect}"
           end
           row[:state] = to
-          stamped = event ? append_event_internal(state, id, event) : nil
+          stamped = event ? append_event_internal(state, id, event, revision: row[:current_revision]) : nil
           {id: id, state: to, event: stamped}
         end
 
@@ -134,7 +134,7 @@ module DAG
           state[:definitions][[id, new_revision]] = stored_definition
 
           previous_states = state[:node_states][[id, parent_revision]] || {}
-          invalidated = invalidated_node_ids.map(&:to_sym)
+          invalidated = invalidated_node_ids.map(&:to_sym).to_set
           result_projections = {}
           new_states = stored_definition.nodes.each_with_object({}) do |node_id, acc|
             acc[node_id] = if invalidated.include?(node_id)
@@ -153,7 +153,7 @@ module DAG
           state[:node_states][[id, new_revision]] = new_states
           result_projections.each { |key, result| state[:committed_result_projections][key] = result }
           row[:current_revision] = new_revision
-          stamped = event ? append_event_internal(state, id, event) : nil
+          stamped = event ? append_event_internal(state, id, event, revision: [parent_revision, new_revision]) : nil
           {id: id, revision: new_revision, event: stamped}
         end
 
@@ -245,6 +245,13 @@ module DAG
           end
           terminal_state = attempt_terminal_state_for(result)
           validate_node_state_for_result!(result, node_state)
+          validate_event_coordinates!(
+            event,
+            workflow_id: attempt[:workflow_id],
+            revision: attempt[:revision],
+            node_id: attempt[:node_id],
+            attempt_id: attempt[:attempt_id]
+          )
 
           rev_states = state[:node_states][[attempt[:workflow_id], attempt[:revision]]]
           current_node_state = rev_states[attempt[:node_id]]
@@ -259,7 +266,14 @@ module DAG
           rev_states[attempt[:node_id]] = node_state
           apply_effect_reservations(state, reservations)
 
-          append_event_internal(state, attempt[:workflow_id], event)
+          append_event_internal(
+            state,
+            attempt[:workflow_id],
+            event,
+            revision: attempt[:revision],
+            node_id: attempt[:node_id],
+            attempt_id: attempt[:attempt_id]
+          )
         end
 
         # Implements `Ports::Storage#list_effects_for_node`.
@@ -520,12 +534,21 @@ module DAG
 
         # Internal: stamp seq + push to event log.
         # @api private
-        def append_event_internal(state, workflow_id, event)
-          state[:seq][workflow_id] ||= 0
-          state[:seq][workflow_id] += 1
-          stamped = event.with(seq: state[:seq][workflow_id])
-          state[:events][workflow_id] ||= []
-          state[:events][workflow_id] << stamped
+        def append_event_internal(state, workflow_id, event, revision: nil, node_id: nil, attempt_id: nil)
+          row = fetch_workflow!(state, workflow_id)
+          stored_workflow_id = row.fetch(:id)
+          validate_event_coordinates!(
+            event,
+            workflow_id: stored_workflow_id,
+            revision: revision,
+            node_id: node_id,
+            attempt_id: attempt_id
+          )
+          state[:seq][stored_workflow_id] ||= 0
+          state[:seq][stored_workflow_id] += 1
+          stamped = event.with(seq: state[:seq][stored_workflow_id])
+          state[:events][stored_workflow_id] ||= []
+          state[:events][stored_workflow_id] << stamped
           stamped
         end
 
@@ -569,7 +592,7 @@ module DAG
           failed_node_ids.each { |node_id| states_for_rev[node_id] = :pending }
           row[:workflow_retry_count] += 1
           row[:state] = to
-          stamped = event ? append_event_internal(state, id, event) : nil
+          stamped = event ? append_event_internal(state, id, event, revision: revision) : nil
 
           {id: id, state: to, reset: failed_node_ids, workflow_retry_count: row[:workflow_retry_count], event: stamped}
         end
@@ -685,6 +708,21 @@ module DAG
         # @api private
         def same_effect_link?(left, right)
           left[:attempt_id] == right[:attempt_id] && left[:effect_id] == right[:effect_id]
+        end
+
+        def validate_event_coordinates!(event, workflow_id:, revision:, node_id:, attempt_id:)
+          DAG::Validation.instance!(event, DAG::Event, "event")
+          raise ArgumentError, "event.workflow_id does not match workflow_id" unless event.workflow_id == workflow_id
+          unless revision.nil? || Array(revision).include?(event.revision)
+            raise ArgumentError, "event.revision does not match revision"
+          end
+          DAG::Validation.node_id!(event.node_id) unless event.node_id.nil?
+          unless node_id.nil? || event.node_id.nil? || event.node_id.to_sym == node_id.to_sym
+            raise ArgumentError, "event.node_id does not match node_id"
+          end
+          return if attempt_id.nil? || event.attempt_id.nil? || event.attempt_id == attempt_id
+
+          raise ArgumentError, "event.attempt_id does not match attempt_id"
         end
 
         # Internal: return one projected Record per linked effect. When a node

--- a/lib/dag/edge.rb
+++ b/lib/dag/edge.rb
@@ -6,6 +6,7 @@ module DAG
   # @api public
   Edge = Data.define(:from, :to, :metadata) do
     def initialize(from:, to:, metadata: {})
+      DAG.json_safe!(metadata, "$root.metadata")
       super(from: from.to_sym, to: to.to_sym, metadata: DAG.frozen_copy(metadata))
     end
 

--- a/lib/dag/graph.rb
+++ b/lib/dag/graph.rb
@@ -71,6 +71,7 @@ module DAG
       from_sym = from.to_sym
       to_sym = to.to_sym
 
+      DAG.json_safe!(metadata, "$root.metadata")
       validate_edge_nodes!(from_sym, to_sym)
       # A self-edge is a 1-cycle. Reported as CycleError so callers that
       # rescue cycle errors to recover from bad input catch this case too.

--- a/lib/dag/mutation_service.rb
+++ b/lib/dag/mutation_service.rb
@@ -38,7 +38,7 @@ module DAG
         event: mutation_event(workflow_id, mutation, expected_revision, new_revision, plan)
       )
       event = result[:event]
-      @event_bus.publish(event) if event
+      publish_event(event) if event
 
       DAG::ApplyResult.new(
         workflow_id: workflow_id,
@@ -93,6 +93,12 @@ module DAG
           invalidated_node_ids: plan.invalidated_node_ids
         }
       ]
+    end
+
+    def publish_event(event)
+      @event_bus.publish(event)
+    rescue
+      nil
     end
   end
 end

--- a/lib/dag/proposed_mutation.rb
+++ b/lib/dag/proposed_mutation.rb
@@ -31,6 +31,7 @@ module DAG
     end
 
     def initialize(kind:, target_node_id:, replacement_graph: nil, rationale: nil, confidence: 1.0, metadata: {})
+      DAG::Validation.node_id!(target_node_id)
       DAG::Validation.member!(
         kind,
         DAG::ProposedMutation::KINDS,
@@ -55,7 +56,7 @@ module DAG
 
       super(
         kind: kind,
-        target_node_id: target_node_id,
+        target_node_id: target_node_id.to_sym,
         replacement_graph: replacement_graph,
         rationale: DAG.frozen_copy(rationale),
         confidence: confidence,

--- a/lib/dag/runner.rb
+++ b/lib/dag/runner.rb
@@ -234,7 +234,8 @@ module DAG
     def handle_outcome(run, node_id, attempt_id, attempt_number, result)
       case result
       when DAG::Success
-        commit_and_emit(run, node_id, attempt_id, attempt_number, result, :committed, :node_committed, {})
+        commit_status = commit_and_emit(run, node_id, attempt_id, attempt_number, result, :committed, :node_committed, {})
+        return commit_status if commit_status == :failed_terminal
         return :continue if result.proposed_mutations.empty?
 
         atomic_transition_with_event(
@@ -247,8 +248,10 @@ module DAG
         :paused
 
       when DAG::Waiting
-        commit_and_emit(run, node_id, attempt_id, attempt_number, result, :waiting, :node_waiting,
+        commit_status = commit_and_emit(run, node_id, attempt_id, attempt_number, result, :waiting, :node_waiting,
           {reason: result.reason, not_before_ms: result.not_before_ms})
+        return commit_status if commit_status == :failed_terminal
+
         :continue
 
       when DAG::Failure
@@ -296,7 +299,40 @@ module DAG
         event: event,
         effects: prepared_effects
       )
-      @event_bus.publish(stamped)
+      publish_event(stamped)
+      :committed
+    rescue DAG::Effects::IdempotencyConflictError => conflict
+      commit_idempotency_conflict(run, node_id, attempt_id, attempt_number, conflict)
+      :failed_terminal
+    end
+
+    def commit_idempotency_conflict(run, node_id, attempt_id, attempt_number, conflict)
+      error = {
+        code: :effect_idempotency_conflict,
+        class: conflict.class.name,
+        message: conflict.message
+      }
+      failure = DAG::Failure[error: error, retriable: false]
+      event = build_event(run,
+        type: :node_failed,
+        node_id: node_id,
+        attempt_id: attempt_id,
+        payload: {attempt_number: attempt_number, retriable: false, error: error})
+      stamped = @storage.commit_attempt(
+        attempt_id: attempt_id,
+        result: failure,
+        node_state: :failed,
+        event: event,
+        effects: []
+      )
+      publish_event(stamped)
+      atomic_transition_with_event(
+        run,
+        from: :running,
+        to: :failed,
+        event_type: :workflow_failed,
+        payload: {failed_node: node_id, error: error}
+      )
     end
 
     def build_step_input(run, node_id, attempt_id, attempt_number)
@@ -477,7 +513,7 @@ module DAG
       event = build_event(run, type: event_type, payload: payload)
       result = @storage.transition_workflow_state(id: run.workflow_id, from: from, to: to, event: event)
       stamped = result.is_a?(Hash) ? result[:event] : nil
-      @event_bus.publish(stamped) if stamped
+      publish_event(stamped) if stamped
     end
 
     def build_run_result(run, state)
@@ -504,7 +540,13 @@ module DAG
 
     def append_event(run, **kwargs)
       stamped = @storage.append_event(workflow_id: run.workflow_id, event: build_event(run, **kwargs))
-      @event_bus.publish(stamped)
+      publish_event(stamped)
+    end
+
+    def publish_event(event)
+      @event_bus.publish(event)
+    rescue
+      nil
     end
   end
 end

--- a/spec/graph_test.rb
+++ b/spec/graph_test.rb
@@ -922,6 +922,15 @@ class GraphTest < Minitest::Test
     assert_raises(FrozenError) { graph.edge_metadata(:a, :b)[:tags] << "nope" }
   end
 
+  def test_add_edge_rejects_non_json_safe_metadata
+    graph = build_graph([:a, :b], [])
+
+    assert_raises(ArgumentError) do
+      graph.add_edge(:a, :b, deadline: Time.now)
+    end
+    refute graph.edge?(:a, :b)
+  end
+
   def test_edge_metadata_in_subgraph
     graph = build_graph([:a, :b, :c], [])
     graph.add_edge(:a, :b, weight: 2)
@@ -1137,6 +1146,12 @@ class GraphTest < Minitest::Test
   def test_edge_inspect_with_metadata
     edge = DAG::Edge.new(from: :a, to: :b, metadata: {weight: 3})
     assert_match(/Edge\(a -> b, \{.*weight.*3.*\}\)/, edge.inspect)
+  end
+
+  def test_edge_rejects_non_json_safe_metadata
+    assert_raises(ArgumentError) do
+      DAG::Edge.new(from: :a, to: :b, metadata: {bad: Object.new})
+    end
   end
 
   # --- to_h with metadata ---

--- a/spec/r1/runner_outcomes_test.rb
+++ b/spec/r1/runner_outcomes_test.rb
@@ -169,4 +169,23 @@ class RunnerOutcomesTest < Minitest::Test
     failure_event = event_bus.events.reverse_each.find { |e| e.type == :workflow_failed }
     assert_equal :no_eligible_but_incomplete, failure_event.payload[:diagnostic]
   end
+
+  def test_event_bus_publish_failure_does_not_fail_durable_run
+    storage = DAG::Adapters::Memory::Storage.new
+    runner = build_runner(storage: storage, event_bus: RaisingEventBus.new)
+    workflow_id = create_workflow(storage, simple_definition)
+
+    result = runner.call(workflow_id)
+
+    assert_equal :completed, result.state
+    assert_equal :completed, storage.load_workflow(id: workflow_id)[:state]
+    assert_equal(
+      [:workflow_started, :node_started, :node_committed, :node_started, :node_committed, :workflow_completed],
+      storage.read_events(workflow_id: workflow_id).map(&:type)
+    )
+  end
+
+  class RaisingEventBus
+    def publish(_event) = raise "bus down"
+  end
 end

--- a/spec/r1/storage_state_extras_test.rb
+++ b/spec/r1/storage_state_extras_test.rb
@@ -263,15 +263,51 @@ class StorageStateExtrasTest < Minitest::Test
 
   def test_read_events_filters_after_seq_and_limit
     workflow_id = create_workflow(@storage, @definition)
-    e1 = @storage.append_event(workflow_id: workflow_id, event: build_event(:node_started))
-    @storage.append_event(workflow_id: workflow_id, event: build_event(:node_committed))
-    @storage.append_event(workflow_id: workflow_id, event: build_event(:workflow_completed))
+    e1 = @storage.append_event(workflow_id: workflow_id, event: build_event(:node_started, workflow_id: workflow_id))
+    @storage.append_event(workflow_id: workflow_id, event: build_event(:node_committed, workflow_id: workflow_id))
+    @storage.append_event(workflow_id: workflow_id, event: build_event(:workflow_completed, workflow_id: workflow_id))
 
     after = @storage.read_events(workflow_id: workflow_id, after_seq: e1.seq)
     assert_equal [:node_committed, :workflow_completed], after.map(&:type)
 
     limited = @storage.read_events(workflow_id: workflow_id, limit: 1)
     assert_equal 1, limited.size
+  end
+
+  def test_append_event_rejects_mismatched_workflow_id
+    workflow_id = create_workflow(@storage, @definition)
+    error = assert_raises(ArgumentError) do
+      @storage.append_event(
+        workflow_id: workflow_id,
+        event: build_event(:workflow_started, workflow_id: "other")
+      )
+    end
+
+    assert_match(/event\.workflow_id/, error.message)
+    assert_empty @storage.read_events(workflow_id: workflow_id)
+  end
+
+  def test_commit_attempt_rejects_mismatched_event_coordinates
+    workflow_id = create_workflow(@storage, @definition)
+    attempt_id = @storage.begin_attempt(
+      workflow_id: workflow_id,
+      revision: 1,
+      node_id: :a,
+      expected_node_state: :pending,
+      attempt_number: 1
+    )
+
+    error = assert_raises(ArgumentError) do
+      @storage.commit_attempt(
+        attempt_id: attempt_id,
+        result: DAG::Success[value: 1, context_patch: {}],
+        node_state: :committed,
+        event: build_event(:node_committed, workflow_id: workflow_id, node_id: :b, attempt_id: attempt_id)
+      )
+    end
+
+    assert_match(/event\.node_id/, error.message)
+    assert_equal :running, @storage.list_attempts(workflow_id: workflow_id, node_id: :a).first[:state]
   end
 
   private

--- a/spec/r1/storage_state_extras_test.rb
+++ b/spec/r1/storage_state_extras_test.rb
@@ -94,6 +94,27 @@ class StorageStateExtrasTest < Minitest::Test
     assert_equal 2, current.revision, "stored definition's :revision must match its key"
   end
 
+  def test_append_revision_rejects_mismatched_event_before_mutating_revision
+    workflow_id = create_workflow(@storage, @definition)
+    new_definition = @definition.add_node(:c, type: :passthrough).add_edge(:b, :c)
+
+    error = assert_raises(ArgumentError) do
+      @storage.append_revision(
+        id: workflow_id,
+        parent_revision: 1,
+        definition: new_definition,
+        invalidated_node_ids: [:a],
+        event: build_event(:mutation_applied, workflow_id: workflow_id, revision: 99)
+      )
+    end
+
+    assert_match(/event\.revision/, error.message)
+    assert_equal 1, @storage.load_current_definition(id: workflow_id).revision
+    assert_raises(DAG::StaleRevisionError) { @storage.load_revision(id: workflow_id, revision: 2) }
+    assert_equal({a: :pending, b: :pending}, @storage.load_node_states(workflow_id: workflow_id, revision: 1))
+    assert_empty @storage.read_events(workflow_id: workflow_id)
+  end
+
   def test_create_workflow_isolates_initial_context_from_caller_mutation
     initial = {hello: "world"}
     workflow_id = SecureRandom.uuid
@@ -261,6 +282,47 @@ class StorageStateExtrasTest < Minitest::Test
     assert_equal 1, @storage.load_workflow(id: workflow_id)[:workflow_retry_count]
   end
 
+  def test_prepare_workflow_retry_rejects_mismatched_event_before_mutating_retry_state
+    workflow_id = create_workflow(@storage, @definition,
+      runtime_profile: DAG::RuntimeProfile[
+        durability: :ephemeral,
+        max_attempts_per_node: 1,
+        max_workflow_retries: 1,
+        event_bus_kind: :null
+      ])
+    attempt_id = @storage.begin_attempt(
+      workflow_id: workflow_id,
+      revision: 1,
+      node_id: :a,
+      expected_node_state: :pending,
+      attempt_number: 1
+    )
+    @storage.commit_attempt(
+      attempt_id: attempt_id,
+      result: DAG::Failure[error: {code: :boom}, retriable: true],
+      node_state: :failed,
+      event: build_event(:node_failed, workflow_id: workflow_id, node_id: :a, attempt_id: attempt_id)
+    )
+    @storage.transition_workflow_state(id: workflow_id, from: :pending, to: :failed)
+    event_count = @storage.read_events(workflow_id: workflow_id).size
+
+    error = assert_raises(ArgumentError) do
+      @storage.prepare_workflow_retry(
+        id: workflow_id,
+        from: :failed,
+        to: :pending,
+        event: build_event(:workflow_started, workflow_id: "other")
+      )
+    end
+
+    assert_match(/event\.workflow_id/, error.message)
+    assert_equal :failed, @storage.load_workflow(id: workflow_id)[:state]
+    assert_equal 0, @storage.load_workflow(id: workflow_id)[:workflow_retry_count]
+    assert_equal :failed, node_state(@storage, workflow_id, :a)
+    assert_equal :failed, @storage.list_attempts(workflow_id: workflow_id, node_id: :a).first[:state]
+    assert_equal event_count, @storage.read_events(workflow_id: workflow_id).size
+  end
+
   def test_read_events_filters_after_seq_and_limit
     workflow_id = create_workflow(@storage, @definition)
     e1 = @storage.append_event(workflow_id: workflow_id, event: build_event(:node_started, workflow_id: workflow_id))
@@ -284,6 +346,23 @@ class StorageStateExtrasTest < Minitest::Test
     end
 
     assert_match(/event\.workflow_id/, error.message)
+    assert_empty @storage.read_events(workflow_id: workflow_id)
+  end
+
+  def test_transition_workflow_state_rejects_mismatched_event_before_mutating_state
+    workflow_id = create_workflow(@storage, @definition)
+
+    error = assert_raises(ArgumentError) do
+      @storage.transition_workflow_state(
+        id: workflow_id,
+        from: :pending,
+        to: :running,
+        event: build_event(:workflow_started, workflow_id: "other")
+      )
+    end
+
+    assert_match(/event\.workflow_id/, error.message)
+    assert_equal :pending, @storage.load_workflow(id: workflow_id)[:state]
     assert_empty @storage.read_events(workflow_id: workflow_id)
   end
 

--- a/spec/r1/types_validation_test.rb
+++ b/spec/r1/types_validation_test.rb
@@ -32,6 +32,20 @@ class TypesValidationTest < Minitest::Test
     end
   end
 
+  def test_proposed_mutation_rejects_invalid_target_node_id
+    assert_raises(ArgumentError) do
+      DAG::ProposedMutation[kind: :invalidate, target_node_id: Object.new]
+    end
+  end
+
+  def test_proposed_mutation_normalizes_mutable_string_target
+    target = +"a"
+    mutation = DAG::ProposedMutation[kind: :invalidate, target_node_id: target]
+    target.replace("b")
+
+    assert_equal :a, mutation.target_node_id
+  end
+
   def test_runtime_profile_rejects_invalid_durability
     assert_raises(ArgumentError) do
       DAG::RuntimeProfile[durability: :unknown, max_attempts_per_node: 1, max_workflow_retries: 0, event_bus_kind: :null]

--- a/spec/r2/runner_effects_test.rb
+++ b/spec/r2/runner_effects_test.rb
@@ -149,6 +149,38 @@ class RunnerEffectsTest < Minitest::Test
     assert_equal [{}], observed_effects
   end
 
+  def test_effect_idempotency_conflict_becomes_terminal_failure
+    storage = DAG::Adapters::Memory::Storage.new
+    first = effect_intent(key: "same", payload: {value: 1})
+    second = effect_intent(key: "same", payload: {value: 2})
+    registry = DAG::StepTypeRegistry.new
+    klass = Class.new(DAG::Step::Base) do
+      define_method(:call) do |_input|
+        DAG::Success[value: :ok, proposed_effects: [first, second]]
+      end
+    end
+    registry.register(name: :conflicting_effects, klass: klass, fingerprint_payload: {v: 1})
+    registry.freeze!
+    runner = build_runner(storage: storage, registry: registry)
+    definition = DAG::Workflow::Definition.new.add_node(:a, type: :conflicting_effects)
+    workflow_id = create_workflow(storage, definition)
+
+    result = runner.call(workflow_id)
+
+    assert_equal :failed, result.state
+    assert_equal :failed, storage.load_workflow(id: workflow_id)[:state]
+    assert_equal :failed, node_state(storage, workflow_id, :a)
+    attempts = storage.list_attempts(workflow_id: workflow_id, revision: 1, node_id: :a)
+    assert_equal 1, attempts.size
+    assert_equal :failed, attempts.first[:state]
+    assert_equal :effect_idempotency_conflict, attempts.first[:result].error[:code]
+    assert_empty storage.list_effects_for_attempt(attempt_id: attempts.first[:attempt_id])
+    assert_equal(
+      [:workflow_started, :node_started, :node_failed, :workflow_failed],
+      storage.read_events(workflow_id: workflow_id).map(&:type)
+    )
+  end
+
   private
 
   def effect_intent(key:, payload: {value: 1})

--- a/spec/r3/mutation_active_run_guard_test.rb
+++ b/spec/r3/mutation_active_run_guard_test.rb
@@ -49,6 +49,31 @@ class R3MutationActiveRunGuardTest < Minitest::Test
     assert_empty event_bus.events
   end
 
+  def test_apply_persists_revision_when_event_bus_publish_fails
+    storage = DAG::Adapters::Memory::Storage.new
+    workflow_id = create_workflow(storage, simple_definition)
+    storage.transition_workflow_state(id: workflow_id, from: :pending, to: :paused)
+    service = DAG::MutationService.new(
+      storage: storage,
+      event_bus: RaisingEventBus.new,
+      clock: DAG::Adapters::Stdlib::Clock.new
+    )
+
+    result = service.apply(
+      workflow_id: workflow_id,
+      mutation: DAG::ProposedMutation[kind: :invalidate, target_node_id: :a],
+      expected_revision: 1
+    )
+
+    assert_equal 2, result.revision
+    assert_equal 2, storage.load_current_definition(id: workflow_id).revision
+    assert_equal :mutation_applied, storage.read_events(workflow_id: workflow_id).last.type
+  end
+
+  class RaisingEventBus
+    def publish(_event) = raise "bus down"
+  end
+
   class StateRacingStorage
     def initialize(storage, workflow_id:, from:, to:)
       @storage = storage

--- a/spec/support/event_helpers.rb
+++ b/spec/support/event_helpers.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 module EventHelpers
-  def build_event(type = :node_started, workflow_id: "x", revision: 1, at_ms: 0, payload: {})
+  def build_event(type = :node_started, workflow_id: "x", revision: 1, at_ms: 0, node_id: nil, attempt_id: nil, payload: {})
     DAG::Event[
       type: type,
       workflow_id: workflow_id,
       revision: revision,
       at_ms: at_ms,
+      node_id: node_id,
+      attempt_id: attempt_id,
       payload: payload
     ]
   end


### PR DESCRIPTION
## Summary
- convert effect idempotency conflicts into durable terminal workflow failures
- make event bus publishing best-effort after storage commits in runner and mutation flows
- tighten JSON/coordinate validation for graph metadata, proposed mutations, and memory storage events
- add focused regression tests for each fixed path

## Validation
- bundle exec rake
- git diff --check