### PR TITLE
Prepare ruby-dag v1.5.0 with Mutant gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /vendor/bundle
 /coverage/
+/.mutant/
 /.ruby-lsp/
 /.rubocop_cache/
 /doc/

--- a/.mutant.yml
+++ b/.mutant.yml
@@ -1,0 +1,28 @@
+---
+usage: opensource
+includes:
+  - lib
+requires:
+  - dag
+integration:
+  name: minitest
+jobs: 4
+fail_fast: true
+matcher:
+  subjects:
+    - DAG::Edge*
+    - DAG::Graph*
+    - DAG::Result*
+    - DAG::Success*
+    - DAG::Failure*
+    - DAG::ExecutionContext*
+    - DAG::ProposedMutation*
+    - DAG::ReplacementGraph*
+    - DAG::RuntimeProfile*
+    - DAG::Event*
+    - DAG::Waiting*
+    - DAG::Effects::Intent*
+    - DAG::Effects::PreparedIntent*
+    - DAG::Effects::Record*
+    - DAG::Effects::HandlerResult*
+    - DAG::Effects::Await*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## Unreleased
 
+## 1.5.0 — 2026-05-31
+
+V1.5 is a mutation-testing release. It adds a focused Mutant gate for the
+pure value/kernel surface and folds in the equivalent-code simplifications
+and missing assertions surfaced while driving the configured subjects to
+100% mutation coverage.
+
+### Added
+
+- `mutant-minitest` is available as a development dependency with a
+  repository-local `.mutant.yml` configured for the Minitest integration,
+  `lib` load path, `dag` require, fail-fast execution, and an explicit
+  matcher over the core immutable graph/result/context/value-object
+  subjects plus `DAG::Effects::Await`.
+- `rake mutant:test` verifies Mutant can discover and execute the Minitest
+  suite, `rake mutant:run` runs the focused mutation gate, and
+  `rake mutant:changed` scopes Mutant to subjects changed since
+  `MUTANT_SINCE` (default `main`).
+- `test/all_test.rb` bridges Mutant's default `test/**/*_test.rb`
+  discovery to this repo's `spec/**/*_test.rb` layout, while
+  `mutant/minitest/coverage` hooks and `cover` declarations connect tests
+  to the configured subjects.
+- Additional assertions pin graph normalization, frozen-state behavior,
+  metadata cleanup, DOT/hash ordering, path edge cases, execution-context
+  boundaries, effect-await status mapping, and public error messages.
+
+### Changed
+
+- Simplified equivalent code paths exposed by mutation testing without
+  changing the public contract: graph traversal and path helpers now avoid
+  redundant lookups/reversals, `ExecutionContext#inspect` relies on the
+  public key list, `Graph::Validator` drops an unnecessary empty-graph guard,
+  and `DAG::Effects::Await` lets existing defaults handle absent snapshots
+  and terminal failure retryability.
+- `.gitignore` excludes Mutant session artifacts under `/.mutant/`.
+
 ## 1.4.0 — 2026-05-13
 
 V1.4 lets a dispatcher restrict `claim_ready_effects` to a single

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 gem "rake", "~> 13.0"
 gem "minitest", "~> 5.0"
+gem "mutant-minitest", "~> 0.16", require: false
 gem "standard", "~> 1.0"
 gem "simplecov", "~> 0.22", require: false
 gem "ruby-lsp", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-dag (1.4.0)
+    ruby-dag (1.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,17 +7,45 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    date (3.5.1)
+    diff-lcs (2.0.0)
     docile (1.4.1)
+    erb (6.0.4)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.19.3)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
     minitest (5.27.0)
+    mutant (0.16.3)
+      diff-lcs (>= 1.6, < 3)
+      irb (~> 1.15)
+      parser (~> 3.3.10)
+      regexp_parser (~> 2.10)
+      securerandom (>= 0.3)
+      sorbet-runtime (~> 0.6.0)
+      unparser (>= 0.8.2, < 0.10)
+    mutant-minitest (0.16.3)
+      minitest (>= 5.11, < 7)
+      mutant (= 0.16.3)
+      mutex_m (~> 0.2)
+    mutex_m (0.3.0)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
     prism (1.9.0)
+    psych (5.3.1)
+      date
+      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.1)
@@ -25,7 +53,13 @@ GEM
       logger
       prism (>= 1.6.0)
       tsort
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
     regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
     rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -49,12 +83,14 @@ GEM
       prism (>= 1.2, < 2.0)
       rbs (>= 3, < 5)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    sorbet-runtime (0.6.13222)
     standard (1.54.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -67,10 +103,15 @@ GEM
     standard-performance (1.9.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.26.0)
+    stringio (3.2.0)
     tsort (0.2.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    unparser (0.9.0)
+      diff-lcs (>= 1.6, < 3)
+      parser (>= 3.3.0)
+      prism (>= 1.5.1)
     yard (0.9.43)
 
 PLATFORMS
@@ -79,6 +120,7 @@ PLATFORMS
 
 DEPENDENCIES
   minitest (~> 5.0)
+  mutant-minitest (~> 0.16)
   rake (~> 13.0)
   ruby-dag!
   ruby-lsp

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,6 +48,8 @@ Tracked phases:
 | Release v1.3                   | —    | Done |
 | V1.4 per-workflow effect claim | #186 | Done (#187) |
 | Release v1.4                   | —    | Done |
+| V1.5 mutation testing gate     | —    | Done |
+| Release v1.5                   | —    | Done |
 | S0 (SQLite adapter, in Delphi)   | TBD  | Next |
 | Release v1.0                     | #74  | Done (#126, #156) |
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rake/testtask"
+require "shellwords"
 require "standard/rake"
 require "rubocop/rake_task"
 
@@ -49,6 +50,24 @@ desc "Run tests with coverage report"
 task :coverage do
   ENV["COVERAGE"] = "1"
   Rake::Task[:test].invoke
+end
+
+namespace :mutant do
+  desc "Verify Mutant can discover and run the configured Minitest suite"
+  task :test do
+    sh "bundle exec mutant test"
+  end
+
+  desc "Run focused mutation testing for configured subjects"
+  task :run do
+    sh "bundle exec mutant run --fail-fast"
+  end
+
+  desc "Run focused mutation testing for subjects changed since MUTANT_SINCE (default: main)"
+  task :changed do
+    since = ENV.fetch("MUTANT_SINCE", "main")
+    sh "bundle exec mutant run --fail-fast --since #{Shellwords.escape(since)}"
+  end
 end
 
 task default: [:test, :standard, :rubocop, :yard]

--- a/lib/dag/effects/await.rb
+++ b/lib/dag/effects/await.rb
@@ -27,7 +27,6 @@ module DAG
           when :failed_terminal
             DAG::Failure[
               error: DAG::Effects.fetch_required_snapshot_value(record, :error),
-              retriable: false,
               metadata: {effect_ref: intent.ref}
             ]
           when :failed_retriable
@@ -40,8 +39,8 @@ module DAG
         private
 
         def effect_snapshot(input, intent)
-          metadata = input.respond_to?(:metadata) ? input.metadata : {}
-          effects = DAG::Effects.fetch_snapshot_value(metadata, :effects, {})
+          metadata = input.metadata if input.respond_to?(:metadata)
+          effects = DAG::Effects.fetch_snapshot_value(metadata, :effects)
           DAG::Effects.fetch_snapshot_value(effects, intent.ref)
         end
 

--- a/lib/dag/execution_context.rb
+++ b/lib/dag/execution_context.rb
@@ -15,7 +15,7 @@ module DAG
 
     # @param hash [Hash] JSON-safe payload
     def initialize(hash)
-      DAG.json_safe!(hash, "$root")
+      DAG.json_safe!(hash)
       @data = DAG.frozen_copy(hash)
       freeze
     end
@@ -71,7 +71,7 @@ module DAG
     def hash = @data.hash
 
     # @return [String]
-    def inspect = "#<DAG::ExecutionContext keys=#{@data.keys}>"
+    def inspect = "#<DAG::ExecutionContext keys=#{keys}>"
     alias_method :to_s, :inspect
   end
 end

--- a/lib/dag/graph.rb
+++ b/lib/dag/graph.rb
@@ -90,9 +90,9 @@ module DAG
 
       # Invariant: if `sym → to` is in @adjacency, @reverse[to] contains sym.
       # Direct access (no `&.`) — a NoMethodError would surface inconsistency.
-      fetch_set(@adjacency, sym).each { |to| @reverse[to].delete(sym) }
+      fetch_set(@adjacency, sym).each { |to| @reverse.fetch(to).delete(sym) }
       fetch_set(@reverse, sym).each do |from|
-        @adjacency[from].delete(sym)
+        @adjacency.fetch(from).delete(sym)
         delete_metadata(from, sym)
       end
 
@@ -201,7 +201,7 @@ module DAG
 
     # Prefer `node_count` / `edge_count` in code that cares which it's
     # measuring. `size` aliases `node_count` for symmetry with collection types.
-    def node_count = @nodes.size
+    def node_count = size
 
     # @return [Integer]
     def edge_count
@@ -365,8 +365,8 @@ module DAG
       return nil if empty?
 
       dist, pred = relax(roots, -Float::INFINITY) { |a, b| a > b }
-      target = leaves.max_by { |l| dist[l] }
-      {cost: dist[target], path: rebuild_path(pred, target)}
+      target = leaves.max_by { |l| dist.fetch(l) }
+      {cost: dist.fetch(target), path: rebuild_path(pred, target)}
     end
 
     # --- Iteration ---
@@ -379,10 +379,7 @@ module DAG
     # `graph.each_node.map { ... }` / `graph.each_edge.count` give you the
     # Enumerable surface explicitly.
 
-    def each_node(&block)
-      return enum_for(:each_node) unless block
-      @nodes.each(&block)
-    end
+    def each_node(&block) = @nodes.each(&block)
 
     # @yieldparam edge [DAG::Edge]
     # @return [Enumerator] when no block is given
@@ -439,9 +436,9 @@ module DAG
     # Canonical, ASCII-sorted hash representation suitable for fingerprinting.
     # @return [Hash]
     def to_h
-      sorted_edges = edges.to_a.sort_by { |e| [e.from.to_s, e.to.to_s] }
+      sorted_edges = edges.sort_by { |e| [e.from, e.to] }
       {
-        nodes: @nodes.to_a.sort_by(&:to_s),
+        nodes: @nodes.sort_by(&:to_s),
         edges: sorted_edges.map { |e|
           h = {from: e.from, to: e.to}
           h[:metadata] = e.metadata unless e.metadata.empty?
@@ -488,7 +485,8 @@ module DAG
       keep.each do |from|
         fetch_set(@adjacency, from).each do |to|
           next unless keep.include?(to)
-          graph.send(:insert_edge, from, to, edge_metadata(from, to))
+
+          graph.__send__(:insert_edge, from, to, edge_metadata(from, to))
         end
       end
       graph
@@ -513,12 +511,10 @@ module DAG
     def weighted_path(from, to, sentinel, &better)
       from_sym = from.to_sym
       to_sym = to.to_sym
-      return nil unless @nodes.include?(from_sym) && @nodes.include?(to_sym)
-      return {cost: 0, path: [from_sym]} if from_sym == to_sym
-
+      return nil unless @nodes.include?(to_sym)
       dist, pred = relax(from_sym, sentinel, &better)
       return nil if dist[to_sym] == sentinel
-      {cost: dist[to_sym], path: rebuild_path(pred, to_sym)}
+      {cost: dist.fetch(to_sym), path: rebuild_path(pred, to_sym)}
     end
 
     # Single- or multi-source relaxation in topological order.
@@ -526,6 +522,8 @@ module DAG
     # starts with cost 0; all other nodes start at `sentinel`.
     # `better` decides whether a candidate cost replaces the current one.
     # Returns [dist, pred].
+    # mutant:disable - skipping unreachable nodes is a performance guard; the
+    # sentinel arithmetic would produce the same distances.
     def relax(sources, sentinel, &better)
       dist = Hash.new(sentinel)
       Array(sources).each { |s| dist[s] = 0 }
@@ -548,8 +546,8 @@ module DAG
 
     def rebuild_path(pred, target)
       path = [target]
-      path << pred[path.last] while pred.key?(path.last)
-      path.reverse!
+      path << pred.fetch(path.last) while pred.key?(path.last)
+      path.reverse
     end
 
     def compute_topological_layers
@@ -567,7 +565,7 @@ module DAG
           processed += 1
           fetch_set(@adjacency, n).each do |succ|
             in_degree[succ] -= 1
-            next_queue << succ if in_degree[succ] == 0
+            next_queue << succ if in_degree.fetch(succ) == 0
           end
         end
         queue = next_queue.sort
@@ -577,7 +575,7 @@ module DAG
       # is unreachable in normal flow. Kept as an explicit failure mode in
       # case internal state ever drifts; removing it would silently return
       # incomplete layers.
-      raise CycleError, "Graph contains a cycle" if processed < @nodes.size
+      raise CycleError, "Graph contains a cycle" if processed < size
       # :nocov:
       layers
     end
@@ -586,6 +584,8 @@ module DAG
       layers.each(&:freeze).freeze
     end
 
+    # mutant:disable - Object#initialize_dup has no graph-visible behavior, but
+    # keeping super preserves the Ruby duplication hook contract.
     def initialize_dup(orig)
       super
       @nodes = @nodes.dup
@@ -600,8 +600,8 @@ module DAG
 
     def remove_edge_internal(from, to)
       # Invariant: callers ensure both endpoints exist in both directions.
-      @adjacency[from].delete(to)
-      @reverse[to].delete(from)
+      @adjacency.fetch(from).delete(to)
+      @reverse.fetch(to).delete(from)
       delete_metadata(from, to)
     end
 
@@ -654,6 +654,7 @@ module DAG
       hash.fetch(key, EMPTY_SET)
     end
 
+    # mutant:disable - traversal order is unobservable; keep pop for O(1) DFS.
     def walk(adjacency_hash, start, target: nil)
       visited = Set.new
       stack = fetch_set(adjacency_hash, start).to_a
@@ -677,9 +678,10 @@ module DAG
     # Set of nodes reachable from any graph root *without* entering `blocked`.
     # Used by `exclusive_descendants_of` and `shared_descendants_of` to detect
     # paths that bypass a given subtree root.
+    # mutant:disable - traversal order is unobservable; keep pop for O(1) DFS.
     def reachable_blocking(blocked)
       visited = Set.new
-      stack = roots.reject { |r| r == blocked }.to_a
+      stack = roots.to_a
       until stack.empty?
         current = stack.pop
         next if visited.include?(current) || current == blocked

--- a/lib/dag/graph/validator.rb
+++ b/lib/dag/graph/validator.rb
@@ -81,7 +81,7 @@ module DAG
       # A single-node graph is trivially valid: the lone node is both root and
       # leaf, and an empty graph has nothing to check.
       def check_isolated_nodes(errors)
-        return if @graph.size <= 1
+        return if @graph.size == 1
 
         @graph.each_node do |node|
           next unless @graph.indegree(node).zero? && @graph.outdegree(node).zero?

--- a/lib/dag/version.rb
+++ b/lib/dag/version.rb
@@ -2,5 +2,5 @@
 
 module DAG
   # Library version. Bumped per release; see `CHANGELOG.md`.
-  VERSION = "1.4.0"
+  VERSION = "1.5.0"
 end

--- a/spec/graph_builder_test.rb
+++ b/spec/graph_builder_test.rb
@@ -3,6 +3,8 @@
 require_relative "test_helper"
 
 class GraphBuilderTest < Minitest::Test
+  cover DAG::Graph::Builder
+
   # --- Basic building ---
 
   def test_builds_graph_with_nodes_and_edges
@@ -16,6 +18,16 @@ class GraphBuilderTest < Minitest::Test
     assert graph.node?(:a)
     assert graph.node?(:b)
     assert graph.edge?(:a, :b)
+  end
+
+  def test_add_edge_preserves_metadata
+    graph = DAG::Graph::Builder.new
+      .add_node(:a)
+      .add_node(:b)
+      .add_edge(:a, :b, weight: 7)
+      .build
+
+    assert_equal({weight: 7}, graph.edge_metadata(:a, :b))
   end
 
   def test_build_returns_frozen_graph

--- a/spec/graph_test.rb
+++ b/spec/graph_test.rb
@@ -3,6 +3,9 @@
 require_relative "test_helper"
 
 class GraphTest < Minitest::Test
+  cover DAG::Edge
+  cover DAG::Graph
+
   # --- Building graphs ---
 
   def test_add_nodes
@@ -12,28 +15,48 @@ class GraphTest < Minitest::Test
     assert graph.node?(:b)
   end
 
+  def test_add_node_normalizes_string_name
+    graph = DAG::Graph.new.add_node("a")
+
+    assert graph.node?(:a)
+    assert_raises(DAG::DuplicateNodeError) { graph.add_node(:a) }
+  end
+
   def test_add_edge
     graph = build_graph([:a, :b], [[:a, :b]])
     assert graph.edge?(:a, :b)
+    assert graph.edge?("a", "b")
     refute graph.edge?(:b, :a)
   end
 
+  def test_add_edge_normalizes_string_endpoints
+    graph = build_graph([:a, :b], [])
+    graph.add_edge("a", "b")
+
+    assert graph.edge?(:a, :b)
+  end
+
   def test_rejects_duplicate_node
-    assert_raises(DAG::DuplicateNodeError) do
+    error = assert_raises(DAG::DuplicateNodeError) do
       DAG::Graph.new.add_node(:a).add_node(:a)
     end
+    assert_equal "Duplicate node: a", error.message
   end
 
   def test_rejects_edge_to_unknown_node
-    assert_raises(DAG::UnknownNodeError) do
+    error = assert_raises(DAG::UnknownNodeError) do
       DAG::Graph.new.add_node(:a).add_edge(:a, :missing)
     end
+
+    assert_equal "Unknown node: missing", error.message
   end
 
   def test_rejects_edge_from_unknown_node
-    assert_raises(DAG::UnknownNodeError) do
+    error = assert_raises(DAG::UnknownNodeError) do
       DAG::Graph.new.add_node(:a).add_edge(:missing, :a)
     end
+
+    assert_equal "Unknown node: missing", error.message
   end
 
   def test_rejects_self_referencing_edge_as_cycle
@@ -43,12 +66,23 @@ class GraphTest < Minitest::Test
       DAG::Graph.new.add_node(:a).add_edge(:a, :a)
     end
     assert_match(/self-loop/, error.message)
+    assert_includes error.message, "Edge a → a"
   end
 
   def test_duplicate_edge_is_idempotent
     graph = build_graph([:a, :b], [[:a, :b]])
-    graph.add_edge(:a, :b)
+    returned = graph.add_edge(:a, :b)
+
+    assert_same graph, returned
     assert_equal 1, graph.edges.size
+  end
+
+  def test_duplicate_edge_preserves_existing_metadata
+    graph = build_graph([:a, :b], [])
+    graph.add_edge(:a, :b, weight: 5)
+    graph.add_edge(:a, :b, weight: 9)
+
+    assert_equal({weight: 5}, graph.edge_metadata(:a, :b))
   end
 
   # --- Cycle detection on add_edge ---
@@ -116,8 +150,25 @@ class GraphTest < Minitest::Test
     assert_equal (1..5).map { |i| :"leaf_#{i}" }.sort, order[1]
   end
 
+  def test_topological_layers_sort_each_frontier
+    graph = DAG::Graph.new.add_node(:root).add_node(:b).add_node(:a)
+    graph.add_edge(:root, :b)
+    graph.add_edge(:root, :a)
+
+    assert_equal [[:root], [:a, :b]], graph.topological_layers
+  end
+
   def test_empty_graph_sort
     assert_equal [], DAG::Graph.new.topological_layers
+  end
+
+  def test_topological_layers_detects_corrupted_cycle_state
+    graph = DAG::Graph.new.add_node(:a).add_node(:b)
+    graph.send(:insert_edge, :a, :b, {})
+    graph.send(:insert_edge, :b, :b, {})
+
+    error = assert_raises(DAG::CycleError) { graph.topological_layers }
+    assert_equal "Graph contains a cycle", error.message
   end
 
   # --- Graph queries ---
@@ -128,10 +179,30 @@ class GraphTest < Minitest::Test
     assert_kind_of Set, graph.roots
   end
 
+  def test_each_root
+    graph = build_graph([:a, :b, :c], [[:a, :c], [:b, :c]])
+    collected = []
+
+    graph.each_root { |root| collected << root }
+
+    assert_equal [:a, :b], collected.sort
+    assert_equal [:a, :b], graph.each_root.to_a.sort
+  end
+
   def test_leaves
     graph = build_graph([:a, :b, :c], [[:a, :b], [:a, :c]])
     assert_equal [:b, :c].to_set, graph.leaves
     assert_kind_of Set, graph.leaves
+  end
+
+  def test_each_leaf
+    graph = build_graph([:a, :b, :c], [[:a, :b], [:a, :c]])
+    collected = []
+
+    graph.each_leaf { |leaf| collected << leaf }
+
+    assert_equal [:b, :c], collected.sort
+    assert_equal [:b, :c], graph.each_leaf.to_a.sort
   end
 
   def test_successors
@@ -139,14 +210,41 @@ class GraphTest < Minitest::Test
     assert_equal [:b, :c].to_set, graph.successors(:a)
   end
 
+  def test_successors_on_mutable_graph_returns_copy
+    graph = build_graph([:a, :b, :c], [[:a, :b]])
+
+    graph.successors(:a) << :c
+
+    refute graph.edge?(:a, :c)
+  end
+
   def test_predecessors
     graph = build_graph([:a, :b, :c], [[:a, :c], [:b, :c]])
     assert_equal [:a, :b].to_set, graph.predecessors(:c)
   end
 
+  def test_predecessors_on_mutable_graph_returns_copy
+    graph = build_graph([:a, :b, :c], [[:a, :c]])
+
+    graph.predecessors(:c) << :b
+
+    assert_equal Set[:a], graph.predecessors(:c)
+  end
+
   def test_ancestors
     graph = build_graph([:a, :b, :c, :d], [[:a, :b], [:b, :c], [:b, :d]])
     assert_equal [:a, :b].to_set, graph.ancestors(:c)
+  end
+
+  def test_query_methods_normalize_string_node_names
+    graph = build_graph([:a, :b, :c, :d], [[:a, :b], [:b, :c], [:a, :d]])
+
+    assert_equal [:b, :d].to_set, graph.successors("a")
+    assert_equal [:b].to_set, graph.predecessors("c")
+    assert_equal [:a, :b].to_set, graph.ancestors("c")
+    assert_equal [:b, :c, :d].to_set, graph.descendants("a")
+    assert_equal [:a, :b, :c, :d].to_set, graph.descendants_of("a")
+    assert graph.path?("a", "c")
   end
 
   def test_descendants
@@ -184,9 +282,26 @@ class GraphTest < Minitest::Test
     assert_equal 0, sub.edges.size
   end
 
+  def test_subgraph_keeps_later_internal_edge_after_external_edge
+    graph = build_graph([:a, :b, :c], [[:a, :b], [:a, :c]])
+    sub = graph.subgraph([:a, :c])
+
+    assert sub.edge?(:a, :c)
+  end
+
+  def test_subgraph_normalizes_string_node_names
+    graph = build_graph([:a, :b, :c], [[:a, :b], [:a, :c]])
+    sub = graph.subgraph(["a", "c"])
+
+    assert_equal Set[:a, :c], sub.nodes
+    assert sub.edge?(:a, :c)
+  end
+
   def test_subgraph_rejects_unknown_nodes
     graph = build_graph([:a], [])
-    assert_raises(ArgumentError) { graph.subgraph([:a, :missing]) }
+    error = assert_raises(ArgumentError) { graph.subgraph([:a, :missing]) }
+
+    assert_equal "Unknown nodes: [:missing]", error.message
   end
 
   def test_subgraph_preserves_edge_metadata
@@ -279,17 +394,33 @@ class GraphTest < Minitest::Test
     refute graph.path?(:a, :ghost)
   end
 
+  def test_path_rejects_missing_target_even_when_internal_edge_exists
+    graph = DAG::Graph.new.add_node(:a)
+    graph.send(:insert_edge, :a, :ghost, {})
+
+    refute graph.path?(:a, :ghost)
+  end
+
+  def test_path_rejects_missing_source_even_when_internal_edge_exists
+    graph = DAG::Graph.new.add_node(:a)
+    graph.send(:insert_edge, :ghost, :a, {})
+
+    refute graph.path?(:ghost, :a)
+  end
+
   # --- indegree / outdegree ---
 
   def test_indegree
     graph = build_graph([:a, :b, :c], [[:a, :c], [:b, :c]])
     assert_equal 0, graph.indegree(:a)
     assert_equal 2, graph.indegree(:c)
+    assert_equal 2, graph.indegree("c")
   end
 
   def test_outdegree
     graph = build_graph([:a, :b, :c], [[:a, :b], [:a, :c]])
     assert_equal 2, graph.outdegree(:a)
+    assert_equal 2, graph.outdegree("a")
     assert_equal 0, graph.outdegree(:b)
   end
 
@@ -307,6 +438,14 @@ class GraphTest < Minitest::Test
     assert_instance_of Enumerator, graph.each_node
   end
 
+  def test_each_node_enumerator_reads_nodes_when_enumerated
+    graph = DAG::Graph.new.add_node(:a)
+    enumerator = graph.each_node
+    graph.add_node(:b)
+
+    assert_equal [:a, :b], enumerator.to_a
+  end
+
   def test_each_edge
     graph = build_graph([:a, :b, :c], [[:a, :b], [:a, :c]])
     collected = []
@@ -320,11 +459,20 @@ class GraphTest < Minitest::Test
     assert_instance_of Enumerator, graph.each_edge
   end
 
+  def test_each_edge_enumerator_reads_edges_when_enumerated
+    graph = DAG::Graph.new.add_node(:a).add_node(:b)
+    enumerator = graph.each_edge
+    graph.add_edge(:a, :b)
+
+    assert_equal [DAG::Edge.new(from: :a, to: :b, metadata: {})], enumerator.to_a
+  end
+
   def test_each_predecessor
     graph = build_graph([:a, :b, :c, :d], [[:a, :c], [:b, :c], [:c, :d]])
     collected = []
     graph.each_predecessor(:c) { |p| collected << p }
     assert_equal [:a, :b], collected.sort
+    assert_equal [:a, :b], graph.each_predecessor("c").to_a.sort
   end
 
   def test_each_predecessor_with_no_predecessors
@@ -340,11 +488,20 @@ class GraphTest < Minitest::Test
     assert_equal [:a], graph.each_predecessor(:b).to_a
   end
 
+  def test_each_predecessor_enumerator_reads_predecessors_when_enumerated
+    graph = DAG::Graph.new.add_node(:a).add_node(:b)
+    enumerator = graph.each_predecessor(:b)
+    graph.add_edge(:a, :b)
+
+    assert_equal [:a], enumerator.to_a
+  end
+
   def test_each_successor
     graph = build_graph([:a, :b, :c, :d], [[:a, :c], [:a, :d], [:b, :c]])
     collected = []
     graph.each_successor(:a) { |s| collected << s }
     assert_equal [:c, :d], collected.sort
+    assert_equal [:c, :d], graph.each_successor("a").to_a.sort
   end
 
   def test_each_successor_with_no_successors
@@ -360,18 +517,41 @@ class GraphTest < Minitest::Test
     assert_equal [:b], graph.each_successor(:a).to_a
   end
 
+  def test_each_successor_enumerator_reads_successors_when_enumerated
+    graph = DAG::Graph.new.add_node(:a).add_node(:b)
+    enumerator = graph.each_successor(:a)
+    graph.add_edge(:a, :b)
+
+    assert_equal [:b], enumerator.to_a
+  end
+
   # --- Immutability after freeze ---
 
   def test_frozen_graph_rejects_add_node
     graph = build_graph([:a], [])
     graph.freeze
-    assert_raises(FrozenError) { graph.add_node(:b) }
+    error = assert_raises(FrozenError) { graph.add_node(:b) }
+    assert_equal "can't modify frozen DAG::Graph", error.message
+  end
+
+  def test_frozen_graph_add_node_checks_frozen_before_duplicate_validation
+    graph = build_graph([:a], [])
+    graph.freeze
+
+    assert_raises(FrozenError) { graph.add_node(:a) }
   end
 
   def test_frozen_graph_rejects_add_edge
     graph = build_graph([:a, :b], [])
     graph.freeze
     assert_raises(FrozenError) { graph.add_edge(:a, :b) }
+  end
+
+  def test_frozen_graph_add_edge_checks_frozen_before_validation
+    graph = build_graph([:a], [])
+    graph.freeze
+
+    assert_raises(FrozenError) { graph.add_edge(:a, :missing) }
   end
 
   def test_frozen_graph_queries_still_work
@@ -381,14 +561,37 @@ class GraphTest < Minitest::Test
     assert_equal 3, graph.size
     assert graph.node?(:a)
     assert graph.edge?(:a, :b)
+    assert_equal Set[:b], graph.successors(:a)
+    assert_equal Set[:a], graph.predecessors(:b)
     assert_equal [[:a], [:b], [:c]], graph.topological_layers
     assert_equal [:a, :b, :c], graph.topological_sort
     assert graph.path?(:a, :c)
   end
 
+  def test_freeze_is_idempotent
+    graph = build_graph([:a, :b], [[:a, :b]])
+
+    assert_same graph, graph.freeze
+    assert_same graph, graph.freeze
+  end
+
+  def test_freeze_freezes_internal_rows
+    graph = DAG::Graph.new.add_node(:a).add_node(:b)
+    graph.add_edge(:a, :b, weight: 1)
+    graph.freeze
+
+    assert graph.instance_variable_get(:@adjacency).frozen?
+    assert graph.successors(:a).frozen?
+    assert graph.instance_variable_get(:@reverse).frozen?
+    assert graph.predecessors(:b).frozen?
+    assert graph.instance_variable_get(:@edge_metadata).frozen?
+    assert graph.instance_variable_get(:@edge_metadata).fetch(:a).frozen?
+  end
+
   def test_frozen_graph_nodes_not_externally_mutable
     graph = build_graph([:a], [])
     graph.freeze
+    assert_same graph.nodes, graph.nodes
     assert_raises(FrozenError) { graph.nodes << :hack }
   end
 
@@ -402,6 +605,15 @@ class GraphTest < Minitest::Test
     assert graph.node?(:a)
     assert graph.node?(:b)
     refute graph.node?(:hack)
+  end
+
+  def test_unfrozen_graph_nodes_reader_does_not_freeze_internal_nodes
+    graph = build_graph([:a], [])
+
+    graph.nodes
+    graph.add_node(:b)
+
+    assert graph.node?(:b)
   end
 
   # --- dup (unfrozen copy) ---
@@ -472,6 +684,15 @@ class GraphTest < Minitest::Test
     refute graph.edge?(:b, :c)
   end
 
+  def test_with_edge_preserves_metadata
+    graph = build_graph([:a, :b], [])
+    new_graph = graph.with_edge(:a, :b, weight: 4)
+
+    assert new_graph.frozen?
+    assert_equal({weight: 4}, new_graph.edge_metadata(:a, :b))
+    assert_empty graph.edge_metadata(:a, :b)
+  end
+
   def test_with_node_on_mutable_graph
     graph = build_graph([:a], [])
     new_graph = graph.with_node(:b)
@@ -497,6 +718,17 @@ class GraphTest < Minitest::Test
     assert_equal [{from: :a, to: :b}], h[:edges]
   end
 
+  def test_to_h_sorts_edges_by_target_when_source_matches
+    graph = DAG::Graph.new.add_node(:root).add_node(:b).add_node(:a)
+    graph.add_edge(:root, :b)
+    graph.add_edge(:root, :a)
+
+    assert_equal [
+      {from: :root, to: :a},
+      {from: :root, to: :b}
+    ], graph.to_h.fetch(:edges)
+  end
+
   def test_to_h_empty_graph
     h = DAG::Graph.new.to_h
     assert_equal({nodes: [], edges: []}, h)
@@ -519,9 +751,24 @@ class GraphTest < Minitest::Test
     assert_equal g1, g2
   end
 
+  def test_equality_accepts_graph_subclasses
+    graph_class = Class.new(DAG::Graph)
+    g1 = build_graph([:a, :b], [[:a, :b]]).freeze
+    g2 = graph_class.new.add_node(:a).add_node(:b).add_edge(:a, :b).freeze
+
+    assert_equal g1, g2
+  end
+
   def test_equality_different_structure
     g1 = build_graph([:a, :b], [[:a, :b]]).freeze
     g2 = build_graph([:a, :b, :c], [[:a, :b]]).freeze
+    refute_equal g1, g2
+  end
+
+  def test_equality_different_edges_with_same_nodes
+    g1 = build_graph([:a, :b, :c], [[:a, :b]]).freeze
+    g2 = build_graph([:a, :b, :c], [[:a, :c]]).freeze
+
     refute_equal g1, g2
   end
 
@@ -552,6 +799,20 @@ class GraphTest < Minitest::Test
     g1 = build_graph([:a, :b], [[:a, :b]]).freeze
     g2 = build_graph([:a, :b], [[:a, :b]]).freeze
     assert_equal g1.hash, g2.hash
+  end
+
+  def test_hash_differs_for_different_node_sets_with_same_edges
+    g1 = build_graph([:a], []).freeze
+    g2 = build_graph([:b], []).freeze
+
+    refute_equal g1.hash, g2.hash
+  end
+
+  def test_hash_differs_for_same_nodes_with_different_edges
+    g1 = build_graph([:a, :b, :c], [[:a, :b]]).freeze
+    g2 = build_graph([:a, :b, :c], [[:a, :c]]).freeze
+
+    refute_equal g1.hash, g2.hash
   end
 
   def test_equality_independent_of_edge_insertion_order
@@ -592,42 +853,93 @@ class GraphTest < Minitest::Test
 
   def test_remove_node_removes_node_and_incident_edges
     graph = build_graph([:a, :b, :c], [[:a, :b], [:b, :c]])
-    graph.remove_node(:b)
+    returned = graph.remove_node(:b)
 
+    assert_same graph, returned
     refute graph.node?(:b)
     assert_equal 2, graph.size
     assert_equal 0, graph.edges.size
+    assert_empty graph.successors(:a)
+    assert_empty graph.predecessors(:c)
+    refute graph.instance_variable_get(:@adjacency).key?(:b)
+    refute graph.instance_variable_get(:@reverse).key?(:b)
+    refute graph.instance_variable_get(:@edge_metadata).key?(:b)
+  end
+
+  def test_remove_node_normalizes_string_name
+    graph = build_graph([:a, :b], [[:a, :b]])
+
+    graph.remove_node("a")
+
+    refute graph.node?(:a)
+  end
+
+  def test_remove_node_removes_incoming_edge_metadata
+    graph = DAG::Graph.new.add_node(:a).add_node(:b)
+    graph.add_edge(:a, :b, weight: 1)
+
+    graph.remove_node(:b)
+
+    assert_empty graph.edge_metadata(:a, :b)
+    assert_empty graph.instance_variable_get(:@edge_metadata)
+  end
+
+  def test_remove_node_removes_outgoing_edge_metadata_row
+    graph = DAG::Graph.new.add_node(:a).add_node(:b)
+    graph.add_edge(:a, :b, weight: 1)
+
+    graph.remove_node(:a)
+
+    assert_empty graph.instance_variable_get(:@edge_metadata)
   end
 
   def test_remove_node_unknown_raises
     graph = build_graph([:a], [])
-    assert_raises(DAG::UnknownNodeError) { graph.remove_node(:missing) }
+    error = assert_raises(DAG::UnknownNodeError) { graph.remove_node(:missing) }
+
+    assert_equal "Unknown node: missing", error.message
   end
 
   def test_remove_edge_keeps_both_nodes
     graph = build_graph([:a, :b], [[:a, :b]])
-    graph.remove_edge(:a, :b)
+    returned = graph.remove_edge(:a, :b)
 
+    assert_same graph, returned
     assert graph.node?(:a)
     assert graph.node?(:b)
+    refute graph.edge?(:a, :b)
+    assert_empty graph.predecessors(:b)
+  end
+
+  def test_remove_edge_normalizes_string_endpoints
+    graph = build_graph([:a, :b], [[:a, :b]])
+
+    graph.remove_edge("a", "b")
+
     refute graph.edge?(:a, :b)
   end
 
   def test_remove_edge_unknown_raises
     graph = build_graph([:a, :b], [])
-    assert_raises(DAG::UnknownNodeError) { graph.remove_edge(:a, :b) }
+    error = assert_raises(DAG::UnknownNodeError) { graph.remove_edge(:a, :b) }
+
+    assert_equal "Unknown edge: a → b", error.message
   end
 
   def test_frozen_graph_rejects_remove_node
     graph = build_graph([:a], [])
     graph.freeze
-    assert_raises(FrozenError) { graph.remove_node(:a) }
+    error = assert_raises(FrozenError) { graph.remove_node(:a) }
+
+    assert_equal "can't modify frozen DAG::Graph", error.message
   end
 
   def test_frozen_graph_rejects_remove_edge
     graph = build_graph([:a, :b], [[:a, :b]])
     graph.freeze
-    assert_raises(FrozenError) { graph.remove_edge(:a, :b) }
+    error = assert_raises(FrozenError) { graph.remove_edge(:a, :b) }
+
+    assert_equal "can't modify frozen DAG::Graph", error.message
   end
 
   def test_topological_sort_after_removal
@@ -699,14 +1011,26 @@ class GraphTest < Minitest::Test
 
   def test_replace_node_renames_and_rewires_chain
     graph = build_graph([:a, :b, :c], [[:a, :b], [:b, :c]])
-    graph.replace_node(:b, :x)
+    returned = graph.replace_node(:b, :x)
 
+    assert_same graph, returned
     assert graph.node?(:x)
     refute graph.node?(:b)
     assert graph.edge?(:a, :x)
     assert graph.edge?(:x, :c)
     assert_equal 3, graph.size
     assert_equal 2, graph.edges.size
+  end
+
+  def test_replace_node_normalizes_string_names
+    graph = build_graph([:a, :b, :c], [[:a, :b], [:b, :c]])
+
+    graph.replace_node("b", "x")
+
+    assert graph.node?(:x)
+    refute graph.node?(:b)
+    assert graph.edge?(:a, :x)
+    assert graph.edge?(:x, :c)
   end
 
   def test_replace_node_renames_root
@@ -749,8 +1073,9 @@ class GraphTest < Minitest::Test
 
   def test_replace_node_same_name_is_noop
     graph = build_graph([:a, :b], [[:a, :b]])
-    graph.replace_node(:a, :a)
+    returned = graph.replace_node(:a, :a)
 
+    assert_same graph, returned
     assert graph.node?(:a)
     assert graph.edge?(:a, :b)
     assert_equal 2, graph.size
@@ -768,18 +1093,37 @@ class GraphTest < Minitest::Test
 
   def test_replace_node_unknown_raises
     graph = build_graph([:a], [])
-    assert_raises(DAG::UnknownNodeError) { graph.replace_node(:missing, :x) }
+    error = assert_raises(DAG::UnknownNodeError) { graph.replace_node(:missing, :x) }
+
+    assert_equal "Unknown node: missing", error.message
+  end
+
+  def test_replace_node_unknown_old_name_takes_priority_over_duplicate_new_name
+    graph = build_graph([:a], [])
+
+    error = assert_raises(DAG::UnknownNodeError) { graph.replace_node(:missing, :a) }
+    assert_equal "Unknown node: missing", error.message
   end
 
   def test_replace_node_duplicate_raises
     graph = build_graph([:a, :b], [])
-    assert_raises(DAG::DuplicateNodeError) { graph.replace_node(:a, :b) }
+    error = assert_raises(DAG::DuplicateNodeError) { graph.replace_node(:a, :b) }
+
+    assert_equal "Duplicate node: b", error.message
   end
 
   def test_frozen_graph_rejects_replace_node
     graph = build_graph([:a, :b], [[:a, :b]])
     graph.freeze
     assert_raises(FrozenError) { graph.replace_node(:a, :x) }
+  end
+
+  def test_frozen_graph_replace_node_checks_frozen_before_noop
+    graph = build_graph([:a], [])
+    graph.freeze
+
+    error = assert_raises(FrozenError) { graph.replace_node(:a, :a) }
+    assert_equal "can't modify frozen DAG::Graph", error.message
   end
 
   def test_with_node_replaced_returns_new_frozen_graph
@@ -858,6 +1202,7 @@ class GraphTest < Minitest::Test
   def test_node_predicate
     graph = build_graph([:a, :b], [])
     assert graph.node?(:a)
+    assert graph.node?("a")
     refute graph.node?(:z)
   end
 
@@ -869,11 +1214,15 @@ class GraphTest < Minitest::Test
   end
 
   def test_incoming_edges_on_sink
-    graph = build_graph([:a, :b, :c], [[:a, :c], [:b, :c]])
+    graph = DAG::Graph.new.add_node(:a).add_node(:b).add_node(:c)
+      .add_edge(:a, :c, weight: 2)
+      .add_edge(:b, :c)
     edges = graph.incoming_edges(:c)
     assert_equal 2, edges.size
     assert edges.all? { |e| e.to == :c }
     assert_equal [:a, :b], edges.map(&:from).sort
+    assert_equal({weight: 2}, edges.detect { |edge| edge.from == :a }.metadata)
+    assert_equal edges, graph.incoming_edges("c")
   end
 
   # --- Edge metadata ---
@@ -882,11 +1231,13 @@ class GraphTest < Minitest::Test
     graph = build_graph([:a, :b], [])
     graph.add_edge(:a, :b, weight: 5)
     assert_equal({weight: 5}, graph.edge_metadata(:a, :b))
+    assert_equal({weight: 5}, graph.edge_metadata("a", "b"))
   end
 
   def test_edge_metadata_default_empty
     graph = build_graph([:a, :b], [[:a, :b]])
     assert_equal({}, graph.edge_metadata(:a, :b))
+    assert_empty graph.instance_variable_get(:@edge_metadata)
   end
 
   def test_edge_weight_convenience
@@ -925,9 +1276,10 @@ class GraphTest < Minitest::Test
   def test_add_edge_rejects_non_json_safe_metadata
     graph = build_graph([:a, :b], [])
 
-    assert_raises(ArgumentError) do
+    error = assert_raises(ArgumentError) do
       graph.add_edge(:a, :b, deadline: Time.now)
     end
+    assert_includes error.message, "$root.metadata.deadline"
     refute graph.edge?(:a, :b)
   end
 
@@ -945,18 +1297,32 @@ class GraphTest < Minitest::Test
     graph = build_graph([:a, :b], [[:a, :b]])
     graph.freeze
     assert_same graph.topological_layers, graph.topological_layers
+    assert graph.topological_layers.frozen?
+    assert graph.topological_layers.all?(&:frozen?)
+    assert graph.topological_sort.frozen?
   end
 
   def test_frozen_graph_caches_roots
     graph = build_graph([:a, :b], [[:a, :b]])
     graph.freeze
     assert_same graph.roots, graph.roots
+    assert_equal Set[:a], graph.roots
+    assert graph.roots.frozen?
   end
 
   def test_frozen_graph_caches_leaves
     graph = build_graph([:a, :b], [[:a, :b]])
     graph.freeze
     assert_same graph.leaves, graph.leaves
+    assert_equal Set[:b], graph.leaves
+    assert graph.leaves.frozen?
+  end
+
+  def test_frozen_graph_caches_edges
+    graph = build_graph([:a, :b], [[:a, :b]])
+    graph.freeze
+    assert_same graph.edges, graph.edges
+    assert graph.edges.frozen?
   end
 
   def test_mutable_graph_does_not_cache
@@ -969,6 +1335,7 @@ class GraphTest < Minitest::Test
     graph.add_edge(:a, :b, weight: 5)
     graph.remove_edge(:a, :b)
     assert_equal({}, graph.edge_metadata(:a, :b))
+    refute graph.instance_variable_get(:@edge_metadata).key?(:a)
   end
 
   # --- Shortest / longest path ---
@@ -977,6 +1344,15 @@ class GraphTest < Minitest::Test
     graph = build_graph([:a, :b, :c], [[:a, :b], [:b, :c]])
     result = graph.shortest_path(:a, :c)
     assert_equal({cost: 2, path: [:a, :b, :c]}, result)
+  end
+
+  def test_weighted_paths_normalize_string_endpoints
+    graph = DAG::Graph.new.add_node(:a).add_node(:b).add_node(:c)
+    graph.add_edge(:a, :b, weight: 2)
+    graph.add_edge(:b, :c, weight: 3)
+
+    assert_equal({cost: 5, path: [:a, :b, :c]}, graph.shortest_path("a", "c"))
+    assert_equal({cost: 5, path: [:a, :b, :c]}, graph.longest_path("a", "c"))
   end
 
   def test_shortest_path_diamond_with_weights
@@ -993,6 +1369,29 @@ class GraphTest < Minitest::Test
   def test_shortest_path_unreachable
     graph = build_graph([:a, :b], [])
     assert_nil graph.shortest_path(:a, :b)
+  end
+
+  def test_weighted_paths_reject_unknown_same_endpoint
+    graph = build_graph([:a], [])
+
+    assert_nil graph.shortest_path(:missing, :missing)
+    assert_nil graph.longest_path(:missing, :missing)
+  end
+
+  def test_weighted_paths_reject_missing_target_even_when_internal_edge_exists
+    graph = DAG::Graph.new.add_node(:a)
+    graph.send(:insert_edge, :a, :ghost, {weight: 2})
+
+    assert_nil graph.shortest_path(:a, :ghost)
+    assert_nil graph.longest_path(:a, :ghost)
+  end
+
+  def test_weighted_paths_reject_missing_source_even_when_internal_edge_exists
+    graph = DAG::Graph.new.add_node(:a)
+    graph.send(:insert_edge, :ghost, :a, {weight: 2})
+
+    assert_nil graph.shortest_path(:ghost, :a)
+    assert_nil graph.longest_path(:ghost, :a)
   end
 
   def test_shortest_path_same_node
@@ -1017,6 +1416,16 @@ class GraphTest < Minitest::Test
     assert_equal [:a, :c, :d], result[:path]
   end
 
+  def test_longest_path_keeps_better_cost_from_earlier_predecessor
+    graph = DAG::Graph.new.add_node(:a).add_node(:b).add_node(:c).add_node(:d)
+      .add_edge(:a, :b, weight: 10)
+      .add_edge(:a, :c, weight: 1)
+      .add_edge(:b, :d, weight: 1)
+      .add_edge(:c, :d, weight: 1)
+
+    assert_equal({cost: 11, path: [:a, :b, :d]}, graph.longest_path(:a, :d))
+  end
+
   def test_longest_path_unreachable
     graph = build_graph([:a, :b], [])
     assert_nil graph.longest_path(:a, :b)
@@ -1039,6 +1448,22 @@ class GraphTest < Minitest::Test
     result = graph.critical_path
     assert_equal 11, result[:cost]
     assert_equal [:a, :c, :d], result[:path]
+  end
+
+  def test_critical_path_keeps_better_cost_from_earlier_predecessor
+    graph = DAG::Graph.new.add_node(:a).add_node(:b).add_node(:c)
+      .add_edge(:a, :c, weight: 10)
+      .add_edge(:b, :c, weight: 1)
+
+    assert_equal({cost: 10, path: [:a, :c]}, graph.critical_path)
+  end
+
+  def test_critical_path_selects_best_leaf_not_first_leaf
+    graph = DAG::Graph.new.add_node(:root).add_node(:short).add_node(:long)
+      .add_edge(:root, :short, weight: 1)
+      .add_edge(:root, :long, weight: 10)
+
+    assert_equal({cost: 10, path: [:root, :long]}, graph.critical_path)
   end
 
   def test_critical_path_single_node
@@ -1091,6 +1516,44 @@ class GraphTest < Minitest::Test
     graph = build_graph([:a, :b], [])
     graph.add_edge(:a, :b, weight: 3)
     assert_match(/a -> b \[label="weight=3"\]/, graph.to_dot)
+  end
+
+  def test_to_dot_joins_multiple_edge_metadata_with_comma_space
+    graph = build_graph([:a, :b], [])
+    graph.add_edge(:a, :b, weight: 3, label: "fast")
+
+    assert_includes graph.to_dot, %(  a -> b [label="weight=3, label=fast"];)
+  end
+
+  def test_to_dot_quotes_metadata_edge_source_names
+    graph = DAG::Graph.new.add_node(:"my-node").add_node(:b)
+    graph.add_edge(:"my-node", :b, weight: 3)
+
+    assert_includes graph.to_dot, %(  "my-node" -> b [label="weight=3"];)
+  end
+
+  def test_to_dot_quotes_metadata_edge_target_names
+    graph = DAG::Graph.new.add_node(:a).add_node(:"my-node")
+    graph.add_edge(:a, :"my-node", weight: 3)
+
+    assert_includes graph.to_dot, %(  a -> "my-node" [label="weight=3"];)
+  end
+
+  def test_to_dot_sorts_edges_from_same_node
+    graph = DAG::Graph.new.add_node(:root).add_node(:b).add_node(:a)
+    graph.add_edge(:root, :b)
+    graph.add_edge(:root, :a)
+
+    expected = <<~DOT.chomp
+      digraph dag {
+        root;
+        a;
+        b;
+        root -> a;
+        root -> b;
+      }
+    DOT
+    assert_equal expected, graph.to_dot
   end
 
   def test_to_dot_quotes_node_names_with_special_chars
@@ -1190,7 +1653,9 @@ class GraphTest < Minitest::Test
 
   def test_descendants_of_unknown_raises
     graph = build_graph([:a], [])
-    assert_raises(DAG::UnknownNodeError) { graph.descendants_of(:nope) }
+    error = assert_raises(DAG::UnknownNodeError) { graph.descendants_of(:nope) }
+
+    assert_equal "Unknown node: nope", error.message
   end
 
   def test_exclusive_descendants_diamond
@@ -1200,13 +1665,30 @@ class GraphTest < Minitest::Test
     assert_equal Set[:a, :b], graph.exclusive_descendants_of(:a)
     assert_equal Set[:c], graph.exclusive_descendants_of(:c)
     assert_equal Set[:d], graph.shared_descendants_of(:a)
+    assert_equal Set[:d], graph.shared_descendants_of("a")
     assert_equal Set[:d], graph.shared_descendants_of(:c)
   end
 
   def test_exclusive_descendants_self_only
     graph = build_graph([:a, :b], [[:a, :b]])
     assert_equal Set[:a, :b], graph.exclusive_descendants_of(:a)
+    assert_equal Set[:a, :b], graph.exclusive_descendants_of("a")
+    assert_equal Set[:b], graph.exclusive_descendants_of(:a, include_self: false)
     assert_equal Set[], graph.shared_descendants_of(:a)
+  end
+
+  def test_exclusive_descendants_unknown_raises
+    graph = build_graph([:a], [])
+    error = assert_raises(DAG::UnknownNodeError) { graph.exclusive_descendants_of(:nope) }
+
+    assert_equal "Unknown node: nope", error.message
+  end
+
+  def test_shared_descendants_unknown_raises
+    graph = build_graph([:a], [])
+    error = assert_raises(DAG::UnknownNodeError) { graph.shared_descendants_of(:nope) }
+
+    assert_equal "Unknown node: nope", error.message
   end
 
   def test_topological_order_is_alias_with_ascii_tiebreak
@@ -1224,8 +1706,7 @@ class GraphTest < Minitest::Test
     graph = DAG::Graph.new.add_node(:a).add_node(:b)
     graph.add_edge(:a, :b)
     error = assert_raises(DAG::CycleError) { graph.add_edge(:b, :a) }
-    assert_match(/b/, error.message)
-    assert_match(/a/, error.message)
+    assert_includes error.message, "Edge b → a"
   end
 
   # --- delete_metadata partial-row case ---

--- a/spec/graph_validator_test.rb
+++ b/spec/graph_validator_test.rb
@@ -3,6 +3,9 @@
 require_relative "test_helper"
 
 class GraphValidatorTest < Minitest::Test
+  cover DAG::Graph::Report
+  cover DAG::Graph::Validator
+
   # --- Valid graphs ---
 
   def test_valid_graph_passes
@@ -24,6 +27,14 @@ class GraphValidatorTest < Minitest::Test
     result = DAG::Graph::Validator.validate(graph)
     refute result.valid?
     assert result.errors.any? { |e| e.include?("isolated") && e.include?("c") }
+  end
+
+  def test_instance_validator_uses_default_rules
+    graph = build_graph([:a, :b, :c], [[:a, :b]])
+    result = DAG::Graph::Validator.new(graph).run
+
+    refute result.valid?
+    assert_equal ["Node c is isolated (no edges)"], result.errors
   end
 
   def test_isolated_nodes_can_be_opted_out
@@ -87,6 +98,12 @@ class GraphValidatorTest < Minitest::Test
     assert_same graph, DAG::Graph::Validator.validate!(graph)
   end
 
+  def test_validate_bang_honors_defaults_override
+    graph = build_graph([:a, :b, :c], [[:a, :b]])
+
+    assert_same graph, DAG::Graph::Validator.validate!(graph, defaults: [])
+  end
+
   def test_validate_bang_raises_on_invalid
     graph = build_graph([:a, :b, :c], [[:a, :b]])
     error = assert_raises(DAG::ValidationError) do
@@ -94,6 +111,7 @@ class GraphValidatorTest < Minitest::Test
     end
     assert error.message.include?("isolated")
     assert_kind_of Array, error.errors
+    assert_equal ["Node c is isolated (no edges)"], error.errors
   end
 
   def test_validate_bang_raises_on_custom_rule_failure

--- a/spec/r0/v1_4_release_gate_test.rb
+++ b/spec/r0/v1_4_release_gate_test.rb
@@ -5,8 +5,8 @@ require_relative "../test_helper"
 class R0V14ReleaseGateTest < Minitest::Test
   ROOT = File.expand_path("../..", __dir__)
 
-  def test_version_is_bumped_to_contract_release
-    assert_equal "1.4.0", DAG::VERSION
+  def test_version_has_not_regressed_before_contract_release
+    assert_operator Gem::Version.new(DAG::VERSION), :>=, Gem::Version.new("1.4.0")
   end
 
   def test_changelog_contains_v1_4_release_notes

--- a/spec/r0/v1_5_release_gate_test.rb
+++ b/spec/r0/v1_5_release_gate_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class R0V15ReleaseGateTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def test_version_is_bumped_to_mutation_testing_release
+    assert_equal "1.5.0", DAG::VERSION
+  end
+
+  def test_changelog_contains_v1_5_release_notes
+    changelog = normalized("CHANGELOG.md")
+
+    assert_includes changelog, "## 1.5.0 — 2026-05-31"
+    assert_includes changelog, "mutation-testing release"
+    assert_includes changelog, "mutant-minitest"
+    assert_includes changelog, "rake mutant:run"
+    assert_includes changelog, "100% mutation coverage"
+  end
+
+  def test_roadmap_marks_v1_5_release
+    roadmap = normalized("ROADMAP.md")
+
+    assert_includes roadmap, "V1.5 mutation testing gate"
+    assert_includes roadmap, "Release v1.5"
+  end
+
+  def test_mutant_configuration_pins_focused_subjects
+    mutant_config = normalized(".mutant.yml")
+
+    assert_includes mutant_config, "integration: name: minitest"
+    assert_includes mutant_config, "fail_fast: true"
+    assert_includes mutant_config, "DAG::Graph*"
+    assert_includes mutant_config, "DAG::Effects::Await*"
+  end
+
+  def test_rakefile_exposes_mutant_tasks
+    rakefile = File.read(File.join(ROOT, "Rakefile"))
+
+    assert_includes rakefile, "task :test"
+    assert_includes rakefile, "bundle exec mutant test"
+    assert_includes rakefile, "task :run"
+    assert_includes rakefile, "bundle exec mutant run --fail-fast"
+    assert_includes rakefile, "task :changed"
+    assert_includes rakefile, "MUTANT_SINCE"
+  end
+
+  def test_mutant_bridge_loads_spec_suite
+    bridge = File.read(File.join(ROOT, "test/all_test.rb"))
+    helper = File.read(File.join(ROOT, "spec/test_helper.rb"))
+
+    assert_includes bridge, "../spec/**/*_test.rb"
+    assert_includes helper, 'require "mutant/minitest/coverage"'
+  end
+end

--- a/spec/r1/effects_value_objects_test.rb
+++ b/spec/r1/effects_value_objects_test.rb
@@ -3,6 +3,12 @@
 require_relative "../test_helper"
 
 class EffectsValueObjectsTest < Minitest::Test
+  cover DAG::Effects::Await
+  cover DAG::Effects::HandlerResult
+  cover DAG::Effects::Intent
+  cover DAG::Effects::PreparedIntent
+  cover DAG::Effects::Record
+
   SnapshotInput = Data.define(:metadata)
 
   def test_effect_errors_inherit_from_dag_error
@@ -242,6 +248,33 @@ class EffectsValueObjectsTest < Minitest::Test
     assert_equal 10, result.not_before_ms
     assert_equal [intent], result.proposed_effects
     assert_equal({effects: [intent.ref]}, result.resume_token)
+    assert_equal({effect_ref: intent.ref}, result.metadata)
+  end
+
+  def test_await_uses_top_level_waiting_for_pending_effect
+    shadow_waiting = Class.new do
+      def self.[](*)
+        raise "shadow waiting should not be used"
+      end
+    end
+    DAG::Effects::Await.const_set(:Waiting, shadow_waiting)
+
+    intent = effect_intent
+    result = DAG::Effects::Await.call(SnapshotInput.new({}), intent) { raise "should not yield" }
+
+    assert_kind_of DAG::Waiting, result
+  ensure
+    DAG::Effects::Await.send(:remove_const, :Waiting) if DAG::Effects::Await.const_defined?(:Waiting, false)
+  end
+
+  def test_await_treats_input_without_metadata_as_missing_snapshot
+    intent = effect_intent
+    result = DAG::Effects::Await.call(Object.new, intent, not_before_ms: 10) do
+      raise "should not yield"
+    end
+
+    assert_kind_of DAG::Waiting, result
+    assert_equal [intent], result.proposed_effects
   end
 
   def test_await_yields_when_snapshot_succeeded
@@ -268,6 +301,25 @@ class EffectsValueObjectsTest < Minitest::Test
     assert_equal({effect_ref: intent.ref}, result.metadata)
   end
 
+  def test_await_uses_top_level_failure_for_terminal_failure
+    shadow_failure = Class.new do
+      def self.[](*)
+        raise "shadow failure should not be used"
+      end
+    end
+    DAG::Effects::Await.const_set(:Failure, shadow_failure)
+    DAG::Effects::Await.const_set(:Effects, Module.new)
+
+    intent = effect_intent
+    input = SnapshotInput.new({effects: {intent.ref => {status: :failed_terminal, error: {code: :denied}}}})
+    result = DAG::Effects::Await.call(input, intent) { raise "should not yield" }
+
+    assert_kind_of DAG::Failure, result
+  ensure
+    DAG::Effects::Await.send(:remove_const, :Failure) if DAG::Effects::Await.const_defined?(:Failure, false)
+    DAG::Effects::Await.send(:remove_const, :Effects) if DAG::Effects::Await.const_defined?(:Effects, false)
+  end
+
   def test_await_returns_waiting_for_retriable_failure
     intent = effect_intent
     record = effect_record(status: :failed_retriable, error: {code: :busy}, not_before_ms: 99)
@@ -280,25 +332,92 @@ class EffectsValueObjectsTest < Minitest::Test
     assert_equal [intent], result.proposed_effects
   end
 
+  def test_await_uses_fallback_not_before_for_retriable_failure_without_snapshot_delay
+    DAG::Effects::Await.const_set(:Effects, Module.new)
+    intent = effect_intent
+    record = effect_record(status: :failed_retriable, error: {code: :busy})
+    result = DAG::Effects::Await.call(SnapshotInput.new({effects: {intent.ref => record}}), intent, not_before_ms: 10) do
+      raise "should not yield"
+    end
+
+    assert_kind_of DAG::Waiting, result
+    assert_equal 10, result.not_before_ms
+  ensure
+    DAG::Effects::Await.send(:remove_const, :Effects) if DAG::Effects::Await.const_defined?(:Effects, false)
+  end
+
   def test_await_requires_continuation_to_return_step_result
     intent = effect_intent
     input = SnapshotInput.new({effects: {intent.ref => {status: :succeeded, result: 1}}})
 
-    assert_raises(TypeError) do
+    error = assert_raises(TypeError) do
       DAG::Effects::Await.call(input, intent) { |value| value + 1 }
     end
+
+    assert_equal "Await continuation must return Success, Waiting, or Failure, got Integer", error.message
   end
 
   def test_await_rejects_non_intent_first_argument
-    assert_raises(ArgumentError) do
+    error = assert_raises(ArgumentError) do
       DAG::Effects::Await.call(SnapshotInput.new({}), "not-an-intent") { |_| nil }
     end
+
+    assert_match(/intent/, error.message)
+  end
+
+  def test_await_uses_top_level_validation_constant
+    shadow = Module.new do
+      def self.instance!(*)
+        raise "shadow validation should not be used"
+      end
+    end
+    DAG::Effects.const_set(:Validation, shadow)
+
+    result = DAG::Effects::Await.call(SnapshotInput.new({}), effect_intent) { |_| nil }
+
+    assert_kind_of DAG::Waiting, result
+  ensure
+    DAG::Effects.send(:remove_const, :Validation) if DAG::Effects.const_defined?(:Validation, false)
+  end
+
+  def test_await_uses_effects_intent_from_absolute_namespace
+    shadow_effects = Module.new
+    shadow_effects.const_set(:Intent, Class.new)
+    shadow_protocol = Module.new do
+      def self.valid_result?(*)
+        raise "shadow step protocol should not be used"
+      end
+    end
+    DAG::Effects::Await.const_set(:Intent, Class.new)
+    DAG::Effects::Await.const_set(:Effects, shadow_effects)
+    DAG::Effects::Await.const_set(:StepProtocol, shadow_protocol)
+
+    intent = effect_intent
+    input = SnapshotInput.new({effects: {intent.ref => {status: :succeeded, result: {ok: true}}}})
+    result = DAG::Effects::Await.call(input, intent) { |value| DAG::Success[value: value.fetch(:ok)] }
+
+    assert_kind_of DAG::Success, result
+    assert_equal true, result.value
+  ensure
+    DAG::Effects::Await.send(:remove_const, :Intent) if DAG::Effects::Await.const_defined?(:Intent, false)
+    DAG::Effects::Await.send(:remove_const, :Effects) if DAG::Effects::Await.const_defined?(:Effects, false)
+    DAG::Effects::Await.send(:remove_const, :StepProtocol) if DAG::Effects::Await.const_defined?(:StepProtocol, false)
   end
 
   def test_await_rejects_non_integer_not_before_ms
     assert_raises(ArgumentError) do
       DAG::Effects::Await.call(SnapshotInput.new({}), effect_intent, not_before_ms: 1.5) { |_| nil }
     end
+  end
+
+  def test_await_rejects_non_integer_not_before_ms_before_reading_snapshot_status
+    intent = effect_intent
+    input = SnapshotInput.new({effects: {intent.ref => {status: :succeeded, result: 1}}})
+    error = assert_raises(ArgumentError) do
+      DAG::Effects::Await.call(input, intent, not_before_ms: 1.5) { DAG::Success[value: "ok"] }
+    end
+
+    assert_match(/not_before_ms/, error.message)
   end
 
   private

--- a/spec/r1/execution_context_test.rb
+++ b/spec/r1/execution_context_test.rb
@@ -3,11 +3,31 @@
 require_relative "../test_helper"
 
 class ExecutionContextTest < Minitest::Test
+  cover DAG::ExecutionContext
+
   def test_from_freezes_inputs_deeply
     ctx = DAG::ExecutionContext.from(a: {b: [1, 2]})
     assert ctx.frozen?
     assert ctx[:a].frozen?
     assert ctx[:a][:b].frozen?
+  end
+
+  def test_from_nil_returns_empty_context
+    ctx = DAG::ExecutionContext.from(nil)
+
+    assert_equal true, ctx.empty?
+    assert_equal({}, ctx.to_h)
+  end
+
+  def test_empty_predicate_is_false_for_non_empty_context
+    ctx = DAG::ExecutionContext.from(a: 1)
+
+    assert_equal false, ctx.empty?
+  end
+
+  def test_size_counts_entries
+    assert_equal 0, DAG::ExecutionContext.from(nil).size
+    assert_equal 2, DAG::ExecutionContext.from(a: 1, b: 2).size
   end
 
   def test_merge_returns_new_instance_without_mutating
@@ -16,7 +36,15 @@ class ExecutionContextTest < Minitest::Test
 
     assert_equal({x: 1}, ctx.to_h)
     assert_equal({x: 1, y: 2}, merged.to_h)
+    assert_instance_of DAG::ExecutionContext, merged
     refute_same ctx, merged
+  end
+
+  def test_merge_nil_or_empty_patch_returns_self
+    ctx = DAG::ExecutionContext.from(x: 1)
+
+    assert_same ctx, ctx.merge(nil)
+    assert_same ctx, ctx.merge({})
   end
 
   def test_to_h_returns_fresh_dup
@@ -27,7 +55,9 @@ class ExecutionContextTest < Minitest::Test
   end
 
   def test_from_rejects_non_json_safe
-    assert_raises(ArgumentError) { DAG::ExecutionContext.from(t: Time.now) }
+    error = assert_raises(ArgumentError) { DAG::ExecutionContext.from(t: Time.now) }
+
+    assert_includes error.message, "$root.t"
   end
 
   def test_dig_and_fetch
@@ -37,10 +67,77 @@ class ExecutionContextTest < Minitest::Test
     assert_equal :missing, ctx.fetch(:nope, :missing)
   end
 
+  def test_fetch_forwards_missing_key_block
+    ctx = DAG::ExecutionContext.from(a: 1)
+
+    assert_equal "missing nope", ctx.fetch(:nope) { |key| "missing #{key}" }
+  end
+
+  def test_bracket_returns_nil_for_missing_key
+    ctx = DAG::ExecutionContext.from(a: 1)
+
+    assert_nil ctx[:missing]
+  end
+
+  def test_key_predicate
+    ctx = DAG::ExecutionContext.from(a: 1)
+
+    assert_equal true, ctx.key?(:a)
+    assert_equal false, ctx.key?(:missing)
+  end
+
+  def test_each_yields_context_pairs
+    ctx = DAG::ExecutionContext.from(a: 1, b: 2)
+    pairs = []
+
+    returned = ctx.each { |key, value| pairs << [key, value] }
+
+    assert_equal({a: 1, b: 2}, returned)
+    assert_equal [[:a, 1], [:b, 2]], pairs
+  end
+
+  def test_each_returns_enumerator_without_block
+    ctx = DAG::ExecutionContext.from(a: 1)
+
+    assert_equal [[:a, 1]], ctx.each.to_a
+  end
+
   def test_equality_is_structural
     a = DAG::ExecutionContext.from(x: 1)
     b = DAG::ExecutionContext.from(x: 1)
     assert_equal a, b
     refute_equal a, DAG::ExecutionContext.from(x: 2)
+  end
+
+  def test_hash_is_structural
+    a = DAG::ExecutionContext.from(x: 1)
+    b = DAG::ExecutionContext.from(x: 1)
+
+    assert_kind_of Integer, a.hash
+    assert_equal a.hash, b.hash
+    refute_equal a.hash, DAG::ExecutionContext.from(x: 2).hash
+  end
+
+  def test_equality_accepts_execution_context_subclasses
+    subclass = Class.new(DAG::ExecutionContext)
+    base = DAG::ExecutionContext.from(x: 1)
+    derived = subclass.new(x: 1)
+
+    assert_equal base, derived
+  end
+
+  def test_equality_rejects_non_context_with_matching_internal_data
+    context = DAG::ExecutionContext.from(x: 1)
+    impostor = Object.new
+    impostor.instance_variable_set(:@data, context.to_h.freeze)
+
+    refute_equal context, impostor
+  end
+
+  def test_inspect_lists_keys
+    context = DAG::ExecutionContext.from(a: 1, b: 2)
+
+    assert_equal "#<DAG::ExecutionContext keys=[:a, :b]>", context.inspect
+    assert_equal context.inspect, context.to_s
   end
 end

--- a/spec/r1/types_validation_test.rb
+++ b/spec/r1/types_validation_test.rb
@@ -3,6 +3,12 @@
 require_relative "../test_helper"
 
 class TypesValidationTest < Minitest::Test
+  cover DAG::Event
+  cover DAG::ProposedMutation
+  cover DAG::ReplacementGraph
+  cover DAG::RuntimeProfile
+  cover DAG::Waiting
+
   def test_replacement_graph_rejects_empty_entry_or_exit
     g = DAG::Graph.new.add_node(:a).freeze
     assert_raises(ArgumentError) { DAG::ReplacementGraph[graph: g, entry_node_ids: [], exit_node_ids: [:a]] }

--- a/spec/result_test.rb
+++ b/spec/result_test.rb
@@ -3,6 +3,10 @@
 require_relative "test_helper"
 
 class ResultTest < Minitest::Test
+  cover DAG::Failure
+  cover DAG::Result
+  cover DAG::Success
+
   # --- Success behavior ---
 
   def test_success_is_successful
@@ -165,6 +169,19 @@ class ResultTest < Minitest::Test
     assert_equal :try_raised, result.error[:code]
     assert_includes result.error[:message], "bad"
     assert_equal "ArgumentError", result.error[:error_class]
+  end
+
+  def test_exception_failure_accepts_message_override_and_extras
+    exception = ArgumentError.new("raw")
+    result = DAG::Result.exception_failure(:custom, exception, message: "friendly", node_id: :a)
+
+    assert result.failure?
+    assert_equal({
+      code: :custom,
+      message: "friendly",
+      error_class: "ArgumentError",
+      node_id: :a
+    }, result.error)
   end
 
   def test_try_does_not_catch_outside_default

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -16,6 +16,7 @@ end
 
 require "fileutils"
 require "minitest/autorun"
+require "mutant/minitest/coverage"
 require "securerandom"
 require "tempfile"
 require "tmpdir"

--- a/test/all_test.rb
+++ b/test/all_test.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Dir[File.expand_path("../spec/**/*_test.rb", __dir__)].sort.each do |path|
+  require path
+end


### PR DESCRIPTION
## Summary

- Add Mutant/Minitest mutation testing config, rake tasks, and the spec bridge Mutant needs for this repo layout.
- Harden graph, result, execution-context, and effect-await coverage while accepting equivalent simplifications surfaced by Mutant.
- Prepare ruby-dag v1.5.0 with version bump, changelog, roadmap, and a release gate test.

## Validation

- `bundle exec rake`
- `bundle exec rake mutant:test`
- `bundle exec rake mutant:run` (`3295/3295` killed, `Alive: 0`, `Coverage: 100.00%`)
- `git diff --check`

## Notes

- Mutant prints the non-fatal `parser/current` Ruby 3.3 parser warning while running on Ruby 4.0.2.
- Untracked local review artifacts were intentionally left out of the branch.