### PR TITLE
Prepare ruby-dag v1.6.0 review-hardening release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.6.0 — 2026-06-10
+
 Project-review hardening pass: design fixes at the storage-port seams,
 DRY consolidation, performance work, and CI/cop enforcement.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-dag (1.5.0)
+    ruby-dag (1.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,6 +50,8 @@ Tracked phases:
 | Release v1.4                   | —    | Done |
 | V1.5 mutation testing gate     | —    | Done |
 | Release v1.5                   | —    | Done |
+| V1.6 review hardening          | #192 | Done (#191) |
+| Release v1.6                   | #192 | Done |
 | S0 (SQLite adapter, in Delphi)   | TBD  | Next |
 | Release v1.0                     | #74  | Done (#126, #156) |
 

--- a/lib/dag/version.rb
+++ b/lib/dag/version.rb
@@ -2,5 +2,5 @@
 
 module DAG
   # Library version. Bumped per release; see `CHANGELOG.md`.
-  VERSION = "1.5.0"
+  VERSION = "1.6.0"
 end

--- a/spec/r0/v1_5_release_gate_test.rb
+++ b/spec/r0/v1_5_release_gate_test.rb
@@ -6,7 +6,7 @@ class R0V15ReleaseGateTest < Minitest::Test
   ROOT = File.expand_path("../..", __dir__)
 
   def test_version_is_bumped_to_mutation_testing_release
-    assert_equal "1.5.0", DAG::VERSION
+    assert_operator Gem::Version.new(DAG::VERSION), :>=, Gem::Version.new("1.5.0")
   end
 
   def test_changelog_contains_v1_5_release_notes

--- a/spec/r0/v1_6_release_gate_test.rb
+++ b/spec/r0/v1_6_release_gate_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class R0V16ReleaseGateTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def test_version_is_bumped_to_review_hardening_release
+    assert_equal "1.6.0", DAG::VERSION
+  end
+
+  def test_changelog_contains_v1_6_release_notes
+    changelog = normalized("CHANGELOG.md")
+
+    assert_includes changelog, "## 1.6.0 — 2026-06-10"
+    assert_includes changelog, "Project-review hardening pass"
+    assert_includes changelog, "DAG::Ports::EffectLedger"
+    assert_includes changelog, "DAG::Effects::DispatchAbortedError"
+    assert_includes changelog, ":workflow_retrying"
+  end
+
+  def test_roadmap_marks_v1_6_release
+    roadmap = normalized("ROADMAP.md")
+
+    assert_includes roadmap, "V1.6 review hardening"
+    assert_includes roadmap, "Release v1.6"
+  end
+
+  def test_effect_ledger_port_carries_the_canonical_completion_defaults
+    port = File.read(File.join(ROOT, "lib/dag/ports/effect_ledger.rb"))
+
+    assert_includes port, "module EffectLedger"
+    assert_includes port, "def complete_effect_succeeded(effect_id:, owner_id:, result:, external_ref:, now_ms:)"
+    assert_includes port, "def complete_effect_failed(effect_id:, owner_id:, error:, retriable:, not_before_ms:, now_ms:)"
+    assert_includes port, "def thread_safe_for_dispatch?"
+    assert_includes DAG::Ports::Storage.ancestors, DAG::Ports::EffectLedger
+    refute File.read(File.join(ROOT, "lib/dag/ports/storage.rb")).include?("method_overridden?")
+  end
+
+  def test_dispatcher_exposes_per_workflow_tick_and_abort_report
+    dispatcher = File.read(File.join(ROOT, "lib/dag/effects/dispatcher.rb"))
+
+    assert_includes dispatcher, "def tick(limit:, only_workflow_id: nil)"
+    assert_includes dispatcher, "DispatchAbortedError"
+    assert_operator DAG::Effects::DispatchAbortedError, :<, DAG::Error
+    assert DAG::Effects::DispatchAbortedError.instance_method(:report)
+  end
+
+  def test_event_types_include_workflow_retrying
+    assert_includes DAG::Event::TYPES, :workflow_retrying
+    assert_equal :retrying, DAG::TraceRecord::EVENT_STATUS.fetch(:workflow_retrying)
+  end
+
+  def test_result_from_h_round_trips_every_step_outcome
+    success = DAG::Success[value: 1, context_patch: {"k" => "v"}]
+    failure = DAG::Failure[error: {"code" => "x"}, retriable: true]
+    waiting = DAG::Waiting[reason: :external, not_before_ms: 5]
+
+    [success, failure, waiting].each do |outcome|
+      assert_equal outcome, DAG::Result.from_h(outcome.to_h)
+    end
+  end
+
+  def test_ci_enforces_the_coverage_gate
+    workflow = File.read(File.join(ROOT, ".github/workflows/ci.yml"))
+
+    assert_includes workflow, "COVERAGE"
+    refute_path_exists File.join(ROOT, ".github/workflows/ruby.yml")
+  end
+end


### PR DESCRIPTION
Release prep for v1.6.0 per the checklist in #192: version bump, dated CHANGELOG section, ROADMAP rows, v1.6 release-gate test (EffectLedger defaults, DispatchAbortedError, per-workflow tick, :workflow_retrying, Result.from_h, CI coverage gate), v1.5 gate version pin relaxed to >=.

Full gate green locally with COVERAGE=1 (770 runs, 100% line / 91.97% branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)