### PR TITLE
chore(ci): dedupe triggers, add concurrency, dependabot, nightly failure alert

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,19 @@
 name: CI
 
+# push is limited to main so PR branches run once (via pull_request)
+# instead of twice; tags still build so releases get a fresh gate.
 on:
   push:
+    branches: [main]
+    tags: ["v*"]
   pull_request:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   test:

--- a/.github/workflows/production-readiness.yml
+++ b/.github/workflows/production-readiness.yml
@@ -17,8 +17,12 @@ on:
         required: false
         default: '1'
 
+# issues: write lets the failure step open/update the alert issue —
+# without it a red nightly is invisible unless someone checks the
+# Actions tab (it once stayed red for six weeks unnoticed).
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: production-readiness-${{ github.ref }}
@@ -57,3 +61,19 @@ jobs:
           path: prodready.json
           if-no-files-found: warn
           retention-days: 30
+
+      - name: Alert on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Production readiness nightly is failing"
+          body="Run failed: ${RUN_URL}"
+          number=$(gh issue list --state open --search "\"${title}\" in:title" --json number --jq '.[0].number')
+          if [ -z "${number}" ]; then
+            gh issue create --title "${title}" --body "${body}"
+          else
+            gh issue comment "${number}" --body "${body}"
+          fi


### PR DESCRIPTION
## Summary

Implements the P1/P2 pipeline items from the CI/CD review (pillars 2, 4, and Build).

### Workflow changes (this PR)

- **`ci.yml`** — `push` trigger limited to `main` + `v*` tags so PR branches run CI **once** (via `pull_request`) instead of twice, halving CI minutes at zero signal cost. Added a `concurrency` group that cancels superseded runs on non-main refs.
- **`production-readiness.yml`** — new `Alert on failure` step: opens a *"Production readiness nightly is failing"* issue on first failure and comments the run URL on subsequent ones. Grants `issues: write` (the job otherwise stays `contents: read`). The nightly was red for six weeks (2026-06-11 → 2026-07-21, fixed in #195) with zero visibility — this closes that hole.
- **`.github/dependabot.yml`** — weekly update PRs for `bundler` (dev/CI dependency tree) and `github-actions`.

### Repo-settings changes (applied out-of-band, recorded here for the audit trail)

- Vulnerability alerts: **enabled**
- Dependabot security updates: **enabled**
- Secret scanning + push protection: **enabled**
- Branch protection on `main`: **`test (3.4)` and `test (4.0)` are now required status checks** (previously zero required checks — red CI was mergeable)

## Test plan

- All three YAML files parse (validated locally)
- This PR itself exercises the new trigger config: expect exactly **one** CI run (pull_request only, no duplicate push run)
- The required-checks gate is exercised by this PR's own merge
- Alert step logic is `gh` CLI only; it fires only on `failure()` of the nightly

🤖 Generated with [Claude Code](https://claude.com/claude-code)