### PR TITLE
fix(runner): scan event log for once-per-lifetime workflow_started guard

### DIFF
--- a/lib/dag/runner.rb
+++ b/lib/dag/runner.rb
@@ -195,8 +195,9 @@ module DAG
 
     # Emitted once per workflow lifetime; survives Runner#retry_workflow.
     def append_workflow_started_once(run)
-      first_event = @storage.read_events(workflow_id: run.workflow_id, limit: 1).first
-      return if first_event&.type == :workflow_started
+      already_emitted = @storage.read_events(workflow_id: run.workflow_id)
+        .any? { |event| event.type == :workflow_started }
+      return if already_emitted
 
       append_event(run,
         type: :workflow_started,

--- a/spec/r1/retry_workflow_test.rb
+++ b/spec/r1/retry_workflow_test.rb
@@ -114,6 +114,41 @@ class RetryWorkflowTest < Minitest::Test
       "workflow_started stays once-per-lifetime; retry must not re-emit it"
   end
 
+  def test_workflow_started_emitted_once_despite_pre_run_event
+    storage = DAG::Adapters::Memory::Storage.new
+    runner = build_runner(storage: storage)
+
+    workflow_id = create_workflow(storage, simple_definition)
+    storage.append_event(workflow_id: workflow_id,
+      event: build_event(:mutation_applied, workflow_id: workflow_id))
+
+    assert_equal :completed, runner.call(workflow_id).state
+
+    events = storage.read_events(workflow_id: workflow_id)
+    assert_equal :mutation_applied, events.first.type
+    assert_equal 1, events.count { |e| e.type == :workflow_started },
+      "pre-run events must not cause a duplicate workflow_started"
+  end
+
+  def test_retry_does_not_re_emit_workflow_started_after_pre_run_event
+    storage = DAG::Adapters::Memory::Storage.new
+    registry, _counter = registry_with_failing_step(failures_before_success: 1)
+    runner = build_runner(storage: storage, registry: registry)
+
+    definition = DAG::Workflow::Definition.new.add_node(:flaky, type: :flaky)
+    workflow_id = create_workflow(storage, definition,
+      runtime_profile: profile(max_attempts_per_node: 1, max_workflow_retries: 1))
+    storage.append_event(workflow_id: workflow_id,
+      event: build_event(:mutation_applied, workflow_id: workflow_id))
+
+    assert_equal :failed, runner.call(workflow_id).state
+    assert_equal :completed, runner.retry_workflow(workflow_id).state
+
+    events = storage.read_events(workflow_id: workflow_id)
+    assert_equal 1, events.count { |e| e.type == :workflow_started },
+      "retry after a pre-run event must not re-emit workflow_started"
+  end
+
   def test_retry_does_not_overwrite_aborted_attempt_records
     storage = DAG::Adapters::Memory::Storage.new
     registry, _counter = registry_with_failing_step(failures_before_success: 4)


### PR DESCRIPTION
## Summary

Fixes #209.

`append_workflow_started_once` (lib/dag/runner.rb:197) read `read_events(workflow_id:, limit: 1)` and compared only the head event. The documented invariant is "workflow_started emitted once per workflow lifetime, detected by scanning the event log" — the head-check is equivalent to a full scan only while `workflow_started` is always seq 1. Any event appended before the first run (raw `Ports::Storage#append_revision` with an event on a `:pending` workflow, or a direct consumer `append_event`) made the head permanently not-`workflow_started`, so `Runner#retry_workflow` appended a second `:workflow_started`.

## Changes

- `lib/dag/runner.rb` — scan the full log for an existing `:workflow_started` instead of checking only the head. No port or contract change; the fixed behavior matches the already-documented invariant.
- `spec/r1/retry_workflow_test.rb` — two regression tests reproducing the issue's minimal trigger (pre-run event → run → `retry_workflow`). Verified the retry test fails against the old implementation (duplicate `workflow_started`).

## Verification

- `bundle exec rake`: 772 runs, 0 failures; standardrb, custom DAG cops, and YARD gates clean.